### PR TITLE
설치모듈의 mod_rewrite 및 SSL 사용 여부 검사를 개선

### DIFF
--- a/modules/install/install.controller.php
+++ b/modules/install/install.controller.php
@@ -453,52 +453,6 @@ class installController extends install
 	}
 
 	/**
-	 * check this server can use rewrite module
-	 * make a file to files/config and check url approach by ".htaccess" rules
-	 *
-	 * @return bool
-	*/
-	function checkRewriteUsable() {
-		$checkString = "isApproached";
-		$checkFilePath = 'files/config/tmpRewriteCheck.txt';
-
-		FileHandler::writeFile(_XE_PATH_.$checkFilePath, trim($checkString));
-
-		$scheme = ($_SERVER['HTTPS'] === 'on') ? 'https' : 'http';
-		$hostname = $_SERVER['SERVER_NAME'];
-		$port = $_SERVER['SERVER_PORT'];
-		$str_port = '';
-		if($port)
-		{
-			$str_port = ':' . $port;
-		}
-
-		$tmpPath = $_SERVER['DOCUMENT_ROOT'];
-
-		//if DIRECTORY_SEPARATOR is not /(IIS)
-		if(DIRECTORY_SEPARATOR !== '/')
-		{
-			//change to slash for compare
-			$tmpPath = str_replace(DIRECTORY_SEPARATOR, '/', $_SERVER['DOCUMENT_ROOT']);
-		}
-
-		$query = "/JUST/CHECK/REWRITE/" . $checkFilePath;
-		$currentPath = str_replace($tmpPath, "", _XE_PATH_);
-		if($currentPath != "")
-		{
-			$query = $currentPath . $query;
-		}
-		$requestUrl = sprintf('%s://%s%s%s', $scheme, $hostname, $str_port, $query);
-		$requestConfig = array();
-		$requestConfig['ssl_verify_peer'] = false;
-		$buff = FileHandler::getRemoteResource($requestUrl, null, 3, 'GET', null, array(), array(), array(), $requestConfig);
-
-		FileHandler::removeFile(_XE_PATH_.$checkFilePath);
-
-		return (trim($buff) == $checkString);
-	}
-
-	/**
 	 * @brief Create files and subdirectories
 	 * Local evironment setting before installation by using DB information
 	 */

--- a/modules/install/install.controller.php
+++ b/modules/install/install.controller.php
@@ -100,7 +100,7 @@ class installController extends install
 		// Save rewrite and time zone settings
 		if(!Context::get('install_config'))
 		{
-			$config_info = Context::gets('use_rewrite','time_zone');
+			$config_info = Context::gets('use_rewrite','time_zone', 'use_ssl');
 			if($config_info->use_rewrite!='Y') $config_info->use_rewrite = 'N';
 			if(!$this->makeEtcConfigFile($config_info))
 			{

--- a/modules/install/install.view.php
+++ b/modules/install/install.view.php
@@ -181,7 +181,8 @@ class installView extends install
 
 		include _XE_PATH_.'files/config/tmpDB.config.php';
 
-		Context::set('use_rewrite', $_SESSION['use_rewrite']); 
+		Context::set('use_rewrite', $_SESSION['use_rewrite']);
+		Context::set('use_ssl', $_SERVER['HTTPS'] === 'on' ? 'always' : 'none');
 		Context::set('time_zone', $GLOBALS['time_zone']);
 		Context::set('db_type', $db_info->db_type);
 		$this->setTemplateFile('admin_form');

--- a/modules/install/install.view.php
+++ b/modules/install/install.view.php
@@ -7,7 +7,10 @@
  */
 class installView extends install
 {
-	var $install_enable = false;
+	public $install_enable = false;
+	
+	public static $rewriteCheckFilePath = 'files/cache/tmpRewriteCheck.txt';
+	public static $rewriteCheckString = '';
 
 	/**
 	 * @brief Initialization
@@ -97,12 +100,11 @@ class installView extends install
 	function dispInstallCheckEnv()
 	{
 		$oInstallController = getController('install');
-		$useRewrite = $oInstallController->checkRewriteUsable() ? 'Y' : 'N';
-		$_SESSION['use_rewrite'] = $useRewrite;
-		Context::set('use_rewrite', $useRewrite); 
-
-		// nginx 체크, rewrite 사용법 안내
-		if($useRewrite == 'N' && stripos($_SERVER['SERVER_SOFTWARE'], 'nginx') !== false) Context::set('use_nginx', 'Y');
+		
+		self::$rewriteCheckString = Password::createSecureSalt(32);
+		FileHandler::writeFile(_XE_PATH_ . self::$rewriteCheckFilePath, self::$rewriteCheckString);;
+		Context::set('use_rewrite', $_SESSION['use_rewrite'] = 'N'); 
+		Context::set('use_nginx', stripos($_SERVER['SERVER_SOFTWARE'], 'nginx') !== false);
 		
 		$this->setTemplateFile('check_env');
 	}
@@ -114,6 +116,16 @@ class installView extends install
 	{
 		// Display check_env if it is not installable
 		if(!$this->install_enable) return $this->dispInstallCheckEnv();
+		
+		// Delete mod_rewrite check file
+		FileHandler::removeFile(_XE_PATH_ . self::$rewriteCheckFilePath);
+		
+		// Save mod_rewrite check status
+		if(Context::get('rewrite') === 'Y')
+		{
+			Context::set('use_rewrite', $_SESSION['use_rewrite'] = 'Y');
+		}
+		
 		// Enter ftp information
 		if(ini_get('safe_mode') && !Context::isFTPRegisted())
 		{

--- a/modules/install/lang/lang.xml
+++ b/modules/install/lang/lang.xml
@@ -722,6 +722,11 @@
 		<value xml:lang="tr"><![CDATA[Eğer websunucusu yenidenyazma(rewritemod) destekliyorsa, http://ornek/?dosya_no=123 gibi URLler http://ornek/123 olarak kısaltılabilir]]></value>
 		<value xml:lang="vi"><![CDATA[Nếu Host của bạn hỗ trợ Mod Rewrite, khi địa chỉ có dạng <b>http://blah/?document_srl=123</b> sẽ được rút ngắn thành <b>http://blah/123</b>]]></value>
 	</item>
+	<item name="checking_rewrite">
+		<value xml:lang="ko"><![CDATA[짧은 주소를 사용할 수 있는지 확인하는 중입니다...]]></value>
+		<value xml:lang="en"><![CDATA[Checking whether "Friendly URL" feature is available...]]></value>
+		<value xml:lang="jp"><![CDATA[短縮アドレスを使用できるかどうかを確認しています...]]></value>
+	</item>
 	<item name="disable_rewrite">
 		<value xml:lang="ko"><![CDATA[짧은 주소를 사용할 수 없습니다. 웹 서버 담당자에게 mod_rewrite 지원 여부를 확인 바랍니다.]]></value>
 		<value xml:lang="en"><![CDATA["Friendly URL" feature is not available. Please check with the server administrator about mod_rewrite module support.]]></value>

--- a/modules/install/lang/lang.xml
+++ b/modules/install/lang/lang.xml
@@ -766,27 +766,50 @@
 		<value xml:lang="tr"><![CDATA[Eğer sunucu zaman dilimi ve bulunduğunuz yerin zaman dilimi uyumlu değilse; zaman dilimi özelliğini kullanarak zamanı bulunduğunuz yere göre ayarlayabilirsiniz ]]></value>
 		<value xml:lang="vi"><![CDATA[Nếu thời gian của khu vực bạn không tự động cập nhật. Bạn có thể chọn thời gian để hiển thị cho Website.]]></value>
 	</item>
-	<item name="qmail_compatibility">
-		<value xml:lang="ko"><![CDATA[Qmail 호환]]></value>
-		<value xml:lang="en"><![CDATA[Enable Qmail]]></value>
-		<value xml:lang="jp"><![CDATA[Qmail 互換]]></value>
-		<value xml:lang="zh-CN"><![CDATA[Qmail互换]]></value>
-		<value xml:lang="zh-TW"><![CDATA[Qmail互換]]></value>
-		<value xml:lang="fr"><![CDATA[Compatible avec Qmail]]></value>
-		<value xml:lang="es"><![CDATA[Compatible con Qmail]]></value>
-		<value xml:lang="tr"><![CDATA[Qmail'i Etkinleştir]]></value>
-		<value xml:lang="vi"><![CDATA[Mở Qmail]]></value>
+	<item name="use_ssl">
+		<value xml:lang="ko"><![CDATA[SSL 사용]]></value>
+		<value xml:lang="en"><![CDATA[SSL]]></value>
+		<value xml:lang="jp"><![CDATA[SSLを使用]]></value>
+		<value xml:lang="zh-CN"><![CDATA[是否使用SSL安全连接?]]></value>
+		<value xml:lang="tr"><![CDATA[SSL'i kullanmak istiyor musunuz?]]></value>
 	</item>
-	<item name="about_qmail_compatibility">
-		<value xml:lang="ko"><![CDATA[Qmail등 CRLF를 줄 구분자로 인식하지 못하는 MTA에서 메일이 발송되도록 합니다.]]></value>
-		<value xml:lang="en"><![CDATA[It will enable sending mails from MTA which cannot distinguish CRLF like Qmail.]]></value>
-		<value xml:lang="jp"><![CDATA[Qmail等、CRLFを改行コードとして認識できないMTA（Message Transfer Agent）で、メールの送信ができるようにします。]]></value>
-		<value xml:lang="zh-CN"><![CDATA[支持不能识别CRLF为换行符的Qmail等MTA，也能发送电子邮件。]]></value>
-		<value xml:lang="zh-TW"><![CDATA[支援無法識別 CRLF 為換行符的 Qmail 等 MTA，也能發送電子郵件。]]></value>
-		<value xml:lang="fr"><![CDATA[Le mél sera envoyé en MTA qui ne peut pas reconnaître le CRLF comme délimiteur des lignes comme le Qmail.]]></value>
-		<value xml:lang="es"><![CDATA[Qmail como MTA no reconoce CRLF como la línea de separación que se enviará por correo.]]></value>
-		<value xml:lang="tr"><![CDATA[Bu size QMail gibi CRLF'den ayırt edilemeyen MTA'dan mail gönderme imkanı sağlayacaktır.]]></value>
-		<value xml:lang="vi"><![CDATA[Nó sẽ cho phép gửi thư từ MTA mà không phân biệt CRLF.]]></value>
+	<item name="ssl_options" type="array">
+		<item name="none">
+			 <value xml:lang="ko"><![CDATA[사용 안함]]></value>
+			 <value xml:lang="en"><![CDATA[Never]]></value>
+			 <value xml:lang="jp"><![CDATA[使わない]]></value>
+			 <value xml:lang="zh-CN"><![CDATA[不使用]]></value>
+			 <value xml:lang="zh-TW"><![CDATA[關閉]]></value>
+			 <value xml:lang="fr"><![CDATA[Ne Pas utiliser]]></value>
+			 <value xml:lang="ru"><![CDATA[Никогда]]></value>
+			 <value xml:lang="es"><![CDATA[Desactivar]]></value>
+			 <value xml:lang="tr"><![CDATA[Hiçbir zaman]]></value>
+			 <value xml:lang="vi"><![CDATA[Không sử dụng]]></value>
+		</item>
+		<item name="optional">
+			 <value xml:lang="ko"><![CDATA[선택적으로]]></value>
+			 <value xml:lang="en"><![CDATA[Optional]]></value>
+			 <value xml:lang="jp"><![CDATA[部分的に使う]]></value>
+			 <value xml:lang="zh-CN"><![CDATA[选择性]]></value>
+			 <value xml:lang="zh-TW"><![CDATA[手動]]></value>
+			 <value xml:lang="fr"><![CDATA[Optionnel]]></value>
+			 <value xml:lang="ru"><![CDATA[На выбор]]></value>
+			 <value xml:lang="es"><![CDATA[Opcionalmente el]]></value>
+			 <value xml:lang="tr"><![CDATA[İsteğe Bağlı]]></value>
+			 <value xml:lang="vi"><![CDATA[Tùy chỉnh]]></value>
+		</item>
+		<item name="always">
+			 <value xml:lang="ko"><![CDATA[항상 사용]]></value>
+			 <value xml:lang="en"><![CDATA[Always]]></value>
+			 <value xml:lang="jp"><![CDATA[常に使う]]></value>
+			 <value xml:lang="zh-CN"><![CDATA[使用]]></value>
+			 <value xml:lang="zh-TW"><![CDATA[開啟]]></value>
+			 <value xml:lang="fr"><![CDATA[Toujours]]></value>
+			 <value xml:lang="ru"><![CDATA[Всегда]]></value>
+			 <value xml:lang="es"><![CDATA[Utilice siempre el]]></value>
+			 <value xml:lang="tr"><![CDATA[Her zaman]]></value>
+			 <value xml:lang="vi"><![CDATA[Luôn luôn]]></value>
+		</item>
 	</item>
 	<item name="about_database_file">
 		<value xml:lang="ko"><![CDATA[Sqlite는 파일에 데이터를 저장합니다. 데이터베이스 파일의 위치를 웹에서 접근할 수 없는 곳으로 해야 합니다.<br/><span style="color:red">데이터 파일은 777퍼미션 설정된 곳으로 지정해주세요.</span>]]></value>

--- a/modules/install/tpl/admin_form.html
+++ b/modules/install/tpl/admin_form.html
@@ -48,6 +48,16 @@
 			</div>
 		</div>
 		<p class="install_help">{$lang->about_time_zone}</p>
+		<div class="x_control-group">
+			<label class="x_control-label">{$lang->use_ssl}</label>
+			<div class="x_controls">
+			<select name="use_ssl">
+				<!--@foreach($lang->ssl_options as $key => $val)-->
+				<option value="{$key}" selected="selected"|cond="$use_ssl==$key" />{$val}</option>
+				<!--@endforeach-->
+			</select>
+			</div>
+		</div>
 	</div>
 	<div id="buttons">
 		<div class="align-left">

--- a/modules/install/tpl/check_env.html
+++ b/modules/install/tpl/check_env.html
@@ -29,12 +29,17 @@
 			</block>
 			<tr>
 				<td class="check_env_item">mod_rewrite</td>
-				<td class="check_env_status">
-					<span cond="$use_rewrite === 'Y'" class="ok">OK</span>
-					<span cond="$use_rewrite === 'N'">&mdash;</span>
+				<td class="check_env_status" id="mod_write_status">
+					<span class="ok" style="display:none">OK</span>
+					<span class="no">&mdash;</span>
 				</td>
 			</tr>
-			<tr cond="$use_rewrite === 'N'">
+			<tr id="mod_rewrite_checking" data-url="{Context::getRequestUri()}REWRITE/CHECK/SRSLY/ANYTHING/GOES/{InstallView::$rewriteCheckFilePath}" data-verify="{InstallView::$rewriteCheckString}">
+				<td colspan="2" class="error_description">
+					{$lang->checking_rewrite}
+				</td>
+			</tr>
+			<tr id="mod_rewrite_no_support" style="display:none">
 				<td colspan="2" class="error_description">
 					{$lang->disable_rewrite}
 					<block cond="$use_nginx == 'Y'"><br />{$lang->about_nginx_rewrite}</block>

--- a/modules/install/tpl/js/install.js
+++ b/modules/install/tpl/js/install.js
@@ -6,6 +6,28 @@ jQuery(function($){
 			$("p.db_type_" + $(this).val()).show();
 		}).triggerHandler("click");
 	}
+	if($("#mod_rewrite_checking").size()) {
+		var checking = $("#mod_rewrite_checking");
+		$.ajax({
+			url: checking.data("url"),
+			cache : false,
+			dataType: "text",
+			success: function(data) {
+				if($.trim(data) === checking.data("verify")) {
+					$("#mod_write_status span.ok").show();
+					$("#mod_write_status span.no").hide();
+					$("#task-checklist-confirm").attr("href", $("#task-checklist-confirm").attr("href") + "&rewrite=Y");
+				} else {
+					$("#mod_rewrite_no_support").show();
+				}
+				checking.hide();
+			},
+			error: function() {
+				$("#mod_rewrite_no_support").show();
+				checking.hide();
+			}
+		});
+	}
 	if($("input[name='user_id']").size() && $("input[name='email_address']").size()) {
 		var user_id_input = $("input[name='user_id']");
 		var email_input = $("input[name='email_address']");


### PR DESCRIPTION
현재 설치모듈에 mod_rewrite 작동 여부를 검사하는 기능이 있긴 하지만, 서버측에서 짧은주소 요청을 시뮬레이션하기 때문에 서버 환경에 따라 제대로 작동하지 않는 경우도 있습니다.

그래서 mod_rewrite 작동 여부를 검사하는 기능을 클라이언트측으로 옮겼습니다. 임의로 생성한 주소를 AJAX로 요청해 보고, 정상 작동하면 mod_rewrite를 사용할 수 있는 것으로 간주합니다.

또한 설치 단계에서부터 SSL을 사용하는 경우, SSL을 꽤나 심각하게 여기는 사용자라고 간주하고 자동으로 SSL "항상 사용"으로 설정해 주도록 했습니다. 단, 이 설정은 설치 마지막 단계에서 변경할 수 있습니다.