### PR TITLE
JSON 결과 반환시 산술 배열의 인코딩 호환성 개선

### DIFF
--- a/classes/display/JSONDisplayHandler.php
+++ b/classes/display/JSONDisplayHandler.php
@@ -9,14 +9,53 @@ class JSONDisplayHandler
 	 * @param ModuleObject $oModule the module object
 	 * @return string
 	 */
-	function toDoc(&$oModule)
+	public function toDoc($oModule)
 	{
 		$variables = $oModule->getVariables();
 		$variables['error'] = $oModule->getError();
 		$variables['message'] = $oModule->getMessage();
+		
+		if (Context::getRequestMethod() === 'XMLRPC')
+		{
+			$temp = array();
+			foreach ($variables as $key => $value)
+			{
+				if (self::_isNumericArray($value))
+				{
+					$temp[$key] = array_values($value);
+				}
+				else
+				{
+					$temp[$key] = $value;
+				}
+			}
+			$variables = $temp;
+		}
+		
 		return json_encode($variables);
 	}
-
+	
+	/**
+	 * Check if an array only has numeric keys.
+	 * 
+	 * @param array $array
+	 * @return bool
+	 */
+	protected static function _isNumericArray($array)
+	{
+		if (!is_array($array) || !count($array))
+		{
+			return false;
+		}
+		foreach ($array as $key => $value)
+		{
+			if (intval($key) != $key)
+			{
+				return false;
+			}
+		}
+		return true;
+	}
 }
 /* End of file JSONDisplayHandler.class.php */
 /* Location: ./classes/display/JSONDisplayHandler.class.php */

--- a/classes/display/JSONDisplayHandler.php
+++ b/classes/display/JSONDisplayHandler.php
@@ -15,24 +15,20 @@ class JSONDisplayHandler
 		$variables['error'] = $oModule->getError();
 		$variables['message'] = $oModule->getMessage();
 		
-		if (Context::getRequestMethod() === 'XMLRPC')
+		$temp = array();
+		foreach ($variables as $key => $value)
 		{
-			$temp = array();
-			foreach ($variables as $key => $value)
+			if (self::_isNumericArray($value))
 			{
-				if (self::_isNumericArray($value))
-				{
-					$temp[$key] = array_values($value);
-				}
-				else
-				{
-					$temp[$key] = $value;
-				}
+				$temp[$key] = array_values($value);
 			}
-			$variables = $temp;
+			else
+			{
+				$temp[$key] = $value;
+			}
 		}
 		
-		return json_encode($variables);
+		return json_encode($temp);
 	}
 	
 	/**


### PR DESCRIPTION
#214 와 마찬가지로, 댓글을 선택하여 삭제할 때도 문제가 있는 것을 발견했습니다.

PHP 4.x 시절부터 XE에서 사용하던 JSON 인코딩 함수는 배열에 숫자 키만 있는 경우 산술 배열로 취급하여 `[a, b, c]` 문법으로 인코딩하지만, 라이믹스에서 사용하는 PHP `json_encode()` 함수는 숫자 키가 연속되지 않는 경우 연관 배열로 취급하여 `{a, b, c}` 문법으로 인코딩하기 때문입니다.

기존 자료와의 호환성을 위해 숫자 키가 연속되지 않더라도 산술 배열로 인코딩하도록 변경했습니다.