### PR TITLE
XEDITION 레이아웃의 로그인 아이콘 표시 문제 수정

### DIFF
--- a/layouts/xedition/layout.html
+++ b/layouts/xedition/layout.html
@@ -236,7 +236,7 @@
 							<!-- /after_login -->
 						<!--@else-->
 							<!-- before_login -->
-							<a href="{getUrl('act', 'dispMemberLoginForm')}" id="ly_btn"><i class="xi-user-add"></i><span class="blind">{$lang->cmd_login}/{$lang->cmd_signup}</span></a>
+							<a href="{getUrl('act', 'dispMemberLoginForm')}" id="ly_btn"><i class="xi-user"></i><span class="blind">{$lang->cmd_login}/{$lang->cmd_signup}</span></a>
 							<div class="ly ly_login">
 								<ul>
 									<li><a id="ly_login_btn" href="{getUrl('act', 'dispMemberLoginForm')}">{$lang->cmd_login}</a></li>


### PR DESCRIPTION
xeicon 2.0.0으로 업데이트한 후 XEDITION 레이아웃의 로그인 아이콘(`xi-user-add`)이 나오지 않는 문제를 수정합니다. 다른 아이콘(`xi-user`)으로 변경하니 훨씬 깔끔해 보이네요.