### PR TITLE
admin 폴더 방문시 admin 모듈로 전달되지 않는 문제 해결

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -31,6 +31,7 @@ RewriteRule ^([0-9]+)$ ./index.php?document_srl=$1 [L,QSA]
 
 # mid link
 RewriteCond %{SCRIPT_FILENAME} !-d
+RewriteRule ^admin/?$ ./index.php?module=admin [L,QSA]
 RewriteRule ^([a-zA-Z0-9_]+)/?$ ./index.php?mid=$1 [L,QSA]
 # mid + document link
 RewriteRule ^([a-zA-Z0-9_]+)/([0-9]+)$ ./index.php?mid=$1&document_srl=$2 [L,QSA]

--- a/classes/module/ModuleHandler.class.php
+++ b/classes/module/ModuleHandler.class.php
@@ -63,6 +63,11 @@ class ModuleHandler extends Handler
         {
             $this->entry = Context::convertEncodingStr($entry);
         }
+        if(!$this->module && $this->mid === 'admin')
+        {
+        	Context::set('module', $this->module = 'admin');
+        	Context::set('mid', $this->mid = null);
+        }
 
 		// Validate variables to prevent XSS
 		$isInvalid = NULL;


### PR DESCRIPTION
더이상 필요 없게 된 `admin` 폴더의 존재 여부와 무관하게, `사이트주소/admin` 주소 방문시 admin 모듈로 전달되도록 합니다. #145