### PR TITLE
관리 모듈의 XE 로고 및 링크를 라이믹스로 변경

### DIFF
--- a/modules/admin/admin.admin.view.php
+++ b/modules/admin/admin.admin.view.php
@@ -198,8 +198,8 @@ class adminAdminView extends admin
 		// Admin logo, title setup
 		$objConfig = $oModuleModel->getModuleConfig('admin');
 		$gnbTitleInfo = new stdClass();
-		$gnbTitleInfo->adminTitle = $objConfig->adminTitle ? $objConfig->adminTitle : 'XE Admin';
-		$gnbTitleInfo->adminLogo = $objConfig->adminLogo ? $objConfig->adminLogo : 'modules/admin/tpl/img/xe.h1.png';
+		$gnbTitleInfo->adminTitle = $objConfig->adminTitle ? $objConfig->adminTitle : 'RhymiX Admin';
+		$gnbTitleInfo->adminLogo = $objConfig->adminLogo ? $objConfig->adminLogo : '';
 
 		$browserTitle = ($subMenuTitle ? $subMenuTitle : 'Dashboard') . ' - ' . $gnbTitleInfo->adminTitle;
 
@@ -210,6 +210,7 @@ class adminAdminView extends admin
 
 		// Retrieve recent news and set them into context,
 		// move from index method, because use in admin footer
+		/*
 		$newest_news_url = sprintf("http://news.xpressengine.com/%s/news.php?version=%s&package=%s", _XE_LOCATION_, __XE_VERSION__, _XE_PACKAGE_);
 		$cache_file = sprintf("%sfiles/cache/newest_news.%s.cache.php", _XE_PATH_, _XE_LOCATION_);
 		if(!file_exists($cache_file) || filemtime($cache_file) + 60 * 60 < $_SERVER['REQUEST_TIME'])
@@ -242,14 +243,11 @@ class adminAdminView extends admin
 					$news[] = $obj;
 				}
 				Context::set('news', $news);
-				if(isset($news) && is_array($news))
-				{
-					Context::set('latestVersion', array_shift($news));
-				}
 			}
 			Context::set('released_version', $buff->zbxe_news->attrs->released_version);
 			Context::set('download_link', $buff->zbxe_news->attrs->download_link);
 		}
+		*/
 
 		Context::set('subMenuTitle', $subMenuTitle);
 		Context::set('gnbUrlList', $menu->list);

--- a/modules/admin/tpl/_footer.html
+++ b/modules/admin/tpl/_footer.html
@@ -2,16 +2,17 @@
 	<!-- /BODY -->
 	<footer class="footer">
 		<p class="power">
-			Powered by <strong><a href="{_XE_LOCATION_SITE_}" target="_blank">XE</a></strong>. <span class="vr">|</span>  
-			<strong>Your version</strong>: {__XE_VERSION__} <span class="vr">|</span> 
-			<!--@if(isset($latestVersion))--><strong>Latest version</strong>: <a href="{htmlspecialchars(html_entity_decode($latestVersion->url), ENT_COMPAT | ENT_HTML401, 'UTF-8', false)}" target="_blank" title="{zdate($latestVersion->date, 'Y-m-d')}">{$latestVersion->title}</a><!--@end-->
+			Powered by <strong>RhymiX {__XE_VERSION__}</strong>
+			<!--@if(isset($released_version))-->
+				<span class="vr">|</span> Latest version: <a href="{htmlspecialchars(html_entity_decode($download_link), ENT_COMPAT | ENT_HTML401, 'UTF-8', false)}" target="_blank">{$released_version}</a>
+			<!--@end-->
 		</p>
 		<p class="cache">
 			<button type="button" class="x_btn-link" onclick="doResetAdminMenu();">{$lang->cmd_admin_menu_reset}</button> <span class="vr">|</span>  
 			<button type="button" class="x_btn-link" onclick="doRecompileCacheFile();">{$lang->cmd_remake_cache}</button> <span class="vr">|</span> 
 			<button type="button" class="x_btn-link" onclick="doClearSession();">{$lang->cmd_clear_session}</button> <span class="vr">|</span> 
 			<a href="./index.php?module=admin&act=dispAdminViewServerEnv">{$lang->cmd_view_server_env}</a> <span class="vr">|</span> 
-			<a href="https://github.com/xpressengine/xe-core/issues" target="_blank" style="vertical-align:middle">{$lang->bug_report}</a>
+			<a href="https://github.com/rhymix/rhymix/issues" target="_blank" style="vertical-align:middle">{$lang->bug_report}</a>
 		</p>
 	</footer>
 </div>

--- a/modules/admin/tpl/_header.html
+++ b/modules/admin/tpl/_header.html
@@ -4,7 +4,7 @@
 <p class="skipNav"><a href="#content">{$lang->skip_to_content}</a></p>
 	<header class="header">
 		<h1>
-			<a href="{getUrl('','module','admin')}"><img src="{getUrl('')}{$gnb_title_info->adminLogo}" alt="{$gnb_title_info->adminTitle}" /> {$gnb_title_info->adminTitle}</a>
+			<a href="{getUrl('','module','admin')}"><img cond="$gnb_title_info->adminLogo" src="{getUrl('')}{$gnb_title_info->adminLogo}" alt="{$gnb_title_info->adminTitle}" /> {$gnb_title_info->adminTitle}</a>
 		</h1>
 		<p class="site"><a href="{getFullUrl('')}">{$xe_default_url}</a></p>
 		<div class="account">


### PR DESCRIPTION
- 관리 모듈 기본 레이아웃 헤더의 XE 로고와 이름을 라이믹스로 변경했습니다.
- 푸터의 Powered by XE도 라이믹스로 변경했습니다.
- 버그신고 URL을 라이믹스 깃허브로 변경했습니다.
- XE 최신 버전을 확인하는 코드를 주석처리했습니다. 나중에 라이믹스 정식 버전을 배포하게 되면 라이믹스 최신 버전을 확인하도록 수정하면 될 것 같습니다.
