### PR TITLE
mbstring이 설치되어 있지 않는 경우 서드파티 라이브러리 오류 수정

### DIFF
--- a/common/legacy.php
+++ b/common/legacy.php
@@ -6,23 +6,6 @@
  * Copyright (c) NAVER <http://www.navercorp.com>
  */
 
-// define an empty function to avoid errors when iconv function doesn't exist
-if(!function_exists('iconv'))
-{
-	function iconv($in_charset, $out_charset, $str)
-	{
-		if(function_exists('mb_convert_encoding'))
-		{
-			$out_charset = preg_replace('#//.+$#', '', $out_charset);
-			return mb_convert_encoding($str, $out_charset, $in_charset);
-		}
-		else
-		{
-			return $str;
-		}
-	}
-}
-
 /**
  * Time zone
  * @var array
@@ -1530,6 +1513,166 @@ function changeValueInUrl($key, $requestKey, $dbKey, $urlName = 'success_return_
 				Context::set($urlName, $successReturnUrl);
 			}
 		}
+	}
+}
+
+/**
+ * Polyfill for iconv()
+ */
+if(!function_exists('iconv'))
+{
+	function iconv($in_charset, $out_charset, $str)
+	{
+		if(function_exists('mb_convert_encoding'))
+		{
+			$out_charset = preg_replace('#//.+$#', '', $out_charset);
+			return mb_convert_encoding($str, $out_charset, $in_charset);
+		}
+		else
+		{
+			return $str;
+		}
+	}
+}
+
+/**
+ * Polyfill for iconv_strlen()
+ */
+if(!function_exists('iconv_strlen'))
+{
+	function iconv_strlen($str, $charset = null)
+	{
+		if(function_exists('mb_strlen'))
+		{
+			return mb_strlen($str, $charset);
+		}
+		else
+		{
+			return strlen($str);
+		}
+	}
+}
+
+/**
+ * Polyfill for iconv_strpos()
+ */
+if(!function_exists('iconv_strpos'))
+{
+	function iconv_strpos($haystack, $needle, $offset, $charset = null)
+	{
+		if(function_exists('mb_strpos'))
+		{
+			return mb_strpos($haystack, $needle, $offset, $charset);
+		}
+		else
+		{
+			return strpos($haystack, $needle, $offset);
+		}
+	}
+}
+
+/**
+ * Polyfill for iconv_substr()
+ */
+if(!function_exists('iconv_substr'))
+{
+	function iconv_substr($str, $offset, $length = null, $charset = null)
+	{
+		if(function_exists('mb_substr'))
+		{
+			return mb_substr($str, $offset, $length, $charset);
+		}
+		else
+		{
+			return $length ? substr($str, $offset, $length) : substr($str, $offset);
+		}
+	}
+}
+
+/**
+ * Polyfill for mb_strlen()
+ */
+if(!function_exists('mb_strlen'))
+{
+	function mb_strlen($str, $charset = null)
+	{
+		if(function_exists('iconv_strlen'))
+		{
+			return iconv_strlen($str, $charset);
+		}
+		else
+		{
+			return strlen($str);
+		}
+	}
+}
+
+/**
+ * Polyfill for mb_strpos()
+ */
+if(!function_exists('mb_strpos'))
+{
+	function mb_strpos($haystack, $needle, $offset, $charset = null)
+	{
+		if(function_exists('iconv_strpos'))
+		{
+			return iconv_strpos($haystack, $needle, $offset, $charset);
+		}
+		else
+		{
+			return strpos($haystack, $needle, $offset);
+		}
+	}
+}
+
+/**
+ * Polyfill for mb_substr()
+ */
+if(!function_exists('mb_substr'))
+{
+	function mb_substr($str, $offset, $length = null, $charset = null)
+	{
+		if(function_exists('iconv_substr'))
+		{
+			return iconv_substr($str, $offset, $length, $charset);
+		}
+		else
+		{
+			return $length ? substr($str, $offset, $length) : substr($str, $offset);
+		}
+	}
+}
+
+/**
+ * Polyfill for mb_substr_count()
+ */
+if(!function_exists('mb_substr_count'))
+{
+	function mb_substr_count($haystack, $needle, $charset = null)
+	{
+		return substr_count($haystack, $needle);
+	}
+}
+
+/**
+ * Polyfill for mb_strtoupper()
+ */
+if(!function_exists('mb_strtoupper'))
+{
+	function mb_strtoupper($str, $charset = null)
+	{
+		return strtoupper($str);
+	}
+}
+
+/**
+ * Polyfill for mb_strtolower()
+ */
+if(!function_exists('mb_strtolower'))
+{
+	function mb_strtolower($str, $charset = null)
+	{
+		return strtolower($str);
 	}
 }
 


### PR DESCRIPTION
참고: #124

composer로 설치한 일부 서드파티 라이브러리들이 PHP의 mbstring 모듈에 의존합니다. 그러나 현재 라이믹스의 설치 환경 요구사항을 자세히 보면 mbstring이 반드시 필요한 것이 아니라 iconv, mbstring 중 택일이라고 되어 있습니다. 게다가 국내 호스팅 환경 중 mbstring이 설치되어 있지 않은 곳이 은근히 많기 때문에, 이 경우 오류를 뿜지 않도록 대책이 필요합니다.

이 PR에서는 `mb_strlen()`, `mb_strpos()`, `mb_substr()`, `mb_substr_count()`, `mb_strtoupper()`, `mb_strtolower()` 등 서드파티 라이브러리에서 사용하는 mbstring 함수들이 존재하지 않는 경우 iconv를 사용하여 대체하는 기능을 추가했습니다. 반대 방향도 마찬가지로, 주요 iconv 함수들이 존재하지 않는 경우 mbstring을 사용하여 대체합니다. (단, 둘 다 없는 경우에는 이것마저 오작동할 수 있습니다.)

P.S. 함수들 이름이 참 거시기해요. 전직 대통령을 연상시켜서... ㅡ.ㅡ;;