### PR TITLE
태그에서 act 가 포함된 url이 무조건 제거되지않도록 변경

### DIFF
--- a/common/legacy.php
+++ b/common/legacy.php
@@ -1123,6 +1123,34 @@ function removeSrcHack($match)
 		}
 	}
 
+	//Remove ACT URL (CSRF)
+	$except_act = array('procFileDownload');
+	$block_act = array('dispMemberLogout');
+
+	$filter_arrts = array('style', 'src', 'href');
+	if($tag === 'object') array_push($filter_arrts, 'data');
+	if($tag === 'param') array_push($filter_arrts, 'value');
+
+	foreach($filter_arrts as $attr)
+	{
+		if(!isset($attrs[$attr])) continue;
+
+		$attr_value = rawurldecode($attrs[$attr]);
+		$attr_value = htmlspecialchars_decode($attr_value, ENT_COMPAT);
+		$attr_value = preg_replace('/\s+|[\t\n\r]+/', '', $attr_value);
+
+		preg_match('@(\?|&|;)act=(disp|proc)([^&]*)@i', $attr_value, $actmatch);
+		$url_action = $actmatch[2].$actmatch[3];
+
+		if(!empty($url_action) && !in_array($url_action, $except_act))
+		{
+			if($actmatch[2] == 'proc' || in_array($url_action, $block_act))
+			{
+				unset($attrs[$attr]);
+			}
+		}
+	}
+
 	if(isset($attrs['style']) && preg_match('@(?:/\*|\*/|\n|:\s*expression\s*\()@i', $attrs['style']))
 	{
 		unset($attrs['style']);

--- a/common/legacy.php
+++ b/common/legacy.php
@@ -1123,24 +1123,6 @@ function removeSrcHack($match)
 		}
 	}
 
-	$filter_arrts = array('style', 'src', 'href');
-
-	if($tag === 'object') array_push($filter_arrts, 'data');
-	if($tag === 'param') array_push($filter_arrts, 'value');
-
-	foreach($filter_arrts as $attr)
-	{
-		if(!isset($attrs[$attr])) continue;
-
-		$attr_value = rawurldecode($attrs[$attr]);
-		$attr_value = htmlspecialchars_decode($attr_value, ENT_COMPAT);
-		$attr_value = preg_replace('/\s+|[\t\n\r]+/', '', $attr_value);
-		if(preg_match('@(\?|&|;)(act=)@i', $attr_value))
-		{
-			unset($attrs[$attr]);
-		}
-	}
-
 	if(isset($attrs['style']) && preg_match('@(?:/\*|\*/|\n|:\s*expression\s*\()@i', $attrs['style']))
 	{
 		unset($attrs['style']);

--- a/common/legacy.php
+++ b/common/legacy.php
@@ -1125,7 +1125,7 @@ function removeSrcHack($match)
 
 	//Remove ACT URL (CSRF)
 	$except_act = array('procFileDownload');
-	$block_act = array('dispMemberLogout');
+	$block_act = array('dispMemberLogout', 'dispLayoutPreview');
 
 	$filter_arrts = array('style', 'src', 'href');
 	if($tag === 'object') array_push($filter_arrts, 'data');


### PR DESCRIPTION
지난번 보안문제(`<img src="...act=...">`)로 인하여 글작성시 태그에 act가 포함된 url이 들어가면 제거되는 패치가 되었습니다.

하지만 (이미지가 아닌) 첨부파일을 본문 삽입하면 링크가 지워지는 문제가 있습니다.
또한 펌추적 모듈(https://www.xetown.com/xepoint/23414)도 무용지물이 되버립니다.

해당 보안문제는 이미 패치되었으므로, 굳이 act url까지 제거할 필요가 있을까 하는 것이 제 생각입니다.