### PR TITLE
'admin' 으로 mid를 생성 할 수 있었던 문제점 개선

### DIFF
--- a/modules/module/module.model.php
+++ b/modules/module/module.model.php
@@ -25,6 +25,7 @@ class moduleModel extends module
 		$dirs[] = 'rss';
 		$dirs[] = 'atom';
 		$dirs[] = 'api';
+		$dirs[] = 'admin';
 		if(in_array($id, $dirs)) return true;
 		// mid test
 		$args = new stdClass();


### PR DESCRIPTION
mid를 admin으로 생성 할 수 있엇던 문제점을 고칩니다.
기존에 기진곰님이 말씀하신 module명을 모두 mid으로 생성하지 않도록 하는건, 조금 힘들 것 같습니다.
출석부 모듈도 폴더이름을 그대로 쓰고 있습니다.(attendance강제생성) 이러한 mid하나를 생성하는 모듈들의 경우 강제적으로 생성하도록 되어있기 때문에 괜히 건드리면 서드파티와의 호환성을 떨어뜨릴 것으로 보여집니다. 