### PR TITLE
#55 #56 외부이미지 섬네일 생성 개선

### DIFF
--- a/classes/file/FileHandler.class.php
+++ b/classes/file/FileHandler.class.php
@@ -571,6 +571,7 @@ class FileHandler
 				}
 			}
 			
+			$url = str_replace('&amp;', '&', $url);
 			$response = Requests::request($url, $request_headers, $body ?: $post_data, $method, $request_options);
 			
 			if(count($response->cookies))

--- a/modules/document/document.item.php
+++ b/modules/document/document.item.php
@@ -860,7 +860,7 @@ class documentItem extends Object
 				$config = $oDocumentModel->getDocumentConfig();
 				$GLOBALS['__document_config__'] = $config;
 			}
-			$thumbnail_type = $config->thumbnail_type;
+			$thumbnail_type = $config->thumbnail_type ?: 'crop';
 		}
 
 		// Define thumbnail information

--- a/modules/document/document.item.php
+++ b/modules/document/document.item.php
@@ -925,22 +925,31 @@ class documentItem extends Object
 		// If not exists, file an image file from the content
 		if(!$source_file)
 		{
-			$target_src = null;
-			preg_match_all("!src=(\"|')([^\"' ]*?)(\"|')!is", $content, $matches, PREG_SET_ORDER);
-			$cnt = count($matches);
-			for($i=0;$i<$cnt;$i++)
+			preg_match_all("!<img\s[^>]*?src=(\"|')([^\"' ]*?)(\"|')!is", $content, $matches, PREG_SET_ORDER);
+			foreach($matches as $match)
 			{
-				$target_src = trim($matches[$i][2]);
-				if(!preg_match("/\.(jpg|png|jpeg|gif|bmp)$/i",$target_src)) continue;
-				if(preg_match('/\/(common|modules|widgets|addons|layouts)\//i', $target_src)) continue;
+				$target_src = htmlspecialchars_decode(trim($match[2]));
+				if(preg_match('/\/(common|modules|widgets|addons|layouts)\//i', $target_src))
+				{
+					continue;
+				}
 				else
 				{
-					if(!preg_match('/^(http|https):\/\//i',$target_src)) $target_src = Context::getRequestUri().$target_src;
+					if(!preg_match('/^https?:\/\//i',$target_src))
+					{
+						$target_src = Context::getRequestUri().$target_src;
+					}
 
 					$tmp_file = sprintf('./files/cache/tmp/%d', md5(rand(111111,999999).$this->document_srl));
-					if(!is_dir('./files/cache/tmp')) FileHandler::makeDir('./files/cache/tmp');
+					if(!is_dir('./files/cache/tmp'))
+					{
+						FileHandler::makeDir('./files/cache/tmp');
+					}
 					FileHandler::getRemoteFile($target_src, $tmp_file);
-					if(!file_exists($tmp_file)) continue;
+					if(!file_exists($tmp_file))
+					{
+						continue;
+					}
 					else
 					{
 						if($is_img = @getimagesize($tmp_file))
@@ -951,7 +960,6 @@ class documentItem extends Object
 						{
 							continue;
 						}
-
 						$source_file = $tmp_file;
 						$is_tmp_file = true;
 						break;


### PR DESCRIPTION
아래와 같은 경우 외부이미지의 섬네일이 생성되지 않는 문제를 해결합니다.

- 외부이미지 주소가 jpg, gif, png 등의 확장자로 끝나지 않는 경우
- 외부이미지 주소에 `&amp;` 등이 포함된 경우

또한 문서와 댓글의 외부이미지 섬네일 생성 방식을 통일하여 양쪽에 똑같이 적용되도록 하였습니다.

@qw5414 호출