### PR TITLE
관리자페이지에서는 익명회원이 누군지 구별이 가능하도록 개선

### DIFF
--- a/modules/document/document.admin.view.php
+++ b/modules/document/document.admin.view.php
@@ -75,10 +75,30 @@ class documentAdminView extends document
 		$oModuleModel = getModel('module');
 		$module_list = array();
 		$mod_srls = array();
+		$anonymous_member_srls = array();
 		foreach($output->data as $oDocument)
 		{
 			$mod_srls[] = $oDocument->get('module_srl');
+			if($oDocument->get('member_srl') < 0)
+			{
+				$anonymous_member_srls[] = abs($oDocument->get('member_srl'));
+			}
 		}
+		if($anonymous_member_srls)
+		{
+			$member_args = new stdClass();
+			$member_args->member_srl = $anonymous_member_srls;
+			$member_output = executeQueryArray('member.getMembers', $member_args);
+			if($member_output)
+			{
+				$member_nick_neme = array();
+				foreach($member_output->data as $member)
+				{
+					$member_nick_neme[$member->member_srl] = $member->nick_name;
+				}
+			}
+		}
+		Context::set('member_nick_name', $member_nick_neme);
 		$mod_srls = array_unique($mod_srls);
 		// Module List
 		$mod_srls_count = count($mod_srls);

--- a/modules/document/tpl/document_list.html
+++ b/modules/document/tpl/document_list.html
@@ -51,7 +51,10 @@ xe.lang.msg_empty_search_keyword = '{$lang->msg_empty_search_keyword}';
 				<a href="{getUrl('', 'mid', $module_list[$oDocument->get('module_srl')]->mid)}" target="_blank">{$module_list[$oDocument->get('module_srl')]->browser_title}</a> - 
 				</block>
 				<a href="{getUrl('','document_srl',$oDocument->document_srl)}" target="_blank"><!--@if(trim($oDocument->getTitleText()))-->{htmlspecialchars($oDocument->getTitleText())}<!--@else--><em>{$lang->no_title_document}</em><!--@end--></a></td>
-				<td class="nowr"><a href="#popup_menu_area" class="member_{$oDocument->get('member_srl')}">{$oDocument->getNickName()}</a></td>
+				<td class="nowr">
+					<a href="#popup_menu_area" class="member_{$oDocument->get('member_srl')}" cond="$oDocument->get('member_srl') > 0">{$oDocument->getNickName()}</a>
+					<a href="#popup_menu_area" class="member_{abs($oDocument->get('member_srl'))}" cond="$oDocument->get('member_srl') < 0 && $member_nick_name[abs($oDocument->get('member_srl'))]">({$lang->anonymous}) {$member_nick_name[abs($oDocument->get('member_srl'))]}</a>
+				</td>
 				<td class="nowr">{$oDocument->get('readed_count')}</td>
 				<td class="nowr">{$oDocument->get('voted_count')}/{$oDocument->get('blamed_count')}</td>
 				<td class="nowr">{$oDocument->getRegdate("Y-m-d H:i")}</td>


### PR DESCRIPTION
관리자 페이지에서는 익명회원이 누구인지 모르기 때문에 구별하도록 하엿고,
익명 글인지 아닌지 구분선이 필요하다고 판단되어서 닉네임에 (익명)이라는 네임을 추가하도록 하였습니다.
