### PR TITLE
익명게시판에 누가 글적었는지 확인 할 수 있도록 개선

### DIFF
--- a/modules/document/document.admin.view.php
+++ b/modules/document/document.admin.view.php
@@ -35,6 +35,7 @@ class documentAdminView extends document
 	 */
 	function dispDocumentAdminList()
 	{
+		$oMemberModel = getModel('member');
 		// option to get a list
 		$args = new stdClass();
 		$args->page = Context::get('page'); // /< Page
@@ -63,6 +64,7 @@ class documentAdminView extends document
 		Context::set('document_list', $output->data);
 		Context::set('status_name_list', $statusNameList);
 		Context::set('page_navigation', $output->page_navigation);
+		Context::set('oMemberModel', $oMemberModel);
 
 		// set a search option used in the template
 		$count_search_option = count($this->search_option);

--- a/modules/document/tpl/document_list.html
+++ b/modules/document/tpl/document_list.html
@@ -51,7 +51,18 @@ xe.lang.msg_empty_search_keyword = '{$lang->msg_empty_search_keyword}';
 				<a href="{getUrl('', 'mid', $module_list[$oDocument->get('module_srl')]->mid)}" target="_blank">{$module_list[$oDocument->get('module_srl')]->browser_title}</a> - 
 				</block>
 				<a href="{getUrl('','document_srl',$oDocument->document_srl)}" target="_blank"><!--@if(trim($oDocument->getTitleText()))-->{htmlspecialchars($oDocument->getTitleText())}<!--@else--><em>{$lang->no_title_document}</em><!--@end--></a></td>
-				<td class="nowr"><a href="#popup_menu_area" class="member_{$oDocument->get('member_srl')}">{$oDocument->getNickName()}</a></td>
+				<!--@if($oDocument->get('member_srl') < 0)-->
+				{@
+					$member_srl = abs($oDocument->get('member_srl'));
+					$member_info = $oMemberModel->getMemberInfoByMemberSrl($member_srl);
+					$nick_name = '('.$lang->anonymous.')'.$member_info->nick_name;
+				}
+				<!--@else-->
+				{@
+					$nick_name = $oDocument->getNickName();
+				}
+				<!--@end-->
+				<td class="nowr"><a href="#popup_menu_area" class="member_{abs($oDocument->get('member_srl'))}">{$nick_name}</a></td>
 				<td class="nowr">{$oDocument->get('readed_count')}</td>
 				<td class="nowr">{$oDocument->get('voted_count')}/{$oDocument->get('blamed_count')}</td>
 				<td class="nowr">{$oDocument->getRegdate("Y-m-d H:i")}</td>


### PR DESCRIPTION
요건 생성하면서 고민이 조금 필요한 부분인것 같습니다.
일딴 코드를 넣어뒀지만, 익명게시판을 운영하는 사람들의 대부분의 운영진들이 누가 글을 적엇는지 식별이 어려워 하는 부분이 어느정도 있다 판단됩니다.
그 부분을 어느정도 해결할 수 잇는 요점으로 보여지는데.. 사실 조금 조심스러운 부분이 있어야 할 부분이기도 합니다..

사용자(사이트 사용자를 뜻합니다.)를 위한 운영이냐..
운영자를 위한 운영이냐..

이 두개의 선택중에 택1을 해야할 부분이 아닐까 생각됩니다. 