### PR TITLE
서버에서 멋대로 XML을 반환하는 경우에도 정상 작동하도록 고침

### DIFF
--- a/common/js/xml_handler.js
+++ b/common/js/xml_handler.js
@@ -115,9 +115,23 @@
 		
 		// Define the error handler.
 		var errorHandler = function(xhr, textStatus) {
+			
+			// If the server has returned XML anyway, convert to JSON and call the success handler.
+			if (textStatus === 'parsererror' && xhr.responseText && xhr.responseText.match(/<response/)) {
+				var xmldata = $.parseXML(xhr.responseText);
+				if (xmldata) {
+					var jsondata = $.parseJSON(xml2json(xmldata, false, false));
+					if (jsondata && jsondata.response) {
+						return successHandler(jsondata.response, textStatus, xhr);
+					}
+				}
+			}
+			
+			// Hide the waiting message and display an error notice.
 			clearTimeout(wfsr_timeout);
 			waiting_obj.hide().trigger("cancel_confirm");
-			alert("AJAX communication error while requesting " + params.module + "." + params.act + "\n\n" + xhr.status + " " + xhr.statusText);
+			var error_info = xhr.status + " " + xhr.statusText + " (" + textStatus + ")";
+			alert("AJAX communication error while requesting " + params.module + "." + params.act + "\n\n" + error_info);
 		};
 		
 		// Send the AJAX request.
@@ -190,15 +204,16 @@
 			
 			// If there was a success callback, call it.
 			if($.isFunction(callback_success)) {
-				clearTimeout(wfsr_timeout);
-				waiting_obj.hide().trigger("cancel_confirm");
 				callback_success(data);
 			}
 		};
 		
 		// Define the error handler.
 		var errorHandler = function(xhr, textStatus) {
-			alert("AJAX communication error while requesting " + params.module + "." + params.act + "\n\n" + xhr.status + " " + xhr.statusText);
+			clearTimeout(wfsr_timeout);
+			waiting_obj.hide().trigger("cancel_confirm");
+			var error_info = xhr.status + " " + xhr.statusText + " (" + textStatus + ")";
+			alert("AJAX communication error while requesting " + params.module + "." + params.act + "\n\n" + error_info);
 		};
 		
 		// Send the AJAX request.
@@ -260,7 +275,8 @@
 		var errorHandler = function(xhr, textStatus) {
 			clearTimeout(wfsr_timeout);
 			waiting_obj.hide().trigger("cancel_confirm");
-			alert("AJAX communication error while requesting " + params.module + "." + params.act + "\n\n" + xhr.status + " " + xhr.statusText);
+			var error_info = xhr.status + " " + xhr.statusText + " (" + textStatus + ")";
+			alert("AJAX communication error while requesting " + params.module + "." + params.act + "\n\n" + error_info);
 		};
 		
 		// Send the AJAX request.


### PR DESCRIPTION
#152 에서 분명히 JSON을 반환해 달라고 요청했는데도 여전히 막무가내로 XML을 반환하는 경우가 있습니다. 코어에 포함된 캡챠 애드온과 일부 서드파티 자료들이 그런데요...

그래서 서버에서 XML을 반환하든 JSON을 반환하든 상관없이 정상 처리해 주도록 고쳤습니다. (JSON은 그대로 사용하고, XML은 예전처럼 JSON으로 강제 변환하여 사용합니다.)