### PR TITLE
캐싱 최적화 옵션을 "세션 시작 지연"으로 변경

### DIFF
--- a/classes/context/Context.class.php
+++ b/classes/context/Context.class.php
@@ -373,6 +373,7 @@ class Context
 		}
 		else
 		{
+			ob_start();
 			$this->setCacheControl(-1, true);
 			register_shutdown_function(array($this, 'checkSessionStatus'));
 			$_SESSION = array();

--- a/classes/context/Context.class.php
+++ b/classes/context/Context.class.php
@@ -366,7 +366,7 @@ class Context
 			$session_id = $_COOKIE[$session_name];
 		}
 
-		if($session_id !== NULL || $this->db_info->cache_friendly != 'Y')
+		if($session_id !== NULL || $this->db_info->delay_session != 'Y')
 		{
 			$this->setCacheControl(0, false);
 			session_start();

--- a/modules/addon/addon.controller.php
+++ b/modules/addon/addon.controller.php
@@ -80,7 +80,6 @@ class addonController extends addon
 	{
 		// Add-on module for use in creating the cache file
 		$buff = array('<?php if(!defined("__XE__")) exit();', '$_m = Context::get(\'mid\');');
-		$buff[] = 'ob_start();';
 		$oAddonModel = getAdminModel('addon');
 		$addon_list = $oAddonModel->getInsertedAddons($site_srl, $gtype);
 		foreach($addon_list as $addon => $val)
@@ -136,7 +135,6 @@ class addonController extends addon
 			$buff[] = '$addon_time_log->called_extension = "' . $addon . '";';
 			$buff[] = 'writeSlowlog("addon",$after_time-$before_time,$addon_time_log);';
 		}
-		$buff[] = 'ob_end_flush();';
 		$addon_path = _XE_PATH_ . 'files/cache/addons/';
 		FileHandler::makeDir($addon_path);
 		$addon_file = $addon_path . ($gtype == 'site' ? $site_srl : '') . $type . '.acivated_addons.cache.php';

--- a/modules/admin/admin.admin.view.php
+++ b/modules/admin/admin.admin.view.php
@@ -72,7 +72,7 @@ class adminAdminView extends admin
 		Context::set('use_spaceremover', $db_info->use_spaceremover ? $db_info->use_spaceremover : 'Y'); //not use
 		Context::set('qmail_compatibility', $db_info->qmail_compatibility == 'Y' ? 'Y' : 'N');
 		Context::set('minify_scripts', $db_info->minify_scripts ?: 'common');
-		Context::set('cache_friendly', $db_info->cache_friendly == 'Y' ? 'Y' : 'N');
+		Context::set('delay_session', $db_info->delay_session == 'Y' ? 'Y' : 'N');
 		Context::set('use_db_session', $db_info->use_db_session == 'N' ? 'N' : 'Y');
 		Context::set('use_mobile_view', $db_info->use_mobile_view == 'Y' ? 'Y' : 'N');
 		Context::set('use_ssl', $db_info->use_ssl ? $db_info->use_ssl : "none");

--- a/modules/admin/lang/lang.xml
+++ b/modules/admin/lang/lang.xml
@@ -785,17 +785,15 @@
 		<value xml:lang="en"><![CDATA[Automatically minify all CSS and JS scripts in the Core and all modules.]]></value>
 		<value xml:lang="jp"><![CDATA[コアとすべてのモジュールに含まれたCSS、JSファイルを自動的に圧縮(minify)して配信します。]]></value>
 	</item>
-	<item name="cache_friendly">
-		<value xml:lang="ko"><![CDATA[캐싱 최적화]]></value>
-		<value xml:lang="en"><![CDATA[Optimize for caching]]></value>
-		<value xml:lang="jp"><![CDATA[キャッシュに最適化]]></value>
-		<value xml:lang="zh-CN"><![CDATA[优化缓存]]></value>
-		<value xml:lang="tr"><![CDATA[Önbelleğe alma optimize]]></value>
+	<item name="delay_session">
+		<value xml:lang="ko"><![CDATA[세션 시작 지연]]></value>
+		<value xml:lang="en"><![CDATA[Delay session start]]></value>
+		<value xml:lang="jp"><![CDATA[セッションの開始を遅延]]></value>
 	</item>
-	<item name="about_cache_friendly">
-		<value xml:lang="ko"><![CDATA[Varnish 등의 캐싱 서버 사용시 성능 개선을 위해, 로그인하지 않은 사용자에게는 인증 세션을 부여하지 않습니다.<br>이 옵션을 선택할 경우 방문자 수 및 조회수 집계가 정확하지 않을 수 있습니다.]]></value>
-		<value xml:lang="en"><![CDATA[To improve performance when using a caching server such as Varnish, do not issue sessions to visitors until they log in.<br>Selecting this option may cause view counts and visitor counts to become inaccurate.]]></value>
-		<value xml:lang="jp"><![CDATA[Varnishなどのキャッシュサーバ使用時のパフォーマンスを向上させるために、ログインしていないユーザーには、認証セッションを付与しません。<br>このオプションを選択した場合、訪問者数とヒット集計が正確でない場合があります。]]></value>
+	<item name="about_delay_session">
+		<value xml:lang="ko"><![CDATA[Varnish 등의 프록시 캐싱 서버 사용시 성능 개선을 위해, 로그인하지 않은 사용자에게는 인증 세션을 부여하지 않습니다.<br>이 옵션을 선택할 경우 방문자 수 및 조회수 집계가 정확하게 이루어지지 않을 수 있습니다.]]></value>
+		<value xml:lang="en"><![CDATA[To improve performance when using a caching proxy server such as Varnish, do not issue sessions to visitors until they log in.<br>Selecting this option may cause view counts and visitor counts to become inaccurate.]]></value>
+		<value xml:lang="jp"><![CDATA[Varnishなどのプロキシキャッシュサーバ使用時のパフォーマンスを向上させるために、ログインしていないユーザーには、認証セッションを付与しません。<br>このオプションを選択した場合、訪問者数とヒット集計が正確でない場合があります。]]></value>
 	</item>
 	<item name="sftp">
 		<value xml:lang="ko"><![CDATA[SFTP 사용]]></value>

--- a/modules/admin/tpl/config_general.html
+++ b/modules/admin/tpl/config_general.html
@@ -226,6 +226,15 @@
 			</div>
 		</div>
 		<div class="x_control-group">
+			<label class="x_control-label">{$lang->delay_session}</label>
+			<div class="x_controls">
+				<label for="delay_session_y" class="x_inline"><input type="radio" name="delay_session" id="delay_session_y" value="Y" checked="checked"|cond="$delay_session=='Y'" /> {$lang->cmd_yes}</label>
+				<label for="delay_session_n" class="x_inline"><input type="radio" name="delay_session" id="delay_session_n" value="N" checked="checked"|cond="$delay_session!='Y'" /> {$lang->cmd_no}</label>
+				<br />
+				<p class="x_help-block">{$lang->about_delay_session}</p>
+			</div>
+		</div>
+		<div class="x_control-group">
 			<label class="x_control-label">{$lang->minify_scripts}</label>
 			<div class="x_controls">
 				<label for="minify_scripts_none" class="x_inline"><input type="radio" name="minify_scripts" id="minify_scripts_none" value="none" checked="checked"|cond="$minify_scripts=='none'" /> {$lang->cmd_minify_none}</label>
@@ -233,15 +242,6 @@
 				<label for="minify_scripts_all" class="x_inline"><input type="radio" name="minify_scripts" id="minify_scripts_all" value="all" checked="checked"|cond="$minify_scripts=='all'" /> {$lang->cmd_minify_all}</label>
 				<br />
 				<p class="x_help-block">{$lang->about_minify_scripts}</p>
-			</div>
-		</div>
-		<div class="x_control-group">
-			<label class="x_control-label">{$lang->cache_friendly}</label>
-			<div class="x_controls">
-				<label for="cache_friendly_y" class="x_inline"><input type="radio" name="cache_friendly" id="cache_friendly_y" value="Y" checked="checked"|cond="$cache_friendly=='Y'" /> {$lang->cmd_yes}</label>
-				<label for="cache_friendly_n" class="x_inline"><input type="radio" name="cache_friendly" id="cache_friendly_n" value="N" checked="checked"|cond="$cache_friendly!='Y'" /> {$lang->cmd_no}</label>
-				<br />
-				<p class="x_help-block">{$lang->about_cache_friendly}</p>
 			</div>
 		</div>
 		<div class="x_clearfix btnArea">

--- a/modules/install/install.admin.controller.php
+++ b/modules/install/install.admin.controller.php
@@ -96,11 +96,12 @@ class installAdminController extends install
 		$qmail_compatibility = Context::get('qmail_compatibility');
 		if($qmail_compatibility!='Y') $qmail_compatibility = 'N';
 
+		$delay_session = Context::get('delay_session');
+		if($delay_session!='Y') $delay_session = 'N';
+		unset($db_info->cache_friendly);
+
 		$minify_scripts = Context::get('minify_scripts');
 		if(!$minify_scripts) $minify_scripts = 'common';
-
-		$cache_friendly = Context::get('cache_friendly');
-		if($cache_friendly!='Y') $cache_friendly = 'N';
 
 		$use_html5 = Context::get('use_html5');
 		if(!$use_html5) $use_html5 = 'N';
@@ -108,7 +109,7 @@ class installAdminController extends install
 		$db_info->default_url = $default_url;
 		$db_info->qmail_compatibility = $qmail_compatibility;
 		$db_info->minify_scripts = $minify_scripts;
-		$db_info->cache_friendly = $cache_friendly;
+		$db_info->delay_session = $delay_session;
 		$db_info->use_db_session = $use_db_session;
 		$db_info->use_rewrite = $use_rewrite;
 		$db_info->use_sso = $use_sso;


### PR DESCRIPTION
xpressengine/xe-core#1615 에서 추가한 "캐싱 최적화(cache_friendly)"라는 옵션 이름이 정확하지 않기에 "세션 시작 지연(delay_session)"으로 변경합니다.

Varnish 프록시 캐싱 서버 등 특별한 경우를 제외하면 사용할 필요가 없는 옵션입니다.
