### PR TITLE
템플릿에서 대문자 상수와 $_SERVER 변수를 사용할 수 있도록 개선

### DIFF
--- a/classes/template/TemplateHandler.class.php
+++ b/classes/template/TemplateHandler.class.php
@@ -887,7 +887,7 @@ class TemplateHandler
 			return '$__Context->' . $n[1];
 		};
 
-		return preg_replace_callback('/\$([_a-z0-9^\s]+)/i', $callback, $php);
+		return preg_replace_callback('/(?<!::|\\\\|(?<!eval\()\')\$([_a-z0-9^\s]+)/i', $callback, $php);
 	}
 
 }

--- a/classes/template/TemplateHandler.class.php
+++ b/classes/template/TemplateHandler.class.php
@@ -879,7 +879,7 @@ class TemplateHandler
 
 		$callback = function($n)
 		{
-			if(preg_match('/^_(_Context|SERVER|COOKIE)/i', $n[1]))
+			if(preg_match('/^(_(_Context|SERVER|COOKIE)|GLOBALS)/i', $n[1]))
 			{
 				return $n[0];
 			}


### PR DESCRIPTION
템플릿에서 `$_SERVER` 변수를 사용할 수 없었다는 아쉬움이 있었습니다. 이번에는 그 서버 변수를 사용할 수 있도록 개선해봤습니다.

더불어 __ 언더바가 있어야 비로소 상수로 인식받았던 문제도 고쳤습니다. 이제 `RX_VERSION` 와 같이 앞에 언더바가 없는 상수도 템플릿에서 사용할 수 있습니다.
