### PR TITLE
외부 이미지의 크기가 작을 경우 섬네일을 생성하지 않는 문제점 개선

### DIFF
--- a/modules/document/document.item.php
+++ b/modules/document/document.item.php
@@ -910,7 +910,14 @@ class documentItem extends Object
 					if(!file_exists($tmp_file)) continue;
 					else
 					{
-						list($_w, $_h, $_t, $_a) = getimagesize($tmp_file);
+						if($is_img = @getimagesize($tmp_file))
+						{
+							list($_w, $_h, $_t, $_a) = $is_img;
+						}
+						else
+						{
+							continue;
+						}
 
 						$source_file = $tmp_file;
 						$is_tmp_file = true;

--- a/modules/document/document.item.php
+++ b/modules/document/document.item.php
@@ -910,8 +910,7 @@ class documentItem extends Object
 					if(!file_exists($tmp_file)) continue;
 					else
 					{
-						list($_w, $_h, $_t, $_a) = @getimagesize($tmp_file);
-						if($_w<$width || $_h<$height) continue;
+						list($_w, $_h, $_t, $_a) = getimagesize($tmp_file);
 
 						$source_file = $tmp_file;
 						$is_tmp_file = true;


### PR DESCRIPTION
외부 이미지의 경우 섬네일이 생성되지 않는 경우의 문제점이 있음. 이 부분을 개선합니다.
(티스토리의 경우 확장자 여부를 검사하므로 예외)