### PR TITLE
#177 파일박스의 확장자 제한 및 변수값 길이 제한 해제

### DIFF
--- a/modules/module/module.controller.php
+++ b/modules/module/module.controller.php
@@ -1242,9 +1242,14 @@ class moduleController extends module
 
 		$ext = strtolower(substr(strrchr($vars->addfile['name'],'.'),1));
 		$vars->ext = $ext;
-		if($vars->filter) $filter = explode(',',$vars->filter);
-		else $filter = array('jpg','jpeg','gif','png');
-		if(!in_array($ext,$filter)) return new Object(-1, 'msg_error_occured');
+		if ($vars->filter)
+		{
+			$filter = array_map('trim', explode(',',$vars->filter));
+			if (!in_array($ext, $filter))
+			{
+				return new Object(-1, 'msg_error_occured');
+			}
+		}
 
 		$vars->member_srl = $logged_info->member_srl;
 
@@ -1314,9 +1319,9 @@ class moduleController extends module
 		$args->module_filebox_srl = $vars->module_filebox_srl;
 		$args->comment = $vars->comment;
 
-		// FIXME $args ??
-
-		return executeQuery('module.updateModuleFileBox', $vars);
+		return executeQuery('module.updateModuleFileBox', $args);
+		$output->add('save_filename', $save_filename);
+		return $output;
 	}
 
 

--- a/modules/module/schemas/module_filebox.xml
+++ b/modules/module/schemas/module_filebox.xml
@@ -4,6 +4,6 @@
     <column name="filename" type="varchar" size="250" notnull="notnull" />
     <column name="fileextension" type="varchar" size="4" notnull="notnull" index="idx_fileextension" />
     <column name="filesize" type="number" size="11" default="0" notnull="notnull" />
-    <column name="comment" type="varchar" size="250" />
+    <column name="comment" type="bigtext" />
     <column name="regdate" type="date" />
 </table>

--- a/modules/module/tpl/adminFileBox.html
+++ b/modules/module/tpl/adminFileBox.html
@@ -63,6 +63,8 @@
 						</object>
 					<!--@elseif(in_array($val->fileextension,array('gif','png','jpg','jpeg')))-->
 						<img src="{getUrl('')}{$val->filename}" style="max-height:60px" />
+					<!--@else-->
+						<a href="{getUrl('')}{$val->filename}">{basename($val->filename)}</a>
 					<!--@end-->
 				</td>
 				<td>

--- a/modules/module/tpl/filebox_list.html
+++ b/modules/module/tpl/filebox_list.html
@@ -26,6 +26,8 @@
 						
 					<!--@elseif(in_array($val->fileextension,array('gif','png','jpg','jpeg')))-->
 					<img src="{getUrl('')}{$val->filename}" width="100" height="100" />
+					<!--@else-->
+						<a href="{getUrl('')}{$val->filename}">{basename($val->filename)}</a>
 					<!--@end-->
 				</div>
 			</td>

--- a/modules/module/tpl/filebox_list_html.html
+++ b/modules/module/tpl/filebox_list_html.html
@@ -17,6 +17,8 @@
 					</object>
 				<!--@elseif(in_array($val->fileextension,array('gif','png','jpg','jpeg')))-->
 					<img src="{getUrl('')}{$val->filename}" class="filebox_item" />
+				<!--@else-->
+					<a href="{getUrl('')}{$val->filename}">{basename($val->filename)}</a>
 				<!--@end-->
 			</td>
 			<td>


### PR DESCRIPTION
관리자가 파일박스에 파일을 업로드할 때 지금까지는 이미지 파일만 허용되었지만, 모든 확장자를 허용하도록 변경합니다. (기존에도 `filter` 변수를 조작하면 어떤 확장자든 업로드할 수 있었기 때문에 보안상의 차이는 없어 보입니다.)

라이믹스를 신규 설치하는 경우에는 변수값이 저장되는 `comment` 필드도 `varchar(250)`에서 `longtext`로 늘어나므로 대량의 데이터를 저장할 수 있게 됩니다.

#177 에서 @ForPeople 님이 변수를 사용한 검색 기능도 제안하셨으나, 현재의 DB 스키마에서는 곤란하므로 나중에 별도로 다루도록 하겠습니다.