### PR TITLE
설치 화면에서 GPL 라이선스를 표시

### DIFF
--- a/common/lang/lang.xml
+++ b/common/lang/lang.xml
@@ -3975,8 +3975,8 @@
 		<value xml:lang="en"><![CDATA[License Agreement]]></value>
 	</item>
 	<item name="license">
-		<value xml:lang="ko"><![CDATA[LGPL v2.1]]></value>
-		<value xml:lang="en"><![CDATA[LGPL v2.1]]></value>
+		<value xml:lang="ko"><![CDATA[GPL v2]]></value>
+		<value xml:lang="en"><![CDATA[GPL v2]]></value>
 	</item>
 	<item name="cmd_license_agree">
 		<value xml:lang="ko"><![CDATA[사용권에 대해 이해했으며, 이에 동의합니다.]]></value>

--- a/modules/install/tpl/license_text.en.html
+++ b/modules/install/tpl/license_text.en.html
@@ -1,41 +1,27 @@
-<p>Copyright &copy; RhymiX Developers and Contributors</p>
-<p>Copyright &copy; <a href="http://www.navercorp.com" target="_blank">NAVER</a></p>
+<p>
+	Copyright &copy; RhymiX Developers and Contributors<br />
+	Copyright &copy; <a href="http://www.navercorp.com" target="_blank">NAVER</a>
+</p>
 
 <p>
-	RhymiX is free software, developed as an open-source project.
-	For more information, please see the links below.
+	RhymiX is free software; you can redistribute it and/or modify it
+	under the terms of the GNU General Public License as published by the Free Software Foundation;
+	either version 2 of the License, or (at your option) any later version.
 </p>
 
 <ul>
-	<li>RhymiX website: <a href="https://www.rhymix.org" target="_blank">https://www.rhymix.org</a></li>
-	<li>RhymiX repository: <a href="https://github.com/rhymix/rhymix" target="_blank">https://github.com/rhymix/rhymix</a></li>
+	<li>Official website: <a href="https://www.rhymix.org" target="_blank">https://www.rhymix.org</a></li>
+	<li>Source code repository: <a href="https://github.com/rhymix/rhymix" target="_blank">https://github.com/rhymix/rhymix</a></li>
 </ul>
 
 <p>
-	RhymiX is a fork of the XpressEngine (XE) CMS
-	with additional patches by members of the XETOWN community.
-</p>
-
-<ul>
-	<li>XE website: <a href="https://www.xpressengine.com" target="_blank">https://www.xpressengine.com</a></li>
-	<li>XE repository: <a href="https://github.com/xpressengine/xe-core" target="_blank">https://github.com/xpressengine/xe-core</a></li>
-</ul>
-
-<p>
-	RhymiX and XE are free software; you can redistribute them and/or modify them
-	under the terms of the GNU Lesser General Public License as published by the Free Software Foundation;
-	either version 2.1 of the License, or (at your option) any later version.
-</p>
-
-<p>
-	This software is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+	This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
 	without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-	See the GNU Lesser General Public License for more details.
-	You should have received a copy of the GNU Lesser General Public License along with this library;
-	if not, write to the <a href="https://fsf.org/" target="_blank">Free Software Foundation, Inc.</a>,
-	51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+	See the GNU General Public License for more details.
+	You should have received a copy of the GNU General Public License along with this program;
+	if not, write to the <a href="https://fsf.org/" target="_blank">Free Software Foundation, Inc.</a>
 </p>
 
 <ul>
-	<li>License : <a href="http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html" target="_blank">GNU Lesser General Public License, version 2.1</a></li>
+	<li>License : <a href="https://www.gnu.org/licenses/old-licenses/gpl-2.0.html" target="_blank">GNU General Public License, version 2</a></li>
 </ul>

--- a/modules/install/tpl/license_text.ko.html
+++ b/modules/install/tpl/license_text.ko.html
@@ -1,41 +1,28 @@
-<p>Copyright &copy; RhymiX Developers and Contributors</p>
-<p>Copyright &copy; <a href="http://www.navercorp.com" target="_blank">NAVER</a></p>
+<p>
+	Copyright &copy; RhymiX Developers and Contributors<br />
+	Copyright &copy; <a href="http://www.navercorp.com" target="_blank">NAVER</a>
+</p>
 
 <p>
-	RhymiX는 자유 소프트웨어이며, 오픈소스 프로젝트로 개발되고 있습니다.
-	자세한 내용은 아래 링크를 참조하시기 바랍니다.
+	RhymiX는 자유 소프트웨어입니다.
+	소프트웨어의 피양도자는 자유 소프트웨어 재단이 공표한 GNU 일반 공중 사용 허가서 2판
+	또는 그 이후 판을 임의로 선택해서, 그 규정에 따라 프로그램을 개작하거나 재배포할 수 있습니다.
 </p>
 
 <ul>
-	<li>RhymiX 공식 사이트: <a href="https://www.rhymix.org" target="_blank">https://www.rhymix.org</a></li>
-	<li>RhymiX 공식 저장소: <a href="https://github.com/rhymix/rhymix" target="_blank">https://github.com/rhymix/rhymix</a></li>
+	<li>공식 사이트: <a href="https://www.rhymix.org" target="_blank">https://www.rhymix.org</a></li>
+	<li>소스 코드 저장소: <a href="https://github.com/rhymix/rhymix" target="_blank">https://github.com/rhymix/rhymix</a></li>
 </ul>
 
 <p>
-	RhymiX는 XpressEngine(XE)을 가지치기(fork)하여 XETOWN 커뮤니티 회원들이 개발한 다양한 기능을 추가한 것입니다.
-</p>
-
-<ul>
-	<li>XE 공식 사이트: <a href="https://www.xpressengine.com" target="_blank">https://www.xpressengine.com</a></li>
-	<li>XE 공식 저장소: <a href="https://github.com/xpressengine/xe-core" target="_blank">https://github.com/xpressengine/xe-core</a></li>
-</ul>
-
-<p>
-	RhymiX와 XE는 자유 소프트웨어입니다.
-	소프트웨어의 피양도자는 자유 소프트웨어 재단이 공표한 GNU 약소 일반 공중 사용 허가서 (LGPL) 2.1판
-	또는 그 이후 판을 임의로 선택해서, 그 규정에 따라 소프트웨어를 개작하거나 재배포할 수 있습니다.
-</p>
-
-<p>
-	이 소프트웨어는 유용하게 사용될 수 있으리라는 희망에서 배포되고 있지만,
-	특정한 목적에 맞는 적합성 여부나 판매용으로 사용할 수 있으리라는 묵시적인 보증을 포함한
-	어떠한 형태의 보증도 제공하지 않습니다.
-	보다 자세한 사항에 대해서는 GNU 약소 일반 공중 사용 허가서를 참고하시기 바랍니다.
-	GNU 약소 일반 공중 사용 허가서는 이 라이브러리와 함께 제공됩니다.
+	이 프로그램은 유용하게 사용될 수 있으리라는 희망에서 배포되고 있지만,
+	특정한 목적에 맞는 적합성 여부나 판매용으로 사용할 수 있으리라는 묵시적인 보증을 포함한 어떠한 형태의 보증도 제공하지 않습니다.
+	보다 자세한 사항에 대해서는 GNU 일반 공중 사용 허가서를 참고하시기 바랍니다.
+	GNU 일반 공중 사용 허가서는 이 프로그램과 함께 제공됩니다.
 	만약, 이 문서가 누락되어 있다면 <a href="https://fsf.org/" target="_blank">자유 소프트웨어 재단</a>으로 문의하시기 바랍니다.
 </p>
-	
+
 <ul>
-	<li>한글 (비공식 번역본) : <a href="http://korea.gnu.org/people/chsong/copyleft/lgpl.ko.html" target="_blank">GNU Lesser General Public License, version 2.1</a></li>
-	<li>영문 (공식 원본) : <a href="http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html" target="_blank">GNU Lesser General Public License, version 2.1</a></li>
+	<li>한글 (비공식 번역본) : <a href="http://korea.gnu.org/documents/copyleft/gpl.ko.html" target="_blank">GNU General Public License, version 2</a></li>
+	<li>영문 (공식 원본) : <a href="https://www.gnu.org/licenses/old-licenses/gpl-2.0.html" target="_blank">GNU General Public License, version 2</a></li>
 </ul>


### PR DESCRIPTION
설치 화면에 표시되는 사용권 동의 내용과 라이선스 원본 링크 등이 여전히 LGPL로 되어 있기에 고칩니다. XE 공식 사이트 및 저장소로 연결되는 링크도 삭제하여 화면을 단순화했습니다.