### PR TITLE
메뉴 편집이 되지 않는 버그 수정

### DIFF
--- a/modules/menu/menu.admin.model.php
+++ b/modules/menu/menu.admin.model.php
@@ -547,6 +547,8 @@ class menuAdminModel extends menu
 							{
 								$this->_menuInfoSetting($menu->list[$key2], $start_module, $isMenuFixed, $value->menu_srl,$siteSrl);
 							}
+							ksort($menu->list);
+							$menu->list = array_values($menu->list);
 						}
 
 						// menu recreate
@@ -574,6 +576,7 @@ class menuAdminModel extends menu
 			}
 		}
 		ksort($menuList);
+		$menuList = array_values($menuList);
 		$this->add('menuList', $menuList);
 	}
 

--- a/modules/menu/menu.admin.model.php
+++ b/modules/menu/menu.admin.model.php
@@ -506,6 +506,8 @@ class menuAdminModel extends menu
 				{
 					$this->_menuInfoSetting($menu->list[$key], $start_module, $isMenuFixed, $menuSrl,$siteSrl);
 				}
+				ksort($menu->list);
+				$menu->list = array_values($menu->list);
 			}
 
 			// menu recreate
@@ -695,6 +697,8 @@ class menuAdminModel extends menu
 			{
 				$this->_menuInfoSetting($menu['list'][$key], $start_module, $isMenuFixed, $menuSrl, $siteSrl);
 			}
+			ksort($menu['list']);
+			$menu['list'] = array_values($menu['list']);
 		}
 	}
 }


### PR DESCRIPTION
#57

기존 XE에서 정의한 `json_encode2()` 함수와 PHP에 내장된 `json_encode()` 함수가 산술 배열을 인코딩하는 방식이 서로 달라서 발생하는 문제였습니다.

일단 메뉴는 표시되도록 수정했고, 다른 문제가 있는지 계속 살펴보겠습니다.