### PR TITLE
Travis (Codeception) 테스트 도중 쉬운설치 업데이트 체크 방지

### DIFF
--- a/tests/Install/AutoinstallCept.php
+++ b/tests/Install/AutoinstallCept.php
@@ -42,6 +42,9 @@ $install_config = array(
 
 $install_config = '<' . '?php $install_config = ' . var_export($install_config, true) . ';';
 
+mkdir(_XE_PATH_ . 'files/env', 0755, true);
+file_put_contents(_XE_PATH_ . 'files/env/easyinstall_last', time());
+
 $I->wantTo('Auto install');
 $I->writeToFile(_XE_PATH_ . 'config/install.config.php', $install_config);
 $I->amOnPage('/');

--- a/tests/Install/InstallCept.php
+++ b/tests/Install/InstallCept.php
@@ -26,6 +26,9 @@ if(file_exists(_XE_PATH_ . 'config/install.config.php')) {
     $I->deleteFile(_XE_PATH_ . 'config/install.config.php');
 }
 
+mkdir(_XE_PATH_ . 'files/env', 0755, true);
+file_put_contents(_XE_PATH_ . 'files/env/easyinstall_last', time());
+
 // Step 1 : License Agreement
 $I->wantTo('Install RhymiX');
 $I->amOnPage('/index.php?l=ko');


### PR DESCRIPTION
Codeception으로 설치 과정을 테스트하는 것이 있는데, 여기서 설치를 마친 후 관리자 화면에 접속할 때 타임아웃이 발생하여 테스트에 실패하는 것을 종종 봅니다. 관리자 화면에 처음 접속하면 라이믹스가 처리해야 하는 일이 많기 때문에 시간이 오래 걸리는 것은 어쩔 수 없지만, 그 중에서도 특별히 오래 걸리는 경우는 XE 서버에 접속하여 쉬운설치 업데이트를 체크하는 과정에서 네트워크 장애가 발생하는 것이 아닌가 의심이 됩니다. Travis 네트워크가 좀 오락가락하거든요.

어차피 뜯어고쳐야 할 기능이므로 유닛테스트 편의를 위해 Codeception에서는 쉬운설치 업데이트 체크를 하지 않도록 합니다. (이미 체크한 것으로 판단하도록 캐시파일을 미리 생성해 둡니다.)