### PR TITLE
모든 DB에서 UTF-8 이모티콘 등을 지원하는 패치

### DIFF
--- a/common/functions.php
+++ b/common/functions.php
@@ -5,3 +5,19 @@
  * 
  * Copyright (c) Rhymix Developers and Contributors
  */
+
+/**
+ * Encode UTF-8 characters outside of the Basic Multilingual Plane in the &#xxxxxx format.
+ * This allows emoticons and other characters to be stored in MySQL without utf8mb4 support.
+ * 
+ * @param $str The string to encode
+ * @return string
+ */
+function utf8_mbencode($str)
+{
+	return preg_replace_callback('/[\xF0-\xF7][\x80-\xBF]{3}/', function($m) {
+		$bytes = array(ord($m[0][0]), ord($m[0][1]), ord($m[0][2]), ord($m[0][3]));
+		$codepoint = ((0x07 & $bytes[0]) << 18) + ((0x3F & $bytes[1]) << 12) + ((0x3F & $bytes[2]) << 6) + (0x3F & $bytes[3]);
+		return '&#x' . dechex($codepoint) . ';';
+	}, $str);
+}

--- a/modules/comment/comment.controller.php
+++ b/modules/comment/comment.controller.php
@@ -357,6 +357,7 @@ class commentController extends comment
 		{
 			$obj->content = removeHackTag($obj->content);
 		}
+		$obj->content = utf8_mbencode($obj->content);
 
 		if(!$obj->notify_message)
 		{
@@ -777,6 +778,7 @@ class commentController extends comment
 		{
 			$obj->content = removeHackTag($obj->content);
 		}
+		$obj->content = utf8_mbencode($obj->content);
 
 		// begin transaction
 		$oDB = DB::getInstance();

--- a/modules/communication/communication.controller.php
+++ b/modules/communication/communication.controller.php
@@ -132,7 +132,7 @@ class communicationController extends communication
 			$content = sprintf("%s<br /><br />From : <a href=\"%s\" target=\"_blank\">%s</a>", $content, $view_url, $view_url);
 			$oMail = new Mail();
 			$oMail->setTitle($title);
-			$oMail->setContent($content);
+			$oMail->setContent(utf8_mbencode(removeHackTag($content)));
 			$oMail->setSender($logged_info->nick_name, $logged_info->email_address);
 			$oMail->setReceiptor($receiver_member_info->nick_name, $receiver_member_info->email_address);
 			$oMail->send();
@@ -172,8 +172,11 @@ class communicationController extends communication
 	 */
 	function sendMessage($sender_srl, $receiver_srl, $title, $content, $sender_log = TRUE)
 	{
-		$content = removeHackTag($content);
+		// Encode the title and content.
 		$title = htmlspecialchars($title, ENT_COMPAT | ENT_HTML401, 'UTF-8', false);
+		$content = removeHackTag($content);
+		$title = utf8_mbencode($title);
+		$content = utf8_mbencode($content);
 
 		$message_srl = getNextSequence();
 		$related_srl = getNextSequence();

--- a/modules/document/document.controller.php
+++ b/modules/document/document.controller.php
@@ -310,6 +310,10 @@ class documentController extends document
 		// An error appears if both log-in info and user name don't exist.
 		if(!$logged_info->member_srl && !$obj->nick_name) return new Object(-1,'msg_invalid_request');
 
+		// Fix encoding of non-BMP UTF-8 characters.
+		$obj->title = utf8_mbencode($obj->title);
+		$obj->content = utf8_mbencode($obj->content);
+
 		$obj->lang_code = Context::getLangType();
 		// Insert data into the DB
 		if(!$obj->status) $this->_checkDocumentStatusForOldVersion($obj);
@@ -551,6 +555,10 @@ class documentController extends document
 		}
 		// if temporary document, regdate is now setting
 		if($source_obj->get('status') == $this->getConfigStatus('temp')) $obj->regdate = date('YmdHis');
+
+		// Fix encoding of non-BMP UTF-8 characters.
+		$obj->title = utf8_mbencode($obj->title);
+		$obj->content = utf8_mbencode($obj->content);
 
 		// Insert data into the DB
 		$output = executeQuery('document.updateDocument', $obj);


### PR DESCRIPTION
현재 라이믹스에서 "😃"와 같은 이모티콘이나 일부 한자를 입력하면 `?`로 바뀌어 표시되거나, 해당 문자 뒷부분의 내용이 아예 잘려 버리기도 합니다. UTF-8에서 1~3바이트로 인코딩되는 대부분의 글자들과 달리, 이모티콘과 일부 한자는 4바이트로 인코딩되기 때문입니다. 흔히 사용하는 MySQL DB의 `utf8` 문자셋은 4바이트 인코딩과 호환되지 않습니다.

라이믹스에서는 얼마 전부터 최초 설치시 DB가 `utf8mb4` 문자셋을 지원하는지 확인하여, 만약 지원할 경우 모든 테이블을 `utf8mb4` 문자셋으로 생성하고 있습니다. 그러나 DB가 `utf8mb4` 문자셋을 지원하지 않거나, 이미 테이블을 `utf8`로 사용하고 있는 사이트라면 변경하기가 쉽지 않습니다. 또한 CUBRID, MS SQL 등 라이믹스에서 지원하는 다른 DB들이 버전에 따라 UTF-8을 어디까지 지원하는지도 정확하게 알기 어렵습니다.

이런 불편을 덜기 위해 신규 설치 여부, DB 종류, DB에서 지원하는 문자셋과 상관없이 **모든 유니코드 문자를 즉시 지원하는** 패치를 작성했습니다.

작동 원리: UTF-8에서 4바이트로 인코딩되는 이모티콘 등의 문자를 입력할 경우 `&#x1f603;` 등의 HTML 문법으로 자동 변환하여 저장합니다. 변환 결과는 평범한 아스키 문자의 조합이므로 모든 DB와 호환되며, 웹상에서는 자동으로 원래의 문자로 표시됩니다.

적용 범위: 문서 제목 및 내용, 댓글 내용, 쪽지 제목 및 내용