### PR TITLE
#162 메뉴 순서 변경이 안 되는 문제 해결

### DIFF
--- a/modules/menu/menu.admin.model.php
+++ b/modules/menu/menu.admin.model.php
@@ -517,7 +517,6 @@ class menuAdminModel extends menu
 				{
 					$this->_menuInfoSetting($menu->list[$key], $start_module, $isMenuFixed, $menuSrl,$siteSrl);
 				}
-				ksort($menu->list);
 				$menu->list = array_values($menu->list);
 			}
 			else
@@ -569,7 +568,6 @@ class menuAdminModel extends menu
 							{
 								$this->_menuInfoSetting($menu->list[$key2], $start_module, $isMenuFixed, $value->menu_srl,$siteSrl);
 							}
-							ksort($menu->list);
 							$menu->list = array_values($menu->list);
 						}
 						else
@@ -721,7 +719,6 @@ class menuAdminModel extends menu
 			{
 				$this->_menuInfoSetting($menu['list'][$key], $start_module, $isMenuFixed, $menuSrl, $siteSrl);
 			}
-			ksort($menu['list']);
 			$menu['list'] = array_values($menu['list']);
 		}
 		else


### PR DESCRIPTION
지난번에 메뉴 편집 버그를 수정하면서 여기저기에 `ksort()`와 `array_values()`를 붙여놨는데, 알고 보니 `ksort()`는 한 군데만 있으면 되더라구요. 그래서 나머지를 모두 지웠더니 메뉴 순서 변경에 문제가 없습니다. #162