### PR TITLE
XML 제거: 폼 제출시 불필요하게 XML을 사용하지 않도록 변경

### DIFF
--- a/classes/context/Context.class.php
+++ b/classes/context/Context.class.php
@@ -214,8 +214,8 @@ class Context
 		{
 			$GLOBALS['HTTP_RAW_POST_DATA'] = file_get_contents("php://input");
 			
-			// If content is not XML JSON, unset
-			if(!preg_match('/^[\<\{\[]/', $GLOBALS['HTTP_RAW_POST_DATA']) && strpos($_SERVER['CONTENT_TYPE'], 'json') === FALSE && strpos($_SERVER['HTTP_CONTENT_TYPE'], 'json') === FALSE)
+			// If content is not XML or JSON, unset
+			if(!preg_match('/^[\<\{\[]/', $GLOBALS['HTTP_RAW_POST_DATA']))
 			{
 				unset($GLOBALS['HTTP_RAW_POST_DATA']);
 			}
@@ -232,7 +232,6 @@ class Context
 		$this->setRequestMethod('');
 
 		$this->_setXmlRpcArgument();
-		$this->_setJSONRequestArgument();
 		$this->_setRequestArgument();
 		$this->_setUploadedArgument();
 
@@ -1276,7 +1275,7 @@ class Context
 		{
 			self::$_instance->request_method = $type;
 		}
-		elseif (strpos($_SERVER['CONTENT_TYPE'], 'json') !== false || strpos($_SERVER['HTTP_CONTENT_TYPE'], 'json') !== false)
+		elseif (strpos($_SERVER['HTTP_ACCEPT'], 'json') !== false || strpos($_SERVER['CONTENT_TYPE'], 'json') !== false || strpos($_SERVER['HTTP_CONTENT_TYPE'], 'json') !== false)
 		{
 			self::$_instance->request_method = 'JSON';
 		}
@@ -1336,7 +1335,7 @@ class Context
 			{
 				$set_to_vars = TRUE;
 			}
-			elseif($requestMethod == 'POST' && isset($_POST[$key]))
+			elseif(($requestMethod == 'POST' || $requestMethod == 'JSON') && isset($_POST[$key]))
 			{
 				$set_to_vars = TRUE;
 			}
@@ -1387,18 +1386,7 @@ class Context
 	 */
 	private function _setJSONRequestArgument()
 	{
-		if(self::getRequestMethod() != 'JSON')
-		{
-			return;
-		}
-
-		$params = array();
-		parse_str($GLOBALS['HTTP_RAW_POST_DATA'], $params);
-
-		foreach($params as $key => $val)
-		{
-			self::set($key, $this->_filterRequestVar($key, $val, 1), TRUE);
-		}
+		
 	}
 
 	/**

--- a/classes/context/Context.class.php
+++ b/classes/context/Context.class.php
@@ -232,6 +232,7 @@ class Context
 		$this->setRequestMethod('');
 
 		$this->_setXmlRpcArgument();
+		$this->_setJSONRequestArgument();
 		$this->_setRequestArgument();
 		$this->_setUploadedArgument();
 
@@ -1386,7 +1387,16 @@ class Context
 	 */
 	private function _setJSONRequestArgument()
 	{
-		
+		if(count($_POST) || self::getRequestMethod() != 'JSON')
+		{
+			return;
+		}
+		$params = array();
+		parse_str($GLOBALS['HTTP_RAW_POST_DATA'], $params);
+		foreach($params as $key => $val)
+		{
+			self::set($key, $this->_filterRequestVar($key, $val, 1), TRUE);
+		}
 	}
 
 	/**

--- a/classes/display/DisplayHandler.class.php
+++ b/classes/display/DisplayHandler.class.php
@@ -91,7 +91,10 @@ class DisplayHandler extends Handler
 		{
 			if(Context::getResponseMethod() == 'JSON' || Context::getResponseMethod() == 'JS_CALLBACK')
 			{
-				self::_printJSONHeader();
+				if(strpos($_SERVER['HTTP_ACCEPT'], 'json') !== false)
+				{
+					self::_printJSONHeader();
+				}
 			}
 			else if(Context::getResponseMethod() != 'HTML')
 			{

--- a/common/js/plugins/jquery.fileupload/js/main.js
+++ b/common/js/plugins/jquery.fileupload/js/main.js
@@ -299,7 +299,9 @@
 
 			$.exec_json('file.getFileList', obj, function(res){
 				data.uploadTargetSrl = res.upload_target_srl;
-				editorRelKeys[data.editorSequence].primary.value = res.upload_target_srl;
+				if(editorRelKeys[data.editorSequence]) {
+					editorRelKeys[data.editorSequence].primary.value = res.upload_target_srl;
+				}
 				data.uploadTargetSrl = res.uploadTargetSrl;
 
 				// @TODO 정리

--- a/common/js/x.js
+++ b/common/js/x.js
@@ -4,7 +4,7 @@
  * Copyright 2001-2005 Michael Foster (Cross-Browser.com)
  **/
 function xDeprecate(funcName) {
-	var msg = 'DEPRECATED : '+funcName+'() is deprecated function.';
+	var msg = 'DEPRECATED : '+funcName+'() is deprecated in Rhymix.';
 	if (typeof console == 'object' && typeof console.log == 'function') {
 		console.log(msg);
 	}

--- a/common/js/xml_handler.js
+++ b/common/js/xml_handler.js
@@ -255,7 +255,11 @@ function xml2json(xml, tab, ignoreAttrib) {
 				if ($.isFunction($.exec_xml.onerror)) {
 					return $.exec_xml.onerror(module, act, data, callback_func, response_tags, callback_func_arg, fo_obj);
 				}
-				alert( (data.message || 'An unknown error occured while loading ['+module+'.'+act+']').replace(/\\n/g, '\n') );
+				if (data.message) {
+					alert(data.message.replace(/\\n/g, "\n"));
+				} else {
+					alert("AJAX communication error while requesting " + params.module + "." + params.act);
+				}
 				return null;
 			}
 
@@ -278,7 +282,7 @@ function xml2json(xml, tab, ignoreAttrib) {
 				success     : onsuccess,
 				error       : function(xhr, textStatus) {
 					waiting_obj.css('display', 'none');
-					alert("AJAX communication error while requesting " + params.module + "." + params.act);
+					alert("AJAX communication error while requesting " + params.module + "." + params.act + "\n\n" + xhr.status + " " + xhr.statusText);
 				}
 			});
 		} catch(e) {
@@ -371,14 +375,18 @@ function xml2json(xml, tab, ignoreAttrib) {
 					data: data,
 					success: function(data) {
 						$(".wfsr").hide().trigger('cancel_confirm');
-						if(data.error != '0' && data.error > -1000) {
+						if(data.error != 0 && data.error > -1000) {
 							if(data.error == -1 && data.message == 'msg_is_not_administrator') {
 								alert('You are not logged in as an administrator');
 								if($.isFunction(callback_error)) callback_error(data);
 
 								return;
 							} else {
-								alert(data.message);
+								if (data.message) {
+									alert(data.message.replace(/\\n/g, "\n"));
+								} else {
+									alert("AJAX communication error while requesting " + data.module + "." + data.act);
+								}
 								if($.isFunction(callback_error)) callback_error(data);
 
 								return;
@@ -389,7 +397,7 @@ function xml2json(xml, tab, ignoreAttrib) {
 					},
 					error: function(xhr, textStatus) {
 						$(".wfsr").hide();
-						alert("AJAX communication error while requesting " + data.module + "." + data.act);
+						alert("AJAX communication error while requesting " + data.module + "." + data.act + "\n\n" + xhr.status + " " + xhr.statusText);
 					}
 				});
 			} catch(e) {
@@ -430,7 +438,7 @@ function xml2json(xml, tab, ignoreAttrib) {
 					},
 					error: function(xhr, textStatus) {
 						$(".wfsr").hide();
-						alert("AJAX communication error while requesting " + data.module + "." + data.act);
+						alert("AJAX communication error while requesting " + data.module + "." + data.act + "\n\n" + xhr.status + " " + xhr.statusText);
 					}
 				});
 			} catch(e) {

--- a/common/js/xml_handler.js
+++ b/common/js/xml_handler.js
@@ -239,21 +239,23 @@ function xml2json(xml, tab, ignoreAttrib) {
 		// 전송 성공시
 		function onsuccess(data, textStatus, xhr) {
 			waiting_obj.css('display', 'none').trigger('cancel_confirm');
-			var ret = [];
-			var tags = {};
+			var ret = {};
 			
-			$.each(response_tags, function(key, val){ tags[val] = true; });
-			tags.redirect_url = true;
-			tags.act = true;
-			$.each(data, function(key, val){ if(tags[key]) ret[key] = val; });
-
-			if(ret.error != '0') {
-				if ($.isFunction($.exec_xml.onerror)) {
-					return $.exec_xml.onerror(module, act, ret, callback_func, response_tags, callback_func_arg, fo_obj);
+			$.each(data, function(key, val) {
+				if(key == "act" || key == "redirect_url" || $.inArray(key, response_tags)) {
+					if($.isArray(val)) {
+						ret[key] = { item: val };
+					} else {
+						ret[key] = val;
+					}
 				}
+			});
 
-				alert( (ret.message || 'An unknown error occured while loading ['+module+'.'+act+']').replace(/\\n/g, '\n') );
-
+			if(data.error != 0) {
+				if ($.isFunction($.exec_xml.onerror)) {
+					return $.exec_xml.onerror(module, act, data, callback_func, response_tags, callback_func_arg, fo_obj);
+				}
+				alert( (data.message || 'An unknown error occured while loading ['+module+'.'+act+']').replace(/\\n/g, '\n') );
 				return null;
 			}
 

--- a/common/js/xml_handler.js
+++ b/common/js/xml_handler.js
@@ -1,10 +1,351 @@
 /**
- * @file   common/js/xml_handler.js
- * @brief  XE에서 ajax기능을 이용함에 있어 module, act를 잘 사용하기 위한 자바스크립트
- **/
+ * Functions for sending AJAX requests to the server.
+ */
+(function($){
 
-// xml handler을 이용하는 user function
-var show_waiting_message = true;
+	/**
+	 * Set this variable to false to hide the "waiting for server response" layer.
+	 */
+	window.show_waiting_message = true;
+	var waiting_obj;
+	
+	/**
+	 * Function for compatibility with XE's exec_xml()
+	 */
+	window.exec_xml = $.exec_xml = function(module, act, params, callback_success, return_fields, callback_success_arg, fo_obj) {
+		
+		// Convert params to object and fill in the module and act.
+		params = params ? ($.isArray(params) ? arr2obj(params) : params) : {};
+		params.module = module;
+		params.act = act;
+		
+		// Fill in the XE vid.
+		if (typeof(xeVid) != "undefined") params.vid = xeVid;
+		
+		// Add 'error' and 'message' to response tags.
+		if (typeof(return_fields) == "undefined" || return_fields.length < 1) {
+			return_fields = ["error", "message"];
+		} else {
+			return_fields.push("error", "message");
+		}
+		
+		// Decide whether or not to use SSL.
+		var url = request_uri;
+		if ($.isArray(ssl_actions) && params.act && $.inArray(params.act, ssl_actions) >= 0) {
+			url = default_url || request_uri;
+			var port = window.https_port || 443;
+			var _ul = $("<a>").attr("href", url)[0];
+			var target = "https://" + _ul.hostname.replace(/:\d+$/, "");
+			if (port != 443) target += ":" + port;
+			if (_ul.pathname[0] != "/") target += "/";
+			target += _ul.pathname;
+			url = target.replace(/\/$/, "") + "/";
+		}
+		
+		// Check whether this is a cross-domain request. If so, use an alternative method.
+		var _u1 = $("<a>").attr("href", location.href)[0];
+		var _u2 = $("<a>").attr("href", url)[0];
+		if (_u1.protocol != _u2.protocol || _u1.port != _u2.port) return send_by_form(url, params);
+		
+		// Do not send AJAX request if another request is in progress.
+		var _xhr = null;
+		if (_xhr && _xhr.readyState !== 0) _xhr.abort();
+
+		// Define the success handler.
+		var successHandler = function(data, textStatus, xhr) {
+			
+			// Copy data to the result object.
+			var result = {};
+			$.each(data, function(key, val) {
+				if (key == "act" || key == "redirect_url" || $.inArray(key, return_fields)) {
+					if ($.isArray(val)) {
+						result[key] = { item: val };
+					} else {
+						result[key] = val;
+					}
+				}
+			});
+			
+			// If the response contains an error, display the error message.
+			if (data.error != "0") {
+				// This way of calling an error handler is deprecated. Do not use it.
+				if ($.isFunction($.exec_xml.onerror)) {
+					if (typeof console == "object" && typeof console.log == "function") {
+						console.log("DEPRECATED : $.exec_xml.onerror() is deprecated in Rhymix.");
+					}
+					return $.exec_xml.onerror(module, act, data, callback_success, return_fields, callback_success_arg, fo_obj);
+				}
+				// Display the error message, or a generic stub if there is no error message.
+				if (data.message) {
+					alert(data.message.replace(/\\n/g, "\n"));
+				} else {
+					alert("AJAX communication error while requesting " + params.module + "." + params.act);
+				}
+				return null;
+			}
+			
+			// If the response contains a redirect URL, redirect immediately.
+			if (result.redirect_url) {
+				window.location = result.redirect_url.replace(/&amp;/g, "&");
+				return null;
+			}
+			
+			// If there was a success callback, call it.
+			if ($.isFunction(callback_success)) {
+				callback_success(result, return_fields, callback_success_arg, fo_obj);
+			}
+		};
+		
+		// Define the error handler.
+		var errorHandler = function(xhr, textStatus) {
+			alert("AJAX communication error while requesting " + params.module + "." + params.act + "\n\n" + xhr.status + " " + xhr.statusText);
+		};
+		
+		// Send the AJAX request.
+		try {
+			$.ajax({
+				url : url,
+				type : "POST",
+				dataType : "json",
+				data : params,
+				beforeSend : function(xhr) { _xhr = xhr; },
+				success : successHandler,
+				error : errorHandler,
+				complete : function(xhr, textStatus) {
+					waiting_obj.hide().trigger("cancel_confirm");
+				}
+			});
+		} catch(e) {
+			alert(e);
+			return;
+		}
+
+		// Display the waiting message.
+		if (show_waiting_message && waiting_obj.length) {
+			var timeoutId = waiting_obj.data("timeout_id");
+			if (timeoutId) clearTimeout(timeoutId);
+			waiting_obj.css("opacity", 0.0).data("timeout_id", setTimeout(function() {
+				waiting_obj.css("opacity", "");
+			}, 1000));
+			waiting_obj.html(waiting_message).show();
+		}
+	};
+
+
+	/**
+	 * Function for compatibility with XE's exec_json()
+	 */
+	window.exec_json = $.exec_json = function(action, params, callback_success, callback_error) {
+		
+		// Convert params to object and fill in the module and act.
+		params = params ? ($.isArray(params) ? arr2obj(params) : params) : {};
+		action = action.split(".");
+		if (action.length != 2) return;
+		params.module = action[0];
+		params.act = action[1];
+		
+		// Fill in the XE vid.
+		if (typeof(xeVid) != "undefined") params.vid = xeVid;
+		
+		// Delay the waiting message for 1 second to prevent rapid blinking.
+		waiting_obj.css("opacity", 0.0);
+		var wfsr_timeout = setTimeout(function() {
+			if (show_waiting_message) {
+				waiting_obj.css("opacity", "").html(waiting_message).show();
+			}
+		}, 1000);
+		
+		// Define the success handler.
+		var successHandler = function(data, textStatus, xhr) {
+			
+			// If the response contains an error, display the error message.
+			if(data.error != "0" && data.error > -1000) {
+				if(data.error == -1 && data.message == "msg_is_not_administrator") {
+					alert("You are not logged in as an administrator.");
+					if ($.isFunction(callback_error)) {
+						callback_error(data);
+					}
+					return;
+				} else {
+					if (data.message) {
+						alert(data.message.replace(/\\n/g, "\n"));
+					} else {
+						alert("AJAX communication error while requesting " + data.module + "." + data.act);
+					}
+					if ($.isFunction(callback_error)) {
+						callback_error(data);
+					}
+					return;
+				}
+			}
+			
+			// If there was a success callback, call it.
+			if($.isFunction(callback_success)) {
+				callback_success(data);
+			}
+		};
+		
+		// Define the error handler.
+		var errorHandler = function(xhr, textStatus) {
+			alert("AJAX communication error while requesting " + params.module + "." + params.act + "\n\n" + xhr.status + " " + xhr.statusText);
+		};
+		
+		// Send the AJAX request.
+		try {
+			$.ajax({
+				type: "POST",
+				dataType: "json",
+				url: request_uri,
+				data: params,
+				success : successHandler,
+				error : errorHandler,
+				complete : function(xhr, textStatus) {
+					clearTimeout(wfsr_timeout);
+					waiting_obj.hide().trigger("cancel_confirm");
+				}
+			});
+		} catch(e) {
+			alert(e);
+			return;
+		}
+	};
+
+	/**
+	 * Function for compatibility with XE's exec_html()
+	 */
+	window.exec_html = $.fn.exec_html = function(action, params, type, callback_func, callback_args) {
+		
+		// Convert params to object and fill in the module and act.
+		params = params ? ($.isArray(params) ? arr2obj(params) : params) : {};
+		action = action.split(".");
+		if (action.length != 2) return;
+		params.module = action[0];
+		params.act = action[1];
+		
+		// Fill in the XE vid.
+		if (typeof(xeVid) != "undefined") params.vid = xeVid;
+		
+		// Determine the request type.
+		if(!$.inArray(type, ["html", "append", "prepend"])) type = "html";
+		var self = $(this);
+		
+		// Delay the waiting message for 1 second to prevent rapid blinking.
+		waiting_obj.css("opacity", 0.0);
+		var wfsr_timeout = setTimeout(function() {
+			if (show_waiting_message) {
+				waiting_obj.css("opacity", "").html(waiting_message).show();
+			}
+		}, 1000);
+		
+		// Define the success handler.
+		var successHandler = function(data, textStatus, xhr) {
+			if (self && self[type]) {
+				self[type](html);
+			}
+			if ($.isFunction(callback_func)) {
+				callback_func(callback_args);
+			}
+		};
+		
+		// Define the error handler.
+		var errorHandler = function(xhr, textStatus) {
+			alert("AJAX communication error while requesting " + params.module + "." + params.act + "\n\n" + xhr.status + " " + xhr.statusText);
+		};
+		
+		// Send the AJAX request.
+		try {
+			$.ajax({
+				type: "POST",
+				dataType: "html",
+				url: request_uri,
+				data: params,
+				success: successHandler,
+				error: errorHandler,
+				complete : function(xhr, textStatus) {
+					clearTimeout(wfsr_timeout);
+					waiting_obj.hide().trigger("cancel_confirm");
+				}
+			});
+		} catch(e) {
+			alert(e);
+			return;
+		}
+	};
+
+	/**
+	 * Empty placeholder for beforeUnload handler.
+	 */
+	var beforeUnloadHandler = function() {
+		return "";
+	};
+	
+	/**
+	 * Register the beforeUnload handler.
+	 */
+	$(function() {
+		waiting_obj = $(".wfsr");
+		$(document).ajaxStart(function() {
+			$(window).bind("beforeunload", beforeUnloadHandler);
+		}).bind("ajaxStop cancel_confirm", function() {
+			$(window).unbind("beforeunload", beforeUnloadHandler);
+		});
+	});
+
+})(jQuery);
+
+/**
+ * This function simulates AJAX requests with HTML forms.
+ * It was meant for cross-domain requests, but should be replaced with JSONP.
+ */
+function send_by_form(url, params) {
+	
+	// This function is deprecated!
+	if (typeof console == "object" && typeof console.log == "function") {
+		console.log("DEPRECATED : send_by_form() is deprecated in Rhymix.");
+	}
+	
+	// Create the hidden iframe.
+	var frame_id = "xeTmpIframe";
+	if (!$("#" + frame_id).length) {
+		$('<iframe name="%id%" id="%id%" style="position:absolute;left:-1px;top:1px;width:1px;height:1px"></iframe>'.replace(/%id%/g, frame_id)).appendTo(document.body);
+	}
+	
+	// Create the hidden form.
+	var form_id  = "xeVirtualForm";
+	$("#" + form_id).remove();
+	var form = $('<form id="%id%"></form>'.replace(/%id%/g, form_id)).attr({
+		"id"     : form_id,
+		"method" : "post",
+		"action" : url,
+		"target" : frame_id
+	});
+	
+	// Add virtual XML parameters.
+	params.xeVirtualRequestMethod = "xml";
+	params.xeRequestURI           = location.href.replace(/#(.*)$/i, "");
+	params.xeVirtualRequestUrl    = request_uri;
+	
+	// Add inputs to the form.
+	$.each(params, function(key, value){
+		$('<input type="hidden">').attr("name", key).attr("value", value).appendTo(form);
+	});
+	
+	// Submit the hidden form.
+	form.appendTo(document.body).submit();
+}
+
+/**
+ * This function converts arrays into objects.
+ */
+function arr2obj(arr) {
+	var ret = {};
+	for (var key in arr) {
+		if (arr.hasOwnProperty(key)) {
+			ret[key] = arr[key];
+		}
+	}
+	return ret;
+}
 
 /**
  * This work is licensed under Creative Commons GNU LGPL License.
@@ -194,272 +535,3 @@ function xml2json(xml, tab, ignoreAttrib) {
 		return "{" + (tab ? json_str.replace(/\t/g, tab) : json_str.replace(/\t|\n/g, "")) + "}";
 	}
 }
-
-(function($){
-	/**
-	* @brief exec_xml
-	* @author NAVER (developers@xpressengine.com)
-	**/
-	$.exec_xml = window.exec_xml = function(module, act, params, callback_func, response_tags, callback_func_arg, fo_obj) {
-		params = params ? ($.isArray(params) ? arr2obj(params) : params) : {};
-		params.module = module;
-		params.act = act;
-
-		if(typeof(xeVid) != "undefined") params.vid = xeVid;
-		if(typeof(response_tags) == "undefined" || response_tags.length < 1) {
-			response_tags = ['error','message'];
-		} else {
-			response_tags.push('error', 'message');
-		}
-
-		// use ssl?
-		var url = request_uri;
-		if ($.isArray(ssl_actions) && params.act && $.inArray(params.act, ssl_actions) >= 0) {
-			url = default_url || request_uri;
-			var port   = window.https_port || 443;
-			var _ul    = $('<a>').attr('href', url)[0];
-			var target = 'https://' + _ul.hostname.replace(/:\d+$/, '');
-
-			if(port != 443) target += ':'+port;
-			if(_ul.pathname[0] != '/') target += '/';
-
-			target += _ul.pathname;
-			url = target.replace(/\/$/, '')+'/';
-		}
-
-		var _u1 = $('<a>').attr('href', location.href)[0];
-		var _u2 = $('<a>').attr('href', url)[0];
-
-		// 현 url과 ajax call 대상 url의 schema 또는 port가 다르면 직접 form 전송
-		if(_u1.protocol != _u2.protocol || _u1.port != _u2.port) return send_by_form(url, params);
-		
-		var _xhr = null;
-		if (_xhr && _xhr.readyState !== 0) _xhr.abort();
-
-		// 전송 성공시
-		function onsuccess(data, textStatus, xhr) {
-			waiting_obj.css('display', 'none').trigger('cancel_confirm');
-			var ret = {};
-			
-			$.each(data, function(key, val) {
-				if(key == "act" || key == "redirect_url" || $.inArray(key, response_tags)) {
-					if($.isArray(val)) {
-						ret[key] = { item: val };
-					} else {
-						ret[key] = val;
-					}
-				}
-			});
-
-			if(data.error != '0') {
-				if ($.isFunction($.exec_xml.onerror)) {
-					return $.exec_xml.onerror(module, act, data, callback_func, response_tags, callback_func_arg, fo_obj);
-				}
-				if (data.message) {
-					alert(data.message.replace(/\\n/g, "\n"));
-				} else {
-					alert("AJAX communication error while requesting " + params.module + "." + params.act);
-				}
-				return null;
-			}
-
-			if(ret.redirect_url) {
-				location.href = ret.redirect_url.replace(/&amp;/g, '&');
-				return null;
-			}
-
-			if($.isFunction(callback_func)) callback_func(ret, response_tags, callback_func_arg, fo_obj);
-		}
-
-		// 모든 데이터는 POST방식으로 전송. try-catch문으로 오류 발생시 대처
-		try {
-			$.ajax({
-				url         : url,
-				type        : "POST",
-				dataType    : "json",
-				data        : params,
-				beforeSend  : function(xhr){ _xhr = xhr; },
-				success     : onsuccess,
-				error       : function(xhr, textStatus) {
-					waiting_obj.css('display', 'none');
-					alert("AJAX communication error while requesting " + params.module + "." + params.act + "\n\n" + xhr.status + " " + xhr.statusText);
-				}
-			});
-		} catch(e) {
-			alert(e);
-			return;
-		}
-
-		// ajax 통신중 대기 메세지 출력 (show_waiting_message값을 false로 세팅시 보이지 않음)
-		var waiting_obj = $('.wfsr');
-		if(show_waiting_message && waiting_obj.length) {
-
-			var timeoutId = $(".wfsr").data('timeout_id');
-			if(timeoutId) clearTimeout(timeoutId);
-			$(".wfsr").css('opacity', 0.0);
-			$(".wfsr").data('timeout_id', setTimeout(function(){
-				$(".wfsr").css('opacity', '');
-			}, 1000));
-
-			waiting_obj.html(waiting_message).show();
-		}
-	};
-
-	function send_by_form(url, params) {
-		var frame_id = 'xeTmpIframe';
-		var form_id  = 'xeVirtualForm';
-
-		if (!$('#'+frame_id).length) {
-			$('<iframe name="%id%" id="%id%" style="position:absolute;left:-1px;top:1px;width:1px;height:1px"></iframe>'.replace(/%id%/g, frame_id)).appendTo(document.body);
-		}
-
-		$('#'+form_id).remove();
-		var form = $('<form id="%id%"></form>'.replace(/%id%/g, form_id)).attr({
-			'id'     : form_id,
-			'method' : 'post',
-			'action' : url,
-			'target' : frame_id
-		});
-
-		params.xeVirtualRequestMethod = 'xml';
-		params.xeRequestURI           = location.href.replace(/#(.*)$/i,'');
-		params.xeVirtualRequestUrl    = request_uri;
-
-		$.each(params, function(key, value){
-			$('<input type="hidden">').attr('name', key).attr('value', value).appendTo(form);
-		});
-
-		form.appendTo(document.body).submit();
-	}
-
-	function arr2obj(arr) {
-		var ret = {};
-		for(var key in arr) {
-			if(arr.hasOwnProperty(key)) ret[key] = arr[key];
-		}
-
-		return ret;
-	}
-
-
-	/**
-	* @brief exec_json (exec_xml와 같은 용도)
-	**/
-	$.exec_json = window.exec_json = function(action, data, callback_sucess, callback_error){
-		data = data ? ($.isArray(data) ? arr2obj(data) : data) : {};
-		action = action.split('.');
-
-		if(action.length == 2) {
-			// The cover can be disturbing if it consistently blinks (because ajax call usually takes very short time). So make it invisible for the 1st 0.5 sec and then make it visible.
-			var timeoutId = $(".wfsr").data('timeout_id');
-
-			if(timeoutId) clearTimeout(timeoutId);
-
-			$(".wfsr").css('opacity', 0.0);
-			$(".wfsr").data('timeout_id', setTimeout(function(){
-				$(".wfsr").css('opacity', '');
-			}, 1000));
-
-			if(show_waiting_message) $(".wfsr").html(waiting_message).show();
-
-			data.module = action[0];
-			data.act = action[1];
-
-			if(typeof(xeVid)!='undefined') $.extend(data,{vid:xeVid});
-
-			try {
-				$.ajax({
-					type: "POST",
-					dataType: "json",
-					url: request_uri,
-					data: data,
-					success: function(data) {
-						$(".wfsr").hide().trigger('cancel_confirm');
-						if(data.error != '0' && data.error > -1000) {
-							if(data.error == -1 && data.message == 'msg_is_not_administrator') {
-								alert('You are not logged in as an administrator');
-								if($.isFunction(callback_error)) callback_error(data);
-
-								return;
-							} else {
-								if (data.message) {
-									alert(data.message.replace(/\\n/g, "\n"));
-								} else {
-									alert("AJAX communication error while requesting " + data.module + "." + data.act);
-								}
-								if($.isFunction(callback_error)) callback_error(data);
-
-								return;
-							}
-						}
-
-						if($.isFunction(callback_sucess)) callback_sucess(data);
-					},
-					error: function(xhr, textStatus) {
-						$(".wfsr").hide();
-						alert("AJAX communication error while requesting " + data.module + "." + data.act + "\n\n" + xhr.status + " " + xhr.statusText);
-					}
-				});
-			} catch(e) {
-				alert(e);
-				return;
-			}
-		}
-	};
-
-	$.fn.exec_html = function(action, data, type, func, args){
-		if(typeof(data) == 'undefined') data = {};
-		if(!$.inArray(type, ['html','append','prepend'])) type = 'html';
-
-		var self = $(this);
-		action = action.split(".");
-		if(action.length == 2){
-			var timeoutId = $(".wfsr").data('timeout_id');
-			if(timeoutId) clearTimeout(timeoutId);
-			$(".wfsr").css('opacity', 0.0);
-			$(".wfsr").data('timeout_id', setTimeout(function(){
-				$(".wfsr").css('opacity', '');
-			}, 1000));
-			if(show_waiting_message) $(".wfsr").html(waiting_message).show();
-
-			data.module = action[0];
-			data.act = action[1];
-
-			try {
-				$.ajax({
-					type: "POST",
-					dataType: "html",
-					url: request_uri,
-					data: data,
-					success: function(html) {
-						$(".wfsr").hide().trigger('cancel_confirm');
-						self[type](html);
-						if($.isFunction(func)) func(args);
-					},
-					error: function(xhr, textStatus) {
-						$(".wfsr").hide();
-						alert("AJAX communication error while requesting " + data.module + "." + data.act + "\n\n" + xhr.status + " " + xhr.statusText);
-					}
-				});
-			} catch(e) {
-				alert(e);
-				return;
-			}
-		}
-	};
-
-	function beforeUnloadHandler(){
-		return '';
-	}
-
-	$(function($){
-		$(document)
-			.ajaxStart(function(){
-				$(window).bind('beforeunload', beforeUnloadHandler);
-			})
-			.bind('ajaxStop cancel_confirm', function(){
-				$(window).unbind('beforeunload', beforeUnloadHandler);
-			});
-	});
-
-})(jQuery);

--- a/common/js/xml_handler.js
+++ b/common/js/xml_handler.js
@@ -251,7 +251,7 @@ function xml2json(xml, tab, ignoreAttrib) {
 				}
 			});
 
-			if(data.error != 0) {
+			if(data.error != '0') {
 				if ($.isFunction($.exec_xml.onerror)) {
 					return $.exec_xml.onerror(module, act, data, callback_func, response_tags, callback_func_arg, fo_obj);
 				}
@@ -375,7 +375,7 @@ function xml2json(xml, tab, ignoreAttrib) {
 					data: data,
 					success: function(data) {
 						$(".wfsr").hide().trigger('cancel_confirm');
-						if(data.error != 0 && data.error > -1000) {
+						if(data.error != '0' && data.error > -1000) {
 							if(data.error == -1 && data.message == 'msg_is_not_administrator') {
 								alert('You are not logged in as an administrator');
 								if($.isFunction(callback_error)) callback_error(data);

--- a/modules/file/file.model.php
+++ b/modules/file/file.model.php
@@ -35,6 +35,7 @@ class fileModel extends file
 		{
 			$tmp_files = $this->getFiles($upload_target_srl);
 			$file_count = count($tmp_files);
+			$files = array();
 
 			for($i=0;$i<$file_count;$i++)
 			{


### PR DESCRIPTION
게시판 글쓰기, 댓글쓰기 등 상당수의 폼 제출 액션이 XML로 실행되고 있습니다. 제출도 XML 포맷으로 하고, 결과도 XML 포맷으로 돌려받죠. 이것 때문에 서버와 클라이언트 양쪽 모두 상당한 자원을 소모하는 것은 물론, 실제로 뚜껑을 들쳐보면 아주 황당한 일이 벌어지고 있습니다.

- `exec_xml()` 함수를 실행하면 폼 내용을 XML로 변환합니다.
- 그리고는 `Content-Type: text/plain` 헤더와 함께 서버로 전송합니다 (뭥미? XML이라며?)
- 서버에서는 처리 결과를 친절하게 XML로 변환하여 돌려줍니다.
- 그러면 클라이언트에서 이것을 JSON으로 변환합니다 (뭥미? XML 안 써?)

열심히 XML로 변환해서 전송했더니 XML은 무시하고 JSON으로 변환이나 하고 앉아 있어요. 이럴 거면 차라리 처음부터 JSON을 쓰지? ㅡ.ㅡ;;

한편, JSON을 요청하는 `exec_json()` 함수도 사정이 크게 낫지 않습니다.

- `Content-Type: application/json` 헤더를 사용합니다.
- 그러나 실제로 전송하는 데이터는 `foo=bar&xe=babo&rhymix=future` 이런 일반적인 폼 형식입니다. 위와 마찬가지로 헤더와 내용이 다른 거죠.
- 서버단의 `Context::_setJSONRequestArgument()` 메소드도 JSON이 아닌 폼 형식의 데이터가 들어온다고 가정하고 데이터를 파싱합니다. 실제로 JSON을 던져주었다가는 큰일나요.

이럴 거면 차라리 그냥 `$_POST`로 받지? ㅡ.ㅡ;;

### 이 PR에서는 아래와 같이 바꾸었습니다.

- `exec_xml()`, `exec_json()`, `exec_html()` 등 XE에서 사용하던 AJAX 관련 함수들은 모두 일반적인 폼 형식으로 데이터를 제출하도록 변경했습니다. 브라우저 개발자도구에서 보기도 편해요.
- jQuery에서 `dataType: "json"`이라고 지정하면 자동으로 `Accept` 헤더에 `json`이라는 문자열이 들어간다는 점을 이용하여, 서버단에서 이것을 감지하여 XML이 아닌 JSON으로 처리 결과를 돌려주도록 변경했습니다. 그러면 이걸 다시 변환한다고 삽질할 필요가 없겠죠?
- 장기적으로 `exec_xml()` 함수는 기존 자료와의 호환성을 위해 파라미터 순서만 그대로 유지하고, 실제로는 `exec_json()` 함수와 똑같은 기능을 하도록 변경하겠습니다.
- 위의 함수들을 사용하지 않고 BlogAPI 등에서 XML을 전송할 경우에는 기존과 같은 방식으로 처리해 줍니다. 따라서 라이믹스를 API로 사용하는 서드파티 자료들과의 호환성에는 차이가 없습니다.

기본적인 게시판 글쓰기/댓글쓰기와 관리모듈 작업까지는 테스트해 보았으나, 다른 모듈에서도 100% 호환되는지 좀더 테스트가 필요합니다.
