### PR TITLE
특성 act에서는 CSRF 체크를 하지않도록 속성추가

### DIFF
--- a/classes/module/ModuleHandler.class.php
+++ b/classes/module/ModuleHandler.class.php
@@ -402,24 +402,29 @@ class ModuleHandler extends Handler
 				return $oMessageObject;
 			}
 		}
-
+		
+		// check CSRF for POST actions
+		if(Context::getRequestMethod() === 'POST' && Context::isInstalled() && !checkCSRF())
+		{
+			if($xml_info->action->{$this->act} && $xml_info->action->{$this->act}->check_csrf !== 'false')
+			{
+				$this->_setInputErrorToContext();
+				$this->error = 'msg_invalid_request';
+				$oMessageObject = ModuleHandler::getModuleInstance('message', $display_mode);
+				$oMessageObject->setError(-1);
+				$oMessageObject->setMessage($this->error);
+				$oMessageObject->dispMessage();
+				return $oMessageObject;
+			}
+		}
+		
 		if($this->module_info->use_mobile != "Y")
 		{
 			Mobile::setMobile(FALSE);
 		}
 
 		$logged_info = Context::get('logged_info');
-
-		// check CSRF for POST actions
-		if(Context::getRequestMethod() === 'POST' && Context::isInstalled() && $this->act !== 'procFileUpload' && !checkCSRF()) {
-			$this->error = 'msg_invalid_request';
-			$oMessageObject = ModuleHandler::getModuleInstance('message', $display_mode);
-			$oMessageObject->setError(-1);
-			$oMessageObject->setMessage($this->error);
-			$oMessageObject->dispMessage();
-			return $oMessageObject;
-		}
-
+		
 		// Admin ip
 		if($kind == 'admin' && $_SESSION['denied_admin'] == 'Y')
 		{
@@ -552,7 +557,22 @@ class ModuleHandler extends Handler
 						return $oMessageObject;
 					}
 				}
-
+				
+				// check CSRF for POST actions
+				if(Context::getRequestMethod() === 'POST' && Context::isInstalled() && !checkCSRF())
+				{
+					if($xml_info->action->{$this->act} && $xml_info->action->{$this->act}->check_csrf !== 'false')
+					{
+						$this->_setInputErrorToContext();
+						$this->error = 'msg_invalid_request';
+						$oMessageObject = ModuleHandler::getModuleInstance('message', $display_mode);
+						$oMessageObject->setError(-1);
+						$oMessageObject->setMessage($this->error);
+						$oMessageObject->dispMessage();
+						return $oMessageObject;
+					}
+				}
+				
 				if($type == "view" && Mobile::isFromMobilePhone())
 				{
 					$orig_type = "view";

--- a/classes/module/ModuleHandler.class.php
+++ b/classes/module/ModuleHandler.class.php
@@ -404,9 +404,9 @@ class ModuleHandler extends Handler
 		}
 		
 		// check CSRF for POST actions
-		if(Context::getRequestMethod() === 'POST' && Context::isInstalled() && !checkCSRF())
+		if(Context::getRequestMethod() === 'POST' && Context::isInstalled())
 		{
-			if($xml_info->action->{$this->act} && $xml_info->action->{$this->act}->check_csrf !== 'false')
+			if($xml_info->action->{$this->act} && $xml_info->action->{$this->act}->check_csrf !== 'false' && !checkCSRF())
 			{
 				$this->_setInputErrorToContext();
 				$this->error = 'msg_invalid_request';
@@ -559,9 +559,9 @@ class ModuleHandler extends Handler
 				}
 				
 				// check CSRF for POST actions
-				if(Context::getRequestMethod() === 'POST' && Context::isInstalled() && !checkCSRF())
+				if(Context::getRequestMethod() === 'POST' && Context::isInstalled())
 				{
-					if($xml_info->action->{$this->act} && $xml_info->action->{$this->act}->check_csrf !== 'false')
+					if($xml_info->action->{$this->act} && $xml_info->action->{$this->act}->check_csrf !== 'false' && !checkCSRF())
 					{
 						$this->_setInputErrorToContext();
 						$this->error = 'msg_invalid_request';

--- a/modules/file/conf/module.xml
+++ b/modules/file/conf/module.xml
@@ -8,7 +8,7 @@
         <action name="dispFileAdminList" type="view" admin_index="true" menu_name="file" menu_index="true" />
         <action name="dispFileAdminConfig" type="view" menu_name="fileUpload" menu_index="true" />
         <action name="getFileList" type="model" />
-        <action name="procFileUpload" type="controller" />
+        <action name="procFileUpload" type="controller" check_csrf="false" />
         <action name="procFileIframeUpload" type="controller" />
         <action name="procFileImageResize" type="controller" ruleset="imageResize" />
         <action name="procFileDelete" type="controller" />

--- a/modules/module/module.model.php
+++ b/modules/module/module.model.php
@@ -934,6 +934,7 @@ class moduleModel extends module
 					$standalone = $action->attrs->standalone=='false'?'false':'true';
 					$ruleset = $action->attrs->ruleset?$action->attrs->ruleset:'';
 					$method = $action->attrs->method?$action->attrs->method:'';
+					$check_csrf = $action->attrs->check_csrf=='false'?'false':'true';
 
 					$index = $action->attrs->index;
 					$admin_index = $action->attrs->admin_index;
@@ -947,6 +948,7 @@ class moduleModel extends module
 					$info->action->{$name}->standalone = $standalone;
 					$info->action->{$name}->ruleset = $ruleset;
 					$info->action->{$name}->method = $method;
+					$info->action->{$name}->check_csrf = $check_csrf;
 					if($action->attrs->menu_name)
 					{
 						if($menu_index == 'true')
@@ -970,6 +972,7 @@ class moduleModel extends module
 					$buff[] = sprintf('$info->action->%s->standalone=\'%s\';', $name, $standalone);
 					$buff[] = sprintf('$info->action->%s->ruleset=\'%s\';', $name, $ruleset);
 					$buff[] = sprintf('$info->action->%s->method=\'%s\';', $name, $method);
+					$buff[] = sprintf('$info->action->%s->check_csrf=\'%s\';', $name, $check_csrf);
 
 					if($index=='true')
 					{


### PR DESCRIPTION
현재 모든 POST 요청에 대해서 CSRF 체크(`checkCSRF()`) 하도록 되어있습니다.

하지만 기능 특성상 CSRF 체크를 원하지않는 act가 있을 수 있습니다. 예를 들어, 결제 기능은 PG사에서 특정 act를 POST로 호출하는 경우가 종종 발생합니다.

이와 같은 예외 상황을 대비하여 module.xml에 check_csrf 속성을 추가하였습니다.

사용방법은 아래와 같습니다. 

     <action name="procFileUpload" type="controller" check_csrf="false" />

CSRF 체크를 원하지않는 action에 `check_csrf="false"` 속성을 추가해주면 됩니다. 

참고로 `check_csrf` 속성은 기본값이 `true`입니다. 따라서 기본적으로 CSRF 체크를 하도록 되어있습니다.