### PR TITLE
HHVM 유닛 테스트 범위 조정

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,13 +15,14 @@ before_script:
 - npm install grunt grunt-cli grunt-contrib-jshint grunt-contrib-csslint grunt-phplint --save-dev
 - mysql -u root -e "CREATE DATABASE rhymix"
 - mysql -u root -e "SET PASSWORD FOR 'travis'@'localhost' = PASSWORD('travis')"
-- php -S localhost:8000 &
-- if [ $(phpenv version-name) == "5.3" ]; then touch codecept.phar; fi
-- if [ $(phpenv version-name) == "5.4" ]; then wget http://codeception.com/releases/2.0.16/codecept.phar; fi
-- if [ ! -f codecept.phar ]; then wget http://codeception.com/codecept.phar; fi
+- if [[ $TRAVIS_PHP_VERSION != "hhvm" ]]; then php -S localhost:8000 & fi
+- if [[ $TRAVIS_PHP_VERSION == "5.3" ]]; then touch codecept.phar; fi
+- if [[ $TRAVIS_PHP_VERSION == "5.4" ]]; then wget http://codeception.com/releases/2.0.16/codecept.phar; fi
+- if [[ ! -f codecept.phar ]]; then wget http://codeception.com/codecept.phar; fi
 script:
-- if [ -f codecept.phar ]; then php codecept.phar build; fi
-- if [ -f codecept.phar ]; then php codecept.phar run -d --fail-fast --env travis; fi
+- if [[ -f codecept.phar ]]; then php codecept.phar build; fi
+- if [[ $TRAVIS_PHP_VERSION == "hhvm" ]]; then php codecept.phar run -d --fail-fast --env travis --skip Install; fi
+- if [[ $TRAVIS_PHP_VERSION != "hhvm" ]]; then php codecept.phar run -d --fail-fast --env travis; fi
 - grunt lint
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,6 @@ php:
 - 5.6
 - 7.0
 - hhvm
-matrix:
-  allow_failures:
-  - php: hhvm
-  fast_finish: true
 sudo: false
 before_script:
 - npm install grunt grunt-cli grunt-contrib-jshint grunt-contrib-csslint grunt-phplint --save-dev


### PR DESCRIPTION
Travis에서 기본 제공하는 HHVM 버전이 개발용 서버를 지원하지 않아서, 엄청 복잡한 과정을 거치지 않으면 acceptance test가 불가능합니다. 그래서 HHVM에서는 acceptance test를 제외하고 unit test만 실행하도록 변경했습니다. 지원되지 않는 테스트 때문에 에러를 뿜느니, unit test라도 제대로 하는 편이 더 도움이 될 거라고 생각합니다.

덕분에 모든 테스트가 녹색입니다 ^^

![hhvm-ok](https://cloud.githubusercontent.com/assets/164058/12530656/d9d95e3a-c228-11e5-84aa-9609029cf82b.png)