### PR TITLE
관리자 문서 페이지에서 게시글선택 이후 삭제버튼 눌럿을대 목록이 인식하지 않던 문제점 개선

### DIFF
--- a/modules/document/document.controller.php
+++ b/modules/document/document.controller.php
@@ -2693,7 +2693,7 @@ class documentController extends document
 		}
 		$oSecurity = new Security($documentList);
 		$oSecurity->encodeHTML('..variables.');
-		$this->add('document_list', $documentList);
+		$this->add('document_list', array_values($documentList));
 	}
 
 	/**


### PR DESCRIPTION
관리자페이지의 문서모듈에서 게시글을 선택이후 삭제 버튼을 눌럿는데도 목록에 나타나지 않던 문제점을 개선하였습니다.

