### PR TITLE
#56 요약이 없을경우, Content 를 다시 불러올 수 잇도록 개선

### DIFF
--- a/modules/document/document.item.php
+++ b/modules/document/document.item.php
@@ -837,8 +837,19 @@ class documentItem extends Object
 
 		// If not specify its height, create a square
 		if(!$height) $height = $width;
+		if($this->get('content'))
+		{
+			$content = $this->get('content');
+		}
+		else
+		{
+			$args = new stdClass();
+			$args->document_srl = $this->document_srl;
+			$output = executeQuery('document.getDocument', $args);
+			$content = $output->data->content;
+		}
 		// Return false if neither attachement nor image files in the document
-		if(!$this->get('uploaded_count') && !preg_match("!<img!is", $this->get('content'))) return;
+		if(!$this->get('uploaded_count') && !preg_match("!<img!is", $content)) return;
 		// Get thumbnai_type information from document module's configuration
 		if(!in_array($thumbnail_type, array('crop','ratio')))
 		{
@@ -914,7 +925,6 @@ class documentItem extends Object
 		// If not exists, file an image file from the content
 		if(!$source_file)
 		{
-			$content = $this->get('content');
 			$target_src = null;
 			preg_match_all("!src=(\"|')([^\"' ]*?)(\"|')!is", $content, $matches, PREG_SET_ORDER);
 			$cnt = count($matches);


### PR DESCRIPTION
요약이 없을 경우 Content중에 이미지만 업로드 달랑햇을경우 목록에서 랜덤으로
$this->get('content');
가 실행이 되게 됩니다.

이 부분의 문제점을 해결하여, $this->get('content')가 검색이 되지 않으면
$content함수에 따로 불러들인 게시판내용을 다시 불러들일 수 잇도록 했습니다.
(일반적인 목록에서는 `columnList` 를 따지기 때문에 가져오는방향이 안잡힙니다..)

한가지 버그 확인했는데..
확장자중에 jpg또는 기타 등등이 있는 확장자가 잇는 facebook 링크임에도 불구하고 이미지가 가져와지지 않는 문제점을 발견했습니다.

http://rhymix.swhite523.com/data
게시판에 접속이 안되는 2개의 부분을 봤습니다.(이 이슈를 마무리할때까지만.. rhymix 테스트게시판을 열어두겠습니다.)