### PR TITLE
캐시폴더를 삭제하면 메뉴가 사라지는 버그 수정

### DIFF
--- a/classes/module/ModuleHandler.class.php
+++ b/classes/module/ModuleHandler.class.php
@@ -1006,6 +1006,12 @@ class ModuleHandler extends Handler
 							}
 
 							$php_file = FileHandler::exists($menu->php_file);
+							if(!$php_file)
+							{
+								$oMenuAdminController = $oMenuAdminController ?: getAdminController('menu');
+								$oMenuAdminController->makeXmlFile((isset($homeMenuSrl) && $homeMenuSrl) ? $homeMenuSrl : $menu->menu_srl);
+								$php_file = FileHandler::exists($menu->php_file);
+							}
 							if($php_file)
 							{
 								include($php_file);


### PR DESCRIPTION
가끔 뭔가가 꼬인 것을 해결하기 위해 `./files/cache` 폴더의 내용을 삭제해야 할 때가 있습니다. 원래 캐시라는 것은 삭제해도 자동으로 재생성되는 것이니까, 삭제해도 괜찮아야 하죠. 그런데 캐시폴더를 삭제하면 메뉴가 증발하는 문제가 있습니다. 시간이 지나면 다시 돌아온다고 해도, 상당히 귀찮은 일입니다.

그래서 메뉴 캐시파일이 존재하지 않는 경우 자동으로 재생성하도록 변경했습니다.