### PR TITLE
Travis 테스트 도중 CSS outline 속성에 대해 경고하는 것을 고침

### DIFF
--- a/common/css/xe.css
+++ b/common/css/xe.css
@@ -72,7 +72,6 @@ a img {
 	box-shadow: 0 10px 20px rgba(0,0,0,0.19), 0 6px 6px rgba(0,0,0,0.23);
 	background: #fff;
 	min-width:80px;
-	outline:none;
 }
 #popup_menu_area ul {
 	margin: 0;
@@ -94,6 +93,7 @@ a img {
 #popup_menu_area a:active,
 #popup_menu_area a:focus {
 	background: #eeeeee;
+	outline:none;
 }
 @media screen and (max-width: 400px) {
 	#popup_menu_area {


### PR DESCRIPTION
`outline` 속성은 `:focus` 선택자 내에서만 사용할 수 있다고 합니다.