### PR TITLE
PHP 5.5 이상에서 설정 변경시 즉시 적용되지 않는 문제 해결

### DIFF
--- a/classes/cache/CacheFile.class.php
+++ b/classes/cache/CacheFile.class.php
@@ -78,10 +78,6 @@ class CacheFile extends CacheBase
 		$content[] = 'if(!defined(\'__XE__\')) { exit(); }';
 		$content[] = 'return \'' . addslashes(serialize($obj)) . '\';';
 		FileHandler::writeFile($cache_file, implode(PHP_EOL, $content));
-		if(function_exists('opcache_invalidate'))
-		{
-			@opcache_invalidate($cache_file, true);
-		}
 	}
 
 	/**
@@ -145,10 +141,6 @@ class CacheFile extends CacheBase
 	function _delete($_key)
 	{
 		$cache_file = $this->getCacheFileName($_key);
-		if(function_exists('opcache_invalidate'))
-		{
-			@opcache_invalidate($cache_file, true);
-		}
 		FileHandler::removeFile($cache_file);
 	}
 

--- a/classes/file/FileHandler.class.php
+++ b/classes/file/FileHandler.class.php
@@ -156,6 +156,10 @@ class FileHandler
 
 		@file_put_contents($filename, $buff, $flags|LOCK_EX);
 		@chmod($filename, 0644);
+		if(function_exists('opcache_invalidate') && substr($filename, -4) === '.php')
+		{
+			@opcache_invalidate($filename, true);
+		}
 	}
 
 	/**
@@ -166,7 +170,16 @@ class FileHandler
 	 */
 	public static function removeFile($filename)
 	{
-		return (($filename = self::exists($filename)) !== FALSE) && @unlink($filename);
+		if(($filename = self::exists($filename)) === false)
+		{
+			return false;
+		}
+		$status = @unlink($filename);
+		if(function_exists('opcache_invalidate') && substr($filename, -4) === '.php')
+		{
+			@opcache_invalidate($filename, true);
+		}
+		return $status;
 	}
 
 	/**


### PR DESCRIPTION
PHP 5.5 이상에는 opcache가 내장되어 있기 때문에 PHP 파일이 변경되어도 2~3초간 업데이트되지 않습니다. XE의 각종 설정은 PHP 파일에 캐싱되기 때문에, 관리모듈에서 일반 설정이나 사이트 디자인 설정 등을 바꾸어도 즉시 적용되지 않고 2~3초 후에 새로고침을 해야 하는 문제가 있었습니다.

일부 캐시파일은 예전에 XE에 PR을 넣어 opcache에서 삭제되도록 조치했으나, 여전히 문제가 있기에 아래와 같이 조치합니다.

확장자가 PHP인 파일을 `FileHandler::writeFile()` 또는 `FileHandler::removeFile()` 메소드로 조작할 경우 자동으로 `opcache_invalidate()` 함수를 호출하여 해당 파일을 opcache에서 삭제합니다. 다음 요청부터는 변경된 파일이 opcache에 저장되므로, 폼 제출 직후에 돌아오는 화면에서 변경된 설정을 확인할 수 있습니다. 새로고침이여 안녕~!