### PR TITLE
모바일에서 zoom 허용

### DIFF
--- a/common/tpl/mobile_layout.html
+++ b/common/tpl/mobile_layout.html
@@ -8,7 +8,7 @@
 <html lang="{str_replace('jp','ja',$lang_type)}" class="xe-mobilelayout">
 <head>
 <meta charset="utf-8" />
-<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1, user-scalable=no" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
 <block loop="Context::getMetaTag() => $no, $val">
 <meta http-equiv="{$val['name']}"|cond="$val['is_http_equiv']" name="{$val['name']}"|cond="!$val['is_http_equiv']" content="{$val['content']}">
 </block>


### PR DESCRIPTION
사용자의 선택권을 제한하고 웹 접근성을 저하시키는 `user-scalable=no` 설정을 모바일 기본 레이아웃에서 제거합니다. #88