### PR TITLE
애드온 등에서 트리거에 콜백 함수를 등록할 수 있도록 허용

### DIFF
--- a/classes/module/ModuleHandler.class.php
+++ b/classes/module/ModuleHandler.class.php
@@ -1207,9 +1207,9 @@ class ModuleHandler extends Handler
 
 		$oModuleModel = getModel('module');
 		$triggers = $oModuleModel->getTriggers($trigger_name, $called_position);
-		if(!$triggers || count($triggers) < 1)
+		if(!$triggers)
 		{
-			return new Object();
+			$triggers = array();
 		}
 		
 		//store before trigger call time
@@ -1250,6 +1250,17 @@ class ModuleHandler extends Handler
 				return $output;
 			}
 			unset($oModule);
+		}
+
+		$trigger_functions = $oModuleModel->getTriggerFunctions($trigger_name, $called_position);
+		foreach($trigger_functions as $item)
+		{
+			$item($obj);
+
+			if(is_object($output) && method_exists($output, 'toBool') && !$output->toBool())
+			{
+				return $output;
+			}
 		}
 
 		return new Object();

--- a/modules/module/module.controller.php
+++ b/modules/module/module.controller.php
@@ -61,6 +61,24 @@ class moduleController extends module
 	}
 
 	/**
+	 * @brief Add trigger callback function
+	 * 
+	 * @param string $trigger_name
+	 * @param string $called_position
+	 * @param callable $callback_function
+	 */
+	function insertTriggerFunction($trigger_name, $called_position, $callback_function)
+	{
+		if(!isset($GLOBALS['__trigger_functions__']))
+		{
+			$GLOBALS['__trigger_functions__'] = array();
+		}
+		
+		$GLOBALS['__trigger_functions__'][$trigger_name][$called_position][] = $callback_function;
+		return true;
+	}
+
+	/**
 	 * @brief Add module trigger
 	 * module trigger is to call a trigger to a target module
 	 *

--- a/modules/module/module.controller.php
+++ b/modules/module/module.controller.php
@@ -67,13 +67,8 @@ class moduleController extends module
 	 * @param string $called_position
 	 * @param callable $callback_function
 	 */
-	function insertTriggerFunction($trigger_name, $called_position, $callback_function)
+	function addTriggerFunction($trigger_name, $called_position, $callback_function)
 	{
-		if(!isset($GLOBALS['__trigger_functions__']))
-		{
-			$GLOBALS['__trigger_functions__'] = array();
-		}
-		
 		$GLOBALS['__trigger_functions__'][$trigger_name][$called_position][] = $callback_function;
 		return true;
 	}

--- a/modules/module/module.model.php
+++ b/modules/module/module.model.php
@@ -626,6 +626,21 @@ class moduleModel extends module
 	}
 
 	/**
+	 * @brief Get trigger functions
+	 */
+	function getTriggerFunctions($trigger_name, $called_position)
+	{
+		if(isset($GLOBALS['__trigger_functions__'][$trigger_name][$called_position]))
+		{
+			return $GLOBALS['__trigger_functions__'][$trigger_name][$called_position];
+		}
+		else
+		{
+			return array();
+		}
+	}
+
+	/**
 	 * @brief Get a list of all triggers on the trigger_name
 	 */
 	function getTriggers($trigger_name, $called_position)


### PR DESCRIPTION
#59

트리거를 정의하는 것은 어디에서나 할 수 있지만, 트리거에서 호출을 받으려면 반드시 모듈이어야 하는 한계가 있었습니다. 그래서 간단한 기능을 수행하는 애드온에서도 `module`과 `act`를 기준으로 자신이 실행되어야 하는지 판단한 후 `Context` 변수를 조작하는 등 복잡한 과정을 거쳐야 했지요. 트리거였다면 현재 글이나 댓글 등이 깔끔하게 `$obj`로 넘어왔을 텐데...

원래 플러그인 구조를 만들면서 함께 작업하려고 했지만, 간단한 기능이라 먼저 커밋합니다.

각설하고... `ModuleController` 클래스의 `addTriggerFunction()` 메소드를 소개합니다.

```
if($called_position == 'before_module_init')
{
	ModuleController::addTriggerFunction('comment.insertComment', 'before', function($obj) {
		$obj->content .= '<br>Rhymix is the best!';
	});
}
```

애드온에서 이렇게 등록하면 모든 댓글에 "Rhymix is the best!"라는 내용이 추가됩니다.

- 기존의 `insertTrigger()` 메소드를 재사용하지 않는 이유는 모듈명, 모듈 타입, 메소드명 등의 파라미터가 필요하지 않기 때문입니다.
- 넘어오는 `$obj`는 일반 트리거와 동일하며, 일반 트리거 호출을 마친 후 마지막에 호출됩니다.
- 라이믹스는 PHP 5.3 이상에서만 작동하므로 클로져를 자유롭게 활용하시기 바랍니다. 콜백 함수라는 개념은 jQuery를 써보셨다면 아마 익숙하실 거라고 생각합니다.

### 참고사항

- 이 방법으로 등록한 트리거는 프로파일러 모듈에서 실행 시간이 집계되지 않습니다. (호출받은 모듈 정보가 존재하지 않기 때문에 DB에 뭘 넣어야 할지 모르겠네요. 그래서 그냥 패스~ @qw5414)
- 애드온이라면 반드시 `before_module_init` 또는 `before_module_proc` 호출 시점에서 1번만 등록해야 합니다. 중복으로 등록하면 여러 번 호출되고, 너무 늦게 등록하면 호출 시점을 놓치겠죠?
  - 사실 트리거를 잘 사용한다면 다른 호출 시점에는 거의 할 일이 없게 됩니다.
- 처리할 내용이 많다면 클로져 내에서 다른 파일을 인클루드하도록 코딩하는 것이 좋습니다. 트리거 호출 전에는 절대 인클루드되지 않으므로 서버에 부담이 많이 줄어듭니다. 예:

```
// 이 애드온은 트리거 등록 외에 할 일이 없음
if($called_position != 'before_module_init') return;

// 문서 처리 트리거 등록
ModuleController::addTriggerFunction('document.insertDocument', 'before', function($obj) {
	include 'myaddon.lib.php';
	myaddon_fix_document($obj);
});

// 댓글 처리 트리거 등록
ModuleController::addTriggerFunction('comment.insertComment', 'before', function($obj) {
	include 'myaddon.lib.php';
	myaddon_fix_comment($obj);
});
```
