### PR TITLE
조회수 설정 기능을 추가함 #103

### DIFF
--- a/modules/document/document.admin.controller.php
+++ b/modules/document/document.admin.controller.php
@@ -485,7 +485,9 @@ class documentAdminController extends document
 	function procDocumentAdminInsertConfig()
 	{
 		// Get the basic information
-		$config = Context::gets('thumbnail_type');
+		$config = new stdClass();
+		$config->thumbnail_type = Context::get('thumbnail_type');
+		$config->updateCount = Context::get('updatecount');
 		// Insert by creating the module Controller object
 		$oModuleController = getController('module');
 		$output = $oModuleController->insertModuleConfig('document',$config);

--- a/modules/document/document.admin.controller.php
+++ b/modules/document/document.admin.controller.php
@@ -486,8 +486,7 @@ class documentAdminController extends document
 	{
 		// Get the basic information
 		$config = new stdClass();
-		$config->session_read_config = Context::get('session_read_config');
-		$config->updatecount = Context::get('updatecount');
+		$config->view_count_option = Context::get('view_count_option');
 		// Insert by creating the module Controller object
 		$oModuleController = getController('module');
 		$output = $oModuleController->insertModuleConfig('document',$config);

--- a/modules/document/document.admin.controller.php
+++ b/modules/document/document.admin.controller.php
@@ -487,7 +487,7 @@ class documentAdminController extends document
 		// Get the basic information
 		$config = new stdClass();
 		$config->thumbnail_type = Context::get('thumbnail_type');
-		$config->updateCount = Context::get('updatecount');
+		$config->updatecount = Context::get('updatecount');
 		// Insert by creating the module Controller object
 		$oModuleController = getController('module');
 		$output = $oModuleController->insertModuleConfig('document',$config);

--- a/modules/document/document.admin.controller.php
+++ b/modules/document/document.admin.controller.php
@@ -486,7 +486,7 @@ class documentAdminController extends document
 	{
 		// Get the basic information
 		$config = new stdClass();
-		$config->thumbnail_type = Context::get('thumbnail_type');
+		$config->session_read_config = Context::get('session_read_config');
 		$config->updatecount = Context::get('updatecount');
 		// Insert by creating the module Controller object
 		$oModuleController = getController('module');

--- a/modules/document/document.controller.php
+++ b/modules/document/document.controller.php
@@ -902,7 +902,7 @@ class documentController extends document
 
 		$oDocumentModel = getModel('document');
 		$config = $oDocumentModel->getDocumentConfig();
-		if($config->updatecount != 'yes')
+		if($config->updatecount == 'Y')
 		{
 			// Pass if the author's IP address is as same as visitor's.
 			if($oDocument->get('ipaddress') == $_SERVER['REMOTE_ADDR'] && Context::getSessionStatus())

--- a/modules/document/document.controller.php
+++ b/modules/document/document.controller.php
@@ -902,7 +902,7 @@ class documentController extends document
 
 		$oDocumentModel = getModel('document');
 		$config = $oDocumentModel->getDocumentConfig();
-		if($config->updatecount == 'Y')
+		if($config->updatecount != 'Y')
 		{
 			// Pass if the author's IP address is as same as visitor's.
 			if($oDocument->get('ipaddress') == $_SERVER['REMOTE_ADDR'] && Context::getSessionStatus())

--- a/modules/document/document.controller.php
+++ b/modules/document/document.controller.php
@@ -888,7 +888,9 @@ class documentController extends document
 	{
 		// Pass if Crawler access
 		if(isCrawler()) return false;
-		
+		$oDocumentModel = getModel('document');
+		$config = $oDocumentModel->getDocumentConfig();
+
 		$document_srl = $oDocument->document_srl;
 		$member_srl = $oDocument->get('member_srl');
 		$logged_info = Context::get('logged_info');
@@ -898,10 +900,8 @@ class documentController extends document
 		if(!$trigger_output->toBool()) return $trigger_output;
 
 		// Pass if read count is increaded on the session information
-		if($_SESSION['readed_document'][$document_srl]) return false;
+		if($_SESSION['readed_document'][$document_srl] && $config->session_read_config == 'Y') return false;
 
-		$oDocumentModel = getModel('document');
-		$config = $oDocumentModel->getDocumentConfig();
 		if($config->updatecount != 'Y')
 		{
 			// Pass if the author's IP address is as same as visitor's.
@@ -944,7 +944,7 @@ class documentController extends document
 		}
 
 		// Register session
-		if(!$_SESSION['banned_document'][$document_srl] && Context::getSessionStatus()) 
+		if(!$_SESSION['banned_document'][$document_srl] && Context::getSessionStatus())
 		{
 			$_SESSION['readed_document'][$document_srl] = true;
 		}

--- a/modules/document/document.controller.php
+++ b/modules/document/document.controller.php
@@ -891,6 +891,8 @@ class documentController extends document
 		$oDocumentModel = getModel('document');
 		$config = $oDocumentModel->getDocumentConfig();
 
+		if($config->view_count_option == 'none') return false;
+
 		$document_srl = $oDocument->document_srl;
 		$member_srl = $oDocument->get('member_srl');
 		$logged_info = Context::get('logged_info');
@@ -900,9 +902,19 @@ class documentController extends document
 		if(!$trigger_output->toBool()) return $trigger_output;
 
 		// Pass if read count is increaded on the session information
-		if($_SESSION['readed_document'][$document_srl] && $config->session_read_config == 'Y') return false;
+		if($_SESSION['readed_document'][$document_srl] && $config->view_count_option == 'once')
+		{
+			return false;
+		}
+		else if($config->view_count_option == 'some')
+		{
+			if($_SESSION['readed_document'][$document_srl])
+			{
+				return false;
+			}
+		}
 
-		if($config->updatecount != 'Y')
+		if($config->view_count_option == 'once')
 		{
 			// Pass if the author's IP address is as same as visitor's.
 			if($oDocument->get('ipaddress') == $_SERVER['REMOTE_ADDR'] && Context::getSessionStatus())
@@ -944,7 +956,7 @@ class documentController extends document
 		}
 
 		// Register session
-		if(!$_SESSION['banned_document'][$document_srl] && Context::getSessionStatus())
+		if(!$_SESSION['banned_document'][$document_srl] && Context::getSessionStatus()) 
 		{
 			$_SESSION['readed_document'][$document_srl] = true;
 		}

--- a/modules/document/document.model.php
+++ b/modules/document/document.model.php
@@ -916,7 +916,7 @@ class documentModel extends document
 			$config = $oModuleModel->getModuleConfig('document');
 
 			if(!$config) $config = new stdClass();
-			if(!$config->thumbnail_type) $config->thumbnail_type = 'crop';
+			if(!$config->view_count_option) $config->view_count_option = 'once';
 			$GLOBALS['__document_config__'] = $config;
 		}
 		return $GLOBALS['__document_config__'];

--- a/modules/document/lang/lang.xml
+++ b/modules/document/lang/lang.xml
@@ -194,6 +194,9 @@
 		<value xml:lang="tr"><![CDATA[Lütfen kategori ismi giriniz]]></value>
 		<value xml:lang="vi"><![CDATA[Hãy nhập tên thể loại]]></value>
 	</item>
+	<item name="about_read_update_count">
+		<value xml:lang="ko"><![CDATA[조회수설정을 '예'로 설정할 경우 중복된 모든 조회수가 모두 기록됩니다. 만일 같은회원의 대해서 중복조회수를 카운트하지 않기를 원하시면 아니오에 설정하시기 바랍니다.]]></value>
+	</item>
 	<item name="about_expand">
 		<value xml:lang="ko"><![CDATA[선택하면 늘 펼쳐진 상태로 있게 합니다.]]></value>
 		<value xml:lang="en"><![CDATA[Select this option, and they will stay expanded.]]></value>

--- a/modules/document/lang/lang.xml
+++ b/modules/document/lang/lang.xml
@@ -23,6 +23,17 @@
 		<value xml:lang="tr"><![CDATA[Küçük Resim Türü]]></value>
 		<value xml:lang="vi"><![CDATA[Định dạng hình nhỏ]]></value>
 	</item>
+	<item name="read_update_count">
+		<value xml:lang="ko"><![CDATA[조회수 설정]]></value>
+		<value xml:lang="en"></value>
+		<value xml:lang="jp"></value>
+		<value xml:lang="zh-CN"></value>
+		<value xml:lang="zh-TW"></value>
+		<value xml:lang="fr"></value>
+		<value xml:lang="ru"></value>
+		<value xml:lang="tr"></value>
+		<value xml:lang="vi"></value>
+	</item>
 	<item name="thumbnail_crop">
 		<value xml:lang="ko"><![CDATA[잘라내기 (정해진 크기에 꽉 찬 모습의 썸네일을 만듭니다.)]]></value>
 		<value xml:lang="en"><![CDATA[Crop (to a specific size)]]></value>

--- a/modules/document/lang/lang.xml
+++ b/modules/document/lang/lang.xml
@@ -23,27 +23,20 @@
 		<value xml:lang="tr"><![CDATA[Küçük Resim Türü]]></value>
 		<value xml:lang="vi"><![CDATA[Định dạng hình nhỏ]]></value>
 	</item>
-	<item name="read_update_count">
+	<item name="view_count_option">
 		<value xml:lang="ko"><![CDATA[조회수 설정]]></value>
-		<value xml:lang="en"></value>
-		<value xml:lang="jp"></value>
-		<value xml:lang="zh-CN"></value>
-		<value xml:lang="zh-TW"></value>
-		<value xml:lang="fr"></value>
-		<value xml:lang="ru"></value>
-		<value xml:lang="tr"></value>
-		<value xml:lang="vi"></value>
 	</item>
-	<item name="session_config">
-		<value xml:lang="ko"><![CDATA[세션 조회수 증가설정]]></value>
-		<value xml:lang="en"></value>
-		<value xml:lang="jp"></value>
-		<value xml:lang="zh-CN"></value>
-		<value xml:lang="zh-TW"></value>
-		<value xml:lang="fr"></value>
-		<value xml:lang="ru"></value>
-		<value xml:lang="tr"></value>
-		<value xml:lang="vi"></value>
+	<item name="view_count_option_all">
+		<value xml:lang="ko"><![CDATA[모두 계산]]></value>
+	</item>
+	<item name="view_count_option_some">
+		<value xml:lang="ko"><![CDATA[일부 계산]]></value>
+	</item>
+	<item name="view_count_option_once">
+		<value xml:lang="ko"><![CDATA[중복 금지]]></value>
+	</item>
+	<item name="view_count_option_none">
+		<value xml:lang="ko"><![CDATA[계산 안함]]></value>
 	</item>
 	<item name="thumbnail_crop">
 		<value xml:lang="ko"><![CDATA[잘라내기 (정해진 크기에 꽉 찬 모습의 썸네일을 만듭니다.)]]></value>
@@ -205,8 +198,8 @@
 		<value xml:lang="tr"><![CDATA[Lütfen kategori ismi giriniz]]></value>
 		<value xml:lang="vi"><![CDATA[Hãy nhập tên thể loại]]></value>
 	</item>
-	<item name="about_read_update_count">
-		<value xml:lang="ko"><![CDATA[조회수설정을 '예'로 설정할 경우 중복된 모든 조회수가 모두 기록됩니다. 만일 같은회원의 대해서 중복조회수를 카운트하지 않기를 원하시면 아니오에 설정하시기 바랍니다.]]></value>
+	<item name="about_view_count_option">
+		<value xml:lang="ko"><![CDATA[조회수설정에 따라 중복 조회수 카운트를 할 수 있도록 도와줍니다. 각 옵션에 따라 조회수 기록하는 방식이 달라집니다.]]></value>
 	</item>
 	<item name="about_expand">
 		<value xml:lang="ko"><![CDATA[선택하면 늘 펼쳐진 상태로 있게 합니다.]]></value>

--- a/modules/document/lang/lang.xml
+++ b/modules/document/lang/lang.xml
@@ -34,6 +34,17 @@
 		<value xml:lang="tr"></value>
 		<value xml:lang="vi"></value>
 	</item>
+	<item name="session_config">
+		<value xml:lang="ko"><![CDATA[세션 조회수 증가설정]]></value>
+		<value xml:lang="en"></value>
+		<value xml:lang="jp"></value>
+		<value xml:lang="zh-CN"></value>
+		<value xml:lang="zh-TW"></value>
+		<value xml:lang="fr"></value>
+		<value xml:lang="ru"></value>
+		<value xml:lang="tr"></value>
+		<value xml:lang="vi"></value>
+	</item>
 	<item name="thumbnail_crop">
 		<value xml:lang="ko"><![CDATA[잘라내기 (정해진 크기에 꽉 찬 모습의 썸네일을 만듭니다.)]]></value>
 		<value xml:lang="en"><![CDATA[Crop (to a specific size)]]></value>

--- a/modules/document/tpl/declared_list.html
+++ b/modules/document/tpl/declared_list.html
@@ -3,9 +3,7 @@ xe.lang.msg_empty_search_target = '{$lang->msg_empty_search_target}';
 xe.lang.msg_empty_search_keyword = '{$lang->msg_empty_search_keyword}';
 </script>
 <load target="js/document_admin.js" />
-<div class="x_page-header">
-	<h1>{$lang->document} <a class="x_icon-question-sign" href="./common/manual/admin/#UMAN_content_document" target="_blank">{$lang->help}</a></h1>
-</div>
+<include target="header.html" />
 <div cond="$XE_VALIDATOR_MESSAGE && $XE_VALIDATOR_ID == 'modules/document/tpl/declared_list/1'" class="message {$XE_VALIDATOR_MESSAGE_TYPE}">
 	<p>{$XE_VALIDATOR_MESSAGE}</p>
 </div>

--- a/modules/document/tpl/document_config.html
+++ b/modules/document/tpl/document_config.html
@@ -7,15 +7,15 @@
 	<div class="x_control-group">
 		<div class="x_control-label">{$lang->thumbnail_type}</div>
 		<div class="x_controls">
-			<label class="x_inline" for="thumbnail_type_crop"><input type="radio" name="thumbnail_type" id="thumbnail_type_crop" value="Y" checked="checked"|cond="$config->thumbnail_type == 'crop'" /> {$lang->thumbnail_crop}</label>
-			<label class="x_inline" for="thumbnail_type_ratio"><input type="radio" name="thumbnail_type" id="thumbnail_type_ratio" value="N" checked="checked"|cond="$config->thumbnail_type == 'ratio'" /> {$lang->thumbnail_ratio}</label>
+			<label class="x_inline" for="thumbnail_type_crop"><input type="radio" name="thumbnail_type" id="thumbnail_type_crop" value="crop" checked="checked"|cond="$config->thumbnail_type == 'crop'" /> {$lang->thumbnail_crop}</label>
+			<label class="x_inline" for="thumbnail_type_ratio"><input type="radio" name="thumbnail_type" id="thumbnail_type_ratio" value="ratio" checked="checked"|cond="$config->thumbnail_type == 'ratio'" /> {$lang->thumbnail_ratio}</label>
 		</div>
 	</div>
 	<div class="x_control-group">
 		<div class="x_control-label">{$lang->read_update_count}</div>
 		<div class="x_controls">
-			<label class="x_inline" for="updatecount_yes"><input type="radio" name="updatecount" id="updatecount_yes" value="Y" checked="checked"|cond="$config->updatecount == 'yes'" /> {$lang->cmd_yes}</label>
-			<label class="x_inline" for="updatecount_no"><input type="radio" name="updatecount" id="updatecount_no" value="N" checked="checked"|cond="$config->updatecount != 'yes'" /> {$lang->cmd_no}</label>
+			<label class="x_inline" for="updatecount_yes"><input type="radio" name="updatecount" id="updatecount_yes" value="Y" checked="checked"|cond="$config->updatecount == 'Y'" /> {$lang->cmd_yes}</label>
+			<label class="x_inline" for="updatecount_no"><input type="radio" name="updatecount" id="updatecount_no" value="N" checked="checked"|cond="$config->updatecount != 'Y'" /> {$lang->cmd_no}</label>
 			<p>{$lang->about_read_update_count}</p>
 		</div>
 	</div>

--- a/modules/document/tpl/document_config.html
+++ b/modules/document/tpl/document_config.html
@@ -4,19 +4,20 @@
 	<input type="hidden" name="module" value="document" />
 	<input type="hidden" name="act" value="procDocumentAdminInsertConfig" />
 	<input type="hidden" name="xe_validator_id" value="modules/document/tpl/document_config/1" />
-	<div class="x_control-group">
-		<div class="x_control-label">{$lang->thumbnail_type}</div>
-		<div class="x_controls">
-			<label class="x_inline" for="thumbnail_type_crop"><input type="radio" name="thumbnail_type" id="thumbnail_type_crop" value="crop" checked="checked"|cond="$config->thumbnail_type == 'crop'" /> {$lang->thumbnail_crop}</label>
-			<label class="x_inline" for="thumbnail_type_ratio"><input type="radio" name="thumbnail_type" id="thumbnail_type_ratio" value="ratio" checked="checked"|cond="$config->thumbnail_type == 'ratio'" /> {$lang->thumbnail_ratio}</label>
-		</div>
-	</div>
+
 	<div class="x_control-group">
 		<div class="x_control-label">{$lang->read_update_count}</div>
 		<div class="x_controls">
 			<label class="x_inline" for="updatecount_yes"><input type="radio" name="updatecount" id="updatecount_yes" value="Y" checked="checked"|cond="$config->updatecount == 'Y'" /> {$lang->cmd_yes}</label>
 			<label class="x_inline" for="updatecount_no"><input type="radio" name="updatecount" id="updatecount_no" value="N" checked="checked"|cond="$config->updatecount != 'Y'" /> {$lang->cmd_no}</label>
 			<p>{$lang->about_read_update_count}</p>
+		</div>
+	</div>
+	<div class="x_control-group">
+		<div class="x_control-label">SESSION SETTING</div>
+		<div class="x_controls">
+			<label class="x_inline" for="session_read_yes"><input type="radio" name="session_read_config" id="session_read_yes" value="Y" checked="checked"|cond="$config->session_read_config == 'Y'" /> {$lang->cmd_yes}</label>
+			<label class="x_inline" for="session_read_no"><input type="radio" name="session_read_config" id="session_read_no" value="N" checked="checked"|cond="$config->session_read_config != 'Y'" /> {$lang->cmd_no}</label>
 		</div>
 	</div>
 	<div class="btnArea x_clearfix">

--- a/modules/document/tpl/document_config.html
+++ b/modules/document/tpl/document_config.html
@@ -1,21 +1,26 @@
-<!--#include("header.html")-->
+<include target="header.html" />
 
-<form action="./" method="post">
+<form action="./" method="post" class="x_form-horizontal" method="post">
 	<input type="hidden" name="module" value="document" />
 	<input type="hidden" name="act" value="procDocumentAdminInsertConfig" />
-	<table class="x_table x_table-striped x_table-hover">
-		<tr>
-			<th scope="col">{$lang->thumbnail_type}</th>
-		</tr>
-		<tr>
-			<td>
-				<input type="radio" name="thumbnail_type" value="crop" <!--@if($config->thumbnail_type != 'ratio')-->checked="checked"<!--@end-->/> {$lang->thumbnail_crop} <br />
-				<input type="radio" name="thumbnail_type" value="ratio" <!--@if($config->thumbnail_type == 'ratio')-->checked="checked"<!--@end-->/> {$lang->thumbnail_ratio}
-			</td>
-		</tr>
-	</table>
-    <div class="btnArea">
-		<input class="btn" type="submit" value="{$lang->cmd_registration}" />
-		<input class="btn" type="button" value="{$lang->cmd_delete_all_thumbnail}" onclick="doDeleteAllThumbnail()"/>
+	<input type="hidden" name="xe_validator_id" value="modules/member/tpl/1" />
+	<div class="x_control-group">
+		<div class="x_control-label">{$lang->thumbnail_type}</div>
+		<div class="x_controls">
+			<label class="x_inline" for="thumbnail_type_crop"><input type="radio" name="thumbnail_type" id="thumbnail_type_crop" value="Y" checked="checked"|cond="$config->thumbnail_type == 'crop'" /> {$lang->thumbnail_crop}</label>
+			<label class="x_inline" for="thumbnail_type_ratio"><input type="radio" name="thumbnail_type" id="thumbnail_type_ratio" value="N" checked="checked"|cond="$config->thumbnail_type == 'ratio'" /> {$lang->thumbnail_ratio}</label>
+		</div>
+	</div>
+	<div class="x_control-group">
+		<div class="x_control-label">{$lang->read_update_count}</div>
+		<div class="x_controls">
+			<label class="x_inline" for="updatecount_yes"><input type="radio" name="updatecount" id="updatecount_yes" value="Y" checked="checked"|cond="$config->updatecount == 'yes'" /> {$lang->cmd_yes}</label>
+			<label class="x_inline" for="updatecount_no"><input type="radio" name="updatecount" id="updatecount_no" value="N" checked="checked"|cond="$config->updatecount != 'yes'" /> {$lang->cmd_no}</label>
+		</div>
+	</div>
+	<div class="btnArea x_clearfix">
+		<span class="x_pull-right" style="margin-left:10px;"><input class="btn" type="button" value="{$lang->cmd_delete_all_thumbnail}" onclick="doDeleteAllThumbnail()"/></span>
+		<span class="x_pull-right"><input class="x_btn x_btn-primary" type="submit" value="{$lang->cmd_save}" /></span>
 	</div>
 </form>
+

--- a/modules/document/tpl/document_config.html
+++ b/modules/document/tpl/document_config.html
@@ -6,20 +6,20 @@
 	<input type="hidden" name="xe_validator_id" value="modules/document/tpl/document_config/1" />
 
 	<div class="x_control-group">
-		<div class="x_control-label">{$lang->read_update_count}</div>
-		<div class="x_controls">
-			<label class="x_inline" for="updatecount_yes"><input type="radio" name="updatecount" id="updatecount_yes" value="Y" checked="checked"|cond="$config->updatecount == 'Y'" /> {$lang->cmd_yes}</label>
-			<label class="x_inline" for="updatecount_no"><input type="radio" name="updatecount" id="updatecount_no" value="N" checked="checked"|cond="$config->updatecount != 'Y'" /> {$lang->cmd_no}</label>
-			<p>{$lang->about_read_update_count}</p>
+		<div class="x_control-group">
+			<label class="x_control-label">{$lang->view_count_option}</label>
+			<div class="x_controls">
+				<select name="view_count_option">
+					<option value="all" selected="selected"|cond="$config->view_count_option=='all'">{$lang->view_count_option_all}</option>
+					<option value="some" selected="selected"|cond="$config->view_count_option=='some'">{$lang->view_count_option_some}</option>
+					<option value="once" selected="selected"|cond="$config->view_count_option=='once'">{$lang->view_count_option_once}</option>
+					<option value="none" selected="selected"|cond="$config->view_count_option=='none'">{$lang->view_count_option_none}</option>
+				</select>
+				<p>{$lang->about_view_count_option}</p>
+			</div>
 		</div>
 	</div>
-	<div class="x_control-group">
-		<div class="x_control-label">SESSION SETTING</div>
-		<div class="x_controls">
-			<label class="x_inline" for="session_read_yes"><input type="radio" name="session_read_config" id="session_read_yes" value="Y" checked="checked"|cond="$config->session_read_config == 'Y'" /> {$lang->cmd_yes}</label>
-			<label class="x_inline" for="session_read_no"><input type="radio" name="session_read_config" id="session_read_no" value="N" checked="checked"|cond="$config->session_read_config != 'Y'" /> {$lang->cmd_no}</label>
-		</div>
-	</div>
+
 	<div class="btnArea x_clearfix">
 		<span class="x_pull-right" style="margin-left:10px;"><input class="btn" type="button" value="{$lang->cmd_delete_all_thumbnail}" onclick="doDeleteAllThumbnail()"/></span>
 		<span class="x_pull-right"><input class="x_btn x_btn-primary" type="submit" value="{$lang->cmd_save}" /></span>

--- a/modules/document/tpl/document_config.html
+++ b/modules/document/tpl/document_config.html
@@ -3,7 +3,7 @@
 <form action="./" method="post" class="x_form-horizontal" method="post">
 	<input type="hidden" name="module" value="document" />
 	<input type="hidden" name="act" value="procDocumentAdminInsertConfig" />
-	<input type="hidden" name="xe_validator_id" value="modules/member/tpl/1" />
+	<input type="hidden" name="xe_validator_id" value="modules/document/tpl/document_config/1" />
 	<div class="x_control-group">
 		<div class="x_control-label">{$lang->thumbnail_type}</div>
 		<div class="x_controls">
@@ -24,4 +24,3 @@
 		<span class="x_pull-right"><input class="x_btn x_btn-primary" type="submit" value="{$lang->cmd_save}" /></span>
 	</div>
 </form>
-

--- a/modules/document/tpl/document_config.html
+++ b/modules/document/tpl/document_config.html
@@ -16,6 +16,7 @@
 		<div class="x_controls">
 			<label class="x_inline" for="updatecount_yes"><input type="radio" name="updatecount" id="updatecount_yes" value="Y" checked="checked"|cond="$config->updatecount == 'yes'" /> {$lang->cmd_yes}</label>
 			<label class="x_inline" for="updatecount_no"><input type="radio" name="updatecount" id="updatecount_no" value="N" checked="checked"|cond="$config->updatecount != 'yes'" /> {$lang->cmd_no}</label>
+			<p>{$lang->about_read_update_count}</p>
 		</div>
 	</div>
 	<div class="btnArea x_clearfix">

--- a/modules/document/tpl/document_list.html
+++ b/modules/document/tpl/document_list.html
@@ -3,9 +3,7 @@ xe.lang.msg_empty_search_target = '{$lang->msg_empty_search_target}';
 xe.lang.msg_empty_search_keyword = '{$lang->msg_empty_search_keyword}';
 </script>
 <load target="js/document_admin.js" />
-<div class="x_page-header">
-	<h1>{$lang->document} <a class="x_icon-question-sign" href="./common/manual/admin/#UMAN_content_document" target="_blank">{$lang->help}</a></h1>
-</div>
+<include target="header.html" />
 <div cond="$XE_VALIDATOR_MESSAGE && $XE_VALIDATOR_ID == 'modules/document/tpl/document_list/1'" class="message {$XE_VALIDATOR_MESSAGE_TYPE}">
 	<p>{$XE_VALIDATOR_MESSAGE}</p>
 </div>

--- a/modules/document/tpl/header.html
+++ b/modules/document/tpl/header.html
@@ -1,9 +1,16 @@
 <load target="js/document_admin.js" />
-<h1>{$lang->document} {$lang->cmd_management}</h1>
-<p>
-	<a href="{getUrl('act','dispDocumentAdminList')}" class="active"|cond="$act=='dispDocumentAdminList'">{$lang->document_list}</a>
-	<i>|</i>
-	<a href="{getUrl('act','dispDocumentAdminConfig')}" class="active"|cond="$act=='dispDocumentAdminConfig'">{$lang->cmd_module_config}</a>
-	<i>|</i>
-	<a href="{getUrl('act','dispDocumentAdminDeclared')}" class="active"|cond="$act=='dispDocumentAdminDeclared'">{$lang->cmd_declared_list}</a>
-</p>
+
+<div class="x_page-header">
+	<h1>{$lang->document} <a class="x_icon-question-sign" href="./common/manual/admin/#UMAN_content_document" target="_blank">{$lang->help}</a></h1>
+</div>
+<ul class="x_nav x_nav-tabs">
+	<li class="x_active"|cond="$act == 'dispDocumentAdminList'">
+		<a href="{getUrl('', 'module', 'admin', 'act', 'dispDocumentAdminList')}">{$lang->document_list}</a>
+	</li>
+	<li class="x_active"|cond="$act == 'dispDocumentAdminConfig'">
+		<a href="{getUrl('', 'module', 'admin', 'act', 'dispDocumentAdminConfig')}">{$lang->cmd_module_config}</a>
+	</li>
+	<li class="x_active"|cond="$act == 'dispDocumentAdminDeclared'">
+		<a href="{getUrl('', 'module', 'admin', 'act', 'dispDocumentAdminDeclared')}">{$lang->cmd_declared_list}</a>
+	</li>
+</ul>


### PR DESCRIPTION
![_011516_071501_pm](https://cloud.githubusercontent.com/assets/4381756/12350737/501bd41a-bbbc-11e5-8569-bab98a6d56d1.jpg)
#103 이슈에 나온 이야기에 따라 조회수 설정을 기능추가 했습니다 
위사진처럼 문서목록에서 위에 헤더를 추가 하엿고, 해당 헤더를 클릭하여 문서 조회수 설정을 들어갈 수 잇도록 했습니다.

섬네일설정 저건 외있는지 모르겠지만.. 없어도되면 나중에 지워버리는걸로..;ㅁ;

그리고 기본적으로 설정이 저장되어있지 않거나 아니오에 설정되어있는경우 기존과 동일하게 작동하도록 설정되어있습니다. 
