### PR TITLE
utf8mb4 문자셋 사용시 module_part_config 테이블에 복합 인덱스를 생성할 수 없는 문제 해결

### DIFF
--- a/classes/db/DBMysql.class.php
+++ b/classes/db/DBMysql.class.php
@@ -597,7 +597,7 @@ class DBMysql extends DB
 			
 			// MySQL only supports 767 bytes for indexed columns.
 			// This is 191 characters in utf8mb4 and 255 characters in utf8.
-			if($column->attrs->utf8mb4 === 'false')
+			if($column->attrs->utf8mb4 === 'false' && stripos($type, 'char') !== false)
 			{
 				$column_charset = 'CHARACTER SET utf8 COLLATE utf8_unicode_ci';
 			}

--- a/modules/module/schemas/module_part_config.xml
+++ b/modules/module/schemas/module_part_config.xml
@@ -1,5 +1,5 @@
 <table name="module_part_config">
-    <column name="module" type="varchar" size="250" notnull="notnull" />
+    <column name="module" type="varchar" size="180" notnull="notnull" utf8mb4="false" />
     <column name="module_srl" type="number" size="11" notnull="notnull" />
     <column name="config" type="text" />
     <column name="regdate" type="date" />


### PR DESCRIPTION
Fix #144