### PR TITLE
파일첨부 등 일부 언어파일이 표시되지 않는 문제 수정

### DIFF
--- a/common/framework/lang.php
+++ b/common/framework/lang.php
@@ -304,7 +304,14 @@ class Lang
 		// Search custom translations first.
 		if (isset($this->_loaded_plugins['_custom_']->{$key}))
 		{
-			return $this->_loaded_plugins['_custom_']->{$key};
+			if (is_array($this->_loaded_plugins['_custom_']->{$key}))
+			{
+				return new \ArrayObject($this->_loaded_plugins['_custom_']->{$key}, 3);
+			}
+			else
+			{
+				return $this->_loaded_plugins['_custom_']->{$key};
+			}
 		}
 		
 		// Search other plugins.
@@ -312,7 +319,14 @@ class Lang
 		{
 			if (isset($this->_loaded_plugins[$plugin_name]->{$key}))
 			{
-				return $this->_loaded_plugins[$plugin_name]->{$key};
+				if (is_array($this->_loaded_plugins[$plugin_name]->{$key}))
+				{
+					return new \ArrayObject($this->_loaded_plugins[$plugin_name]->{$key}, 3);
+				}
+				else
+				{
+					return $this->_loaded_plugins[$plugin_name]->{$key};
+				}
 			}
 		}
 		


### PR DESCRIPTION
언어파일 내에서 배열을 또 선언해둔 경우가 있습니다.

예:

    $lang->foo['bar'] = 'rhymix';

이 경우에는 원래 형태 그대로 접근해야 하는데, 가끔 오브젝트 문법으로 접근하는 스킨이 있습니다.

예:

    {$lang->foo->bar}

기존 XE에서는 이것도 허용했기 때문에, `ArrayObject`를 사용하여 두 가지 모두 사용할 수 있도록 변경합니다. 파일첨부 부분의 글자가 나오지 않는 문제도 이것으로 해결됩니다.