### PR TITLE
쪽지 답장시 [re] [re] [re] 말머리가 끝없이 붙는 것을 방지

### DIFF
--- a/modules/communication/communication.mobile.php
+++ b/modules/communication/communication.mobile.php
@@ -166,7 +166,10 @@ class communicationMobile extends communicationView
 			$source_message = $oCommunicationModel->getSelectedMessage($message_srl);
 			if($source_message->message_srl == $message_srl && $source_message->sender_srl == $receiver_srl)
 			{
-				$source_message->title = "[re] " . $source_message->title;
+				if(strncasecmp('[re]', $source_message->title, 4) !== 0)
+				{
+					$source_message->title = '[re] ' . $source_message->title;
+				}
 				$source_message->content = "\r\n<br />\r\n<br /><div style=\"padding-left:5px; border-left:5px solid #DDDDDD;\">" . trim($source_message->content) . "</div>";
 				Context::set('source_message', $source_message);
 			}

--- a/modules/communication/communication.view.php
+++ b/modules/communication/communication.view.php
@@ -206,7 +206,10 @@ class communicationView extends communication
 			$source_message = $oCommunicationModel->getSelectedMessage($message_srl);
 			if($source_message->message_srl == $message_srl && $source_message->sender_srl == $receiver_srl)
 			{
-				$source_message->title = "[re] " . $source_message->title;
+				if(strncasecmp('[re]', $source_message->title, 4) !== 0)
+				{
+					$source_message->title = '[re] ' . $source_message->title;
+				}
 				$source_message->content = "\r\n<br />\r\n<br /><div style=\"padding-left:5px; border-left:5px solid #DDDDDD;\">" . trim($source_message->content) . "</div>";
 				Context::set('source_message', $source_message);
 			}


### PR DESCRIPTION
쪽지로 답장을 몇 차례 주고받다 보면 제목이 이렇게 되어 버립니다.

> [re] [re] [re] [re] [re] [re] 원래 제목

이런 문제를 방지하기 위해, 원래 제목이 `[re]`로 시작하는 경우 답장 제목에 `[re]`를 또 붙이지 않도록 변경합니다.