### PR TITLE
slowlog 를 원하는 아이피에서만 실행 하도록 개선

### DIFF
--- a/common/debug.php
+++ b/common/debug.php
@@ -110,6 +110,25 @@ if(!defined('__LOG_SLOW_WIDGET__'))
 }
 
 /**
+ * output comments of the slowlog files
+ *
+ * 0: No limit (not recommended)
+ * 1: Allow only specified IP addresses
+ */
+if(!defined('__LOG_SLOW_PROTECT__'))
+{
+	define('__LOG_SLOW_PROTECT__', 1);
+}
+
+/**
+ * Set a ip address to allow slowlog
+ */
+if(!defined('__LOG_SLOW_PROTECT_IP__'))
+{
+	define('__LOG_SLOW_PROTECT_IP__', '127.0.0.1');
+}
+
+/**
  * Leave DB query information
  *
  * 0: Do not add information to the query

--- a/common/legacy.php
+++ b/common/legacy.php
@@ -822,6 +822,7 @@ function debugPrint($debug_output = NULL, $display_option = TRUE, $file = '_debu
 function writeSlowlog($type, $elapsed_time, $obj)
 {
 	if(!__LOG_SLOW_TRIGGER__ && !__LOG_SLOW_ADDON__ && !__LOG_SLOW_WIDGET__ && !__LOG_SLOW_QUERY__) return;
+	if(__LOG_SLOW_PROTECT__ === 1 &&  __LOG_SLOW_PROTECT_IP__ != $_SERVER['REMOTE_ADDR']) return;
 
 	static $log_filename = array(
 		'query' => 'files/_slowlog_query.php',


### PR DESCRIPTION
현재 slowlog는 모든 아이피에서 실행합니다.

하지만, 이게 문제점은 갑작스러운 트리거의 중첩으로 많은 양을 기록하게 될경우 브라우저의 실행 아이콘이 돌아가는 문제점이 발생됩니다.(실제적으로 작업을 완료한 상태라도..)

그래서 사이트가 일반 유저들에게도 느려지는 현상이 있습니다. 이를 보안하게 하여, 기본적으로 `debugPrint`사용과 마찬가지로 `protect ip`기능을 제공합니다.

사용 방법은 다음과 같습니다
똑같이 `config.user.inc.php` 파일내에 아래 문구를 추가합니다.
```php
define('__LOG_SLOW_TRIGGER__', 1);
define('__LOG_SLOW_WIDGET__', 1);
define('__LOG_SLOW_ADDON__', 1);
define('__LOG_SLOW_QUERY__', 1);
define('__LOG_SLOW_PROTECT__', 1);
define('__LOG_SLOW_PROTECT_IP__', '127.0.0.1');
```

위의 코드에서
```php
define('__LOG_SLOW_TRIGGER__', 1);
define('__LOG_SLOW_WIDGET__', 1);
define('__LOG_SLOW_ADDON__', 1);
define('__LOG_SLOW_QUERY__', 1);
```
에서의 숫자는 `초`단위 숫자입니다.(처음보시는 분들을 위한 설명입니다.)