### PR TITLE
exec_xml() 함수로 요청시 request method를 XMLRPC로 지정

### DIFF
--- a/classes/context/Context.class.php
+++ b/classes/context/Context.class.php
@@ -235,6 +235,12 @@ class Context
 		$this->_setJSONRequestArgument();
 		$this->_setRequestArgument();
 		$this->_setUploadedArgument();
+		
+		if(isset($_POST['_rx_ajax_compat']) && $_POST['_rx_ajax_compat'] === 'XMLRPC')
+		{
+			self::$_instance->request_method = 'XMLRPC';
+			self::$_instance->response_method = 'JSON';
+		}
 
 		$this->loadDBInfo();
 		if($this->db_info->use_sitelock == 'Y')

--- a/classes/display/DisplayHandler.class.php
+++ b/classes/display/DisplayHandler.class.php
@@ -40,21 +40,21 @@ class DisplayHandler extends Handler
 		{
 			$handler = new VirtualXMLDisplayHandler();
 		}
-		else if(Context::getRequestMethod() == 'XMLRPC')
+		elseif(Context::getRequestMethod() == 'JSON' || isset($_POST['_rx_ajax_compat']))
+		{
+			$handler = new JSONDisplayHandler();
+		}
+		elseif(Context::getRequestMethod() == 'JS_CALLBACK')
+		{
+			$handler = new JSCallbackDisplayHandler();
+		}
+		elseif(Context::getRequestMethod() == 'XMLRPC')
 		{
 			$handler = new XMLDisplayHandler();
 			if(strpos($_SERVER['HTTP_USER_AGENT'], 'MSIE') !== FALSE)
 			{
 				$this->gz_enabled = FALSE;
 			}
-		}
-		else if(Context::getRequestMethod() == 'JSON')
-		{
-			$handler = new JSONDisplayHandler();
-		}
-		else if(Context::getRequestMethod() == 'JS_CALLBACK')
-		{
-			$handler = new JSCallbackDisplayHandler();
 		}
 		else
 		{

--- a/common/js/xml_handler.js
+++ b/common/js/xml_handler.js
@@ -27,6 +27,7 @@
 		params = params ? ($.isArray(params) ? arr2obj(params) : params) : {};
 		params.module = module;
 		params.act = act;
+		params._rx_ajax_compat = 'XMLRPC';
 		
 		// Fill in the XE vid.
 		if (typeof(xeVid) != "undefined") params.vid = xeVid;
@@ -162,6 +163,7 @@
 		if (action.length != 2) return;
 		params.module = action[0];
 		params.act = action[1];
+		params._rx_ajax_compat = 'JSON';
 		
 		// Fill in the XE vid.
 		if (typeof(xeVid) != "undefined") params.vid = xeVid;


### PR DESCRIPTION
#152 적용 후 `exec_xml()` 함수를 사용하더라도 서버단에서 `Context::getRequestMethod()` 함수의 반환값이 `XMLRPC`로 지정되지 않는 문제를 해결합니다.

실제 데이터 출력 포맷은 여전히 JSON을 우선순위에 둡니다.