### PR TITLE
의존성 자료가 없는 상태에서 직접 쓰기 방식 쉬운설치 오류 수정

### DIFF
--- a/modules/autoinstall/autoinstall.admin.model.php
+++ b/modules/autoinstall/autoinstall.admin.model.php
@@ -371,6 +371,11 @@ class autoinstallAdminModel extends autoinstall
 			$directModuleInstall = FALSE;
 			$arrUnwritableDir[] = $output->get('path');
 		}
+		
+		if(!is_array($package->depends))
+		{
+			$package->depends = array();
+		}
 
 		foreach($package->depends as $dep)
 		{


### PR DESCRIPTION
의존성 자료가 없는 상태에서 직접 쓰기 방식으로 쉬운설치 사용시 배열이 초기화되지 않아 오류가 발생하는 문제를 수정합니다.