### PR TITLE
크롬에서 신고 팝업창 실행시 창크기가 커지지않는 문제 수정

### DIFF
--- a/modules/comment/tpl/declare_comment.html
+++ b/modules/comment/tpl/declare_comment.html
@@ -51,6 +51,6 @@
 		}
 	});
 	msg_area.hide();
-	$(window).load(setFixedPopupSize);
+	$(document).load(setFixedPopupSize);
 })(jQuery);
 </script>

--- a/modules/document/tpl/declare_document.html
+++ b/modules/document/tpl/declare_document.html
@@ -51,6 +51,6 @@
 		}
 	});
 	msg_area.hide();
-	$(window).load(setFixedPopupSize);
+	$(document).load(setFixedPopupSize);
 })(jQuery);
 </script>


### PR DESCRIPTION
크롬에서만 신고 창크기가 커지지않는 문제가 나타납니다. window보다 document가 더 맞지않나 싶습니다.