### PR TITLE
새 설정 포맷 나머지 정리

### DIFF
--- a/classes/display/DisplayHandler.class.php
+++ b/classes/display/DisplayHandler.class.php
@@ -25,12 +25,7 @@ class DisplayHandler extends Handler
 	public function printContent(&$oModule)
 	{
 		// Check if the gzip encoding supported
-		if(
-				(defined('__OB_GZHANDLER_ENABLE__') && __OB_GZHANDLER_ENABLE__ == 1) &&
-				strpos($_SERVER['HTTP_ACCEPT_ENCODING'], 'gzip') !== FALSE &&
-				extension_loaded('zlib') &&
-				$oModule->gzhandler_enable
-		)
+		if(config('view.use_gzip') && strpos($_SERVER['HTTP_ACCEPT_ENCODING'], 'gzip') !== false && extension_loaded('zlib') && $oModule->gzhandler_enable)
 		{
 			$this->gz_enabled = TRUE;
 		}

--- a/common/framework/compat/configparser.php
+++ b/common/framework/compat/configparser.php
@@ -1,0 +1,269 @@
+<?php
+
+namespace Rhymix\Framework\Compat;
+
+use Rhymix\Framework\Config;
+use Rhymix\Framework\DateTime;
+
+/**
+ * Config parser class for XE compatibility.
+ */
+class ConfigParser
+{
+	/**
+	 * Convert previous configuration files to the current format and return it.
+	 * 
+	 * @return array
+	 */
+	public static function convert()
+	{
+		// Load DB info file.
+		if (file_exists(RX_BASEDIR . Config::$old_db_config_filename))
+		{
+			include RX_BASEDIR . Config::$old_db_config_filename;
+		}
+		else
+		{
+			return array();
+		}
+		
+		// Load FTP info file.
+		if (file_exists(RX_BASEDIR . Config::$old_ftp_config_filename))
+		{
+			include RX_BASEDIR . Config::$old_ftp_config_filename;
+		}
+		
+		// Load selected language file.
+		if (file_exists(RX_BASEDIR . Config::$old_lang_config_filename))
+		{
+			$lang_selected = array();
+			$lang_selected_raw = file_get_contents(RX_BASEDIR . Config::$old_lang_config_filename);
+			$lang_selected_raw = array_map('trim', explode("\n", $lang_selected_raw));
+			foreach ($lang_selected_raw as $lang_selected_item)
+			{
+				$lang_selected_item = array_map('trim', explode(',', $lang_selected_item));
+				if (count($lang_selected_item) && $lang_selected_item[0] !== '')
+				{
+					$lang_selected_item[0] = ($lang_selected_item[0] === 'jp' ? 'ja' : $lang_selected_item[0]);
+					$lang_selected[] = $lang_selected_item[0];
+				}
+			}
+			$lang_selected = array_unique($lang_selected);
+			unset($lang_selected_raw, $lang_selected_item);
+		}
+		else
+		{
+			$lang_selected = \Context::getLangType() === 'jp' ? 'ja' : \Context::getLangType();
+			$lang_selected = array($lang_selected);
+		}
+		
+		// Load defaults for the new configuration.
+		$config = (include RX_BASEDIR . Config::$default_config_filename);
+		
+		// Convert database configuration.
+		if (!isset($db_info->master_db))
+		{
+			$db_info->master_db = array();
+			$db_info->master_db['db_type'] = $db_info->db_type;
+			$db_info->master_db['db_hostname'] = $db_info->db_hostname;
+			$db_info->master_db['db_port'] = $db_info->db_port;
+			$db_info->master_db['db_userid'] = $db_info->db_userid;
+			$db_info->master_db['db_password'] = $db_info->db_password;
+			$db_info->master_db['db_database'] = $db_info->db_database;
+			$db_info->master_db['db_table_prefix'] = $db_info->db_table_prefix;
+		}
+		
+		$config['db']['master']['type'] = strtolower($db_info->master_db['db_type']);
+		$config['db']['master']['host'] = $db_info->master_db['db_hostname'];
+		$config['db']['master']['port'] = $db_info->master_db['db_port'];
+		$config['db']['master']['user'] = $db_info->master_db['db_userid'];
+		$config['db']['master']['pass'] = $db_info->master_db['db_password'];
+		$config['db']['master']['database'] = $db_info->master_db['db_database'];
+		$config['db']['master']['prefix'] = $db_info->master_db['db_table_prefix'];
+		
+		if (substr($config['db']['master']['prefix'], -1) !== '_')
+		{
+			$config['db']['master']['prefix'] .= '_';
+		}
+		
+		$config['db']['master']['charset'] = $db_info->master_db['db_charset'] ?: 'utf8';
+		
+		if (strpos($config['db']['master']['type'], 'innodb') !== false)
+		{
+			$config['db']['master']['type'] = str_replace('_innodb', '', $config['db']['master']['type']);
+			$config['db']['master']['engine'] = 'innodb';
+		}
+		elseif (strpos($config['db']['master']['type'], 'mysql') !== false)
+		{
+			$config['db']['master']['engine'] = 'myisam';
+		}
+		
+		if (isset($db_info->slave_db) && count($db_info->slave_db))
+		{
+			foreach ($db_info->slave_db as $slave_id => $slave_db)
+			{
+				if ($slave_db !== $db_info->master_db)
+				{
+					$slave_id = 'slave' . $slave_id;
+					$config['db'][$slave_id]['type'] = strtolower($slave_db['db_type']);
+					$config['db'][$slave_id]['host'] = $slave_db['db_hostname'];
+					$config['db'][$slave_id]['port'] = $slave_db['db_type'];
+					$config['db'][$slave_id]['user'] = $slave_db['db_userid'];
+					$config['db'][$slave_id]['pass'] = $slave_db['db_password'];
+					$config['db'][$slave_id]['database'] = $slave_db['db_database'];
+					$config['db'][$slave_id]['prefix'] = $slave_db['db_table_prefix'];
+					
+					if (substr($config['db'][$slave_id]['prefix'], -1) !== '_')
+					{
+						$config['db'][$slave_id]['prefix'] .= '_';
+					}
+					
+					$config['db'][$slave_id]['charset'] = $slave_db['db_charset'] ?: 'utf8';
+					
+					if (strpos($config['db'][$slave_id]['type'], 'innodb') !== false)
+					{
+						$config['db'][$slave_id]['type'] = str_replace('_innodb', '', $config['db'][$slave_id]['type']);
+						$config['db'][$slave_id]['engine'] = 'innodb';
+					}
+					elseif (strpos($config['db'][$slave_id]['type'], 'mysql') !== false)
+					{
+						$config['db'][$slave_id]['engine'] = 'myisam';
+					}
+				}
+			}
+		}
+		
+		// Convert cache configuration.
+		if (isset($db_info->use_object_cache))
+		{
+			$config['cache'][] = $db_info->use_object_cache;
+		}
+		
+		// Convert FTP configuration.
+		if (isset($ftp_info))
+		{
+			$config['ftp']['host'] = $ftp_info->ftp_host;
+			$config['ftp']['port'] = $ftp_info->ftp_port;
+			$config['ftp']['path'] = $ftp_info->ftp_root_path;
+			$config['ftp']['user'] = $ftp_info->ftp_user;
+			$config['ftp']['pasv'] = $ftp_info->ftp_pasv;
+			$config['ftp']['sftp'] = $ftp_info->sftp === 'Y' ? true : false;
+		}
+		
+		// Create new crypto keys.
+		$config['crypto']['encryption_key'] = \Password::createSecureSalt(64, 'alnum');
+		$config['crypto']['authentication_key'] = \Password::createSecureSalt(64, 'alnum');
+		$config['crypto']['session_key'] = \Password::createSecureSalt(64, 'alnum');
+		
+		// Convert language configuration.
+		if (isset($db_info->lang_type))
+		{
+			$config['locale']['default_lang'] = str_replace('jp', 'ja', strtolower($db_info->lang_type));
+		}
+		elseif (count($lang_selected))
+		{
+			$config['locale']['default_lang'] = array_first($lang_selected);
+		}
+		$config['locale']['enabled_lang'] = array_values($lang_selected);
+		
+		// Convert timezone configuration.
+		$old_timezone = DateTime::getTimezoneOffsetByLegacyFormat($db_info->time_zone ?: '+0900');
+		switch ($old_timezone)
+		{
+			case 32400:
+				$config['locale']['default_timezone'] = 'Asia/Seoul'; break;
+			default:
+				$config['locale']['default_timezone'] = DateTime::getTimezoneNameByOffset($old_timezone);
+		}
+		$config['locale']['internal_timezone'] = intval(date('Z'));
+		
+		// Convert URL configuration.
+		$default_url = $db_info->default_url;
+		if (strpos($default_url, 'xn--') !== false)
+		{
+			$default_url = \Context::decodeIdna($default_url);
+		}
+		$config['url']['default'] = $default_url ?: \RX_BASEURL;
+		$config['url']['http_port'] = $db_info->http_port ?: null;
+		$config['url']['https_port'] = $db_info->https_port ?: null;
+		$config['url']['ssl'] = $db_info->use_ssl ?: 'none';
+		
+		// Convert session configuration.
+		$config['session']['delay'] = $db_info->delay_session === 'Y' ? true : false;
+		$config['session']['use_db'] = $db_info->use_db_session === 'Y' ? true : false;
+		
+		// Convert view configuration.
+		$config['view']['minify_scripts'] = $db_info->minify_scripts ?: 'common';
+		$config['view']['use_gzip'] = (defined('__OB_GZHANDLER_ENABLE__') && constant('__OB_GZHANDLER_ENABLE__'));
+		
+		// Convert admin IP whitelist.
+		if (isset($db_info->admin_ip_list) && is_array($db_info->admin_ip_list) && count($db_info->admin_ip_list))
+		{
+			$config['admin']['allow'] = array_values($db_info->admin_ip_list);
+		}
+		
+		// Convert sitelock configuration.
+		$config['lock']['locked'] = $db_info->use_sitelock === 'Y' ? true : false;
+		$config['lock']['title'] = strval($db_info->sitelock_title);
+		$config['lock']['message'] = strval($db_info->sitelock_message);
+		if (!is_array($db_info->sitelock_whitelist))
+		{
+			$db_info->sitelock_whitelist = $db_info->sitelock_whitelist ? array_map('trim', explode(',', trim($db_info->sitelock_whitelist))) : array();
+		}
+		if (!in_array('127.0.0.1', $db_info->sitelock_whitelist))
+		{
+			$db_info->sitelock_whitelist[] = '127.0.0.1';
+		}
+		$config['lock']['allow'] = array_values($db_info->sitelock_whitelist);
+		
+		// Convert debug configuration.
+		$config['debug']['enabled'] = true;
+		$config['debug']['log_errors'] = true;
+		$config['debug']['log_queries'] = (\__DEBUG__ & 4) ? true : false;
+		$config['debug']['log_slow_queries'] = floatval(\__LOG_SLOW_QUERY__);
+		$config['debug']['log_slow_triggers'] = floatval(\__LOG_SLOW_TRIGGER__ * 1000);
+		$config['debug']['log_slow_widgets'] = floatval(\__LOG_SLOW_WIDGET__ * 1000);
+		
+		// Convert embed filter configuration.
+		if (is_array($db_info->embed_white_iframe))
+		{
+			$whitelist = array_unique(array_map(function($item) {
+				return preg_match('@^https?://(.*)$@i', $item, $matches) ? $matches[1] : $item;
+			}, $db_info->embed_white_iframe));
+			natcasesort($whitelist);
+			$config['embedfilter']['iframe'] = $whitelist;
+		}
+		if (is_array($db_info->embed_white_object))
+		{
+			$whitelist = array_unique(array_map(function($item) {
+				return preg_match('@^https?://(.*)$@i', $item, $matches) ? $matches[1] : $item;
+			}, $db_info->embed_white_object));
+			natcasesort($whitelist);
+			$config['embedfilter']['object'] = $whitelist;
+		}
+		
+		// Convert miscellaneous configuration.
+		$config['use_mobile_view'] = $db_info->use_mobile_view === 'Y' ? true : false;
+		$config['use_prepared_statements'] = $db_info->use_prepared_statements === 'Y' ? true : false;
+		$config['use_rewrite'] = $db_info->use_rewrite === 'Y' ? true : false;
+		$config['use_sso'] = $db_info->use_sso === 'Y' ? true : false;
+		
+		// Copy other configuration.
+		unset($db_info->master_db, $db_info->slave_db);
+		unset($db_info->lang_type, $db_info->time_zone);
+		unset($db_info->default_url, $db_info->http_port, $db_info->https_port, $db_info->use_ssl);
+		unset($db_info->delay_session, $db_info->use_db_session);
+		unset($db_info->minify_scripts, $db_info->admin_ip_list);
+		unset($db_info->use_sitelock, $db_info->sitelock_title, $db_info->sitelock_message, $db_info->sitelock_whitelist);
+		unset($db_info->embed_white_iframe, $db_info->embed_white_object);
+		unset($db_info->use_object_cache, $db_info->use_mobile_view, $db_info->use_prepared_statements);
+		unset($db_info->use_rewrite, $db_info->use_sso);
+		foreach ($db_info as $key => $value)
+		{
+			$config['other'][$key] = $value;
+		}
+		
+		// Return the new configuration.
+		return $config;
+	}
+}

--- a/common/framework/compat/langparser.php
+++ b/common/framework/compat/langparser.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace Rhymix\Framework\Compat;
+
+use Rhymix\Framework\Lang;
+
+/**
+ * Lang parser class for XE compatibility.
+ */
+class LangParser
+{
+	/**
+	 * Convert a directory of old language files to the RhymiX format.
+	 * 
+	 * @param string $dir
+	 * @param array $xml_langs When converting XML to PHP, only convert these languages. (Optional)
+	 * @return void
+	 */
+	public static function convertDirectory($dir, $xml_langs = array())
+	{
+		if (file_exists("$dir/lang.xml"))
+		{
+			$langs = count($xml_langs) ? $xml_langs : array_keys(Lang::getSupportedList());
+			foreach ($langs as $lang)
+			{
+				self::compileXMLtoPHP("$dir/lang.xml", $lang === 'ja' ? 'jp' : $lang, "$dir/$lang.php");
+			}
+		}
+		else
+		{
+			$files = glob($dir . '/*.lang.php');
+			foreach ($files as $filename)
+			{
+				$new_filename = preg_replace('/\.lang\.php$/', '.php', str_replace('jp.lang', 'ja.lang', $filename));
+				\FileHandler::rename($filename, $new_filename);
+			}
+		}
+	}
+	
+	/**
+	 * Compile XE-compatible XML lang files into PHP.
+	 * 
+	 * @param string $filename
+	 * @param string $language
+	 * @return string|false
+	 */
+	public static function compileXMLtoPHP($filename, $language, $output_filename = null)
+	{
+		// Check if the cache file already exists.
+		if ($output_filename === null)
+		{
+			$output_filename = RX_BASEDIR . 'files/cache/lang/' . md5($filename) . '.' . $language . '.php';
+			if (file_exists($output_filename) && filemtime($output_filename) > filemtime($filename))
+			{
+				return $output_filename;
+			}
+		}
+		
+		// Load the XML lang file.
+		$xml = @simplexml_load_file($filename);
+		if ($xml === false)
+		{
+			\FileHandler::writeFile($output_filename, '');
+			return false;
+		}
+		
+		// Convert XML to a PHP array.
+		$lang = array();
+		self::_toArray($xml, $lang, $language);
+		unset($xml);
+		
+		// Save the array as a cache file.
+		$buff = "<?php\n";
+		foreach ($lang as $key => $value)
+		{
+			if (is_array($value))
+			{
+				foreach ($value as $subkey => $subvalue)
+				{
+					if (is_array($subvalue))
+					{
+						foreach ($subvalue as $subsubkey => $subsubvalue)
+						{
+							$buff .= '$lang->' . $key . "['$subkey']['$subsubkey']" . ' = ' . var_export($subsubvalue, true) . ";\n";
+						}
+					}
+					else
+					{
+						$buff .= '$lang->' . $key . "['$subkey']" . ' = ' . var_export($subvalue, true) . ";\n";
+					}
+				}
+			}
+			else
+			{
+				$buff .= '$lang->' . $key . ' = ' . var_export($value, true) . ";\n";
+			}
+		}
+		\FileHandler::writeFile($output_filename, $buff);
+		return $output_filename;
+	}
+	
+	/**
+	 * XML to array conversion callback.
+	 * 
+	 * @param array $items
+	 * @return void
+	 */
+	protected static function _toArray($items, &$lang, $language)
+	{
+		foreach ($items as $item)
+		{
+			$name = strval($item['name']);
+			if (count($item->item))
+			{
+				$lang[$name] = array();
+				self::_toArray($item->item, $lang[$name], $language);
+			}
+			else
+			{
+				foreach ($item->value as $value)
+				{
+					$attribs = $value->attributes('xml', true);
+					if (strval($attribs['lang']) === $language)
+					{
+						$lang[$name] = strval($value);
+						break;
+					}
+				}
+			}
+		}
+	}
+}

--- a/common/framework/config.php
+++ b/common/framework/config.php
@@ -13,19 +13,28 @@ class Config
 	protected static $_config = array();
 	
 	/**
+	 * Location of configuration files.
+	 */
+	public static $config_filename = 'files/config/config.php';
+	public static $old_db_config_filename = 'files/config/db.config.php';
+	public static $old_ftp_config_filename = 'files/config/ftp.config.php';
+	public static $old_lang_config_filename = 'files/config/lang_selected.info';
+	public static $default_config_filename = 'common/defaults/config.php';
+	
+	/**
 	 * Load system configuration.
 	 * 
 	 * @return void
 	 */
 	public static function init()
 	{
-		if (file_exists(RX_BASEDIR . 'files/config/config.php'))
+		if (file_exists(RX_BASEDIR . self::$config_filename))
 		{
-			self::$_config = (include RX_BASEDIR . 'files/config/config.php');
+			self::$_config = (include RX_BASEDIR . self::$config_filename);
 		}
 		else
 		{
-			if (self::$_config = self::convert())
+			if (self::$_config = Compat\ConfigParser::convert())
 			{
 				self::save();
 			}
@@ -50,7 +59,7 @@ class Config
 	 */
 	public static function getDefaults()
 	{
-		return (include RX_BASEDIR . 'common/defaults/config.php');
+		return (include RX_BASEDIR . self::$default_config_filename);
 	}
 	
 	/**
@@ -112,263 +121,6 @@ class Config
 	}
 	
 	/**
-	 * Convert previous configuration files to the current format and return it.
-	 * 
-	 * @return array
-	 */
-	public static function convert()
-	{
-		// Load DB info file.
-		if (file_exists(RX_BASEDIR . 'files/config/db.config.php'))
-		{
-			include RX_BASEDIR . 'files/config/db.config.php';
-		}
-		else
-		{
-			return array();
-		}
-		
-		// Load FTP info file.
-		if (file_exists(RX_BASEDIR . 'files/config/ftp.config.php'))
-		{
-			include RX_BASEDIR . 'files/config/ftp.config.php';
-		}
-		
-		// Load selected language file.
-		if (file_exists(RX_BASEDIR . 'files/config/lang_selected.info'))
-		{
-			$lang_selected = array();
-			$lang_selected_raw = file_get_contents(RX_BASEDIR . 'files/config/lang_selected.info');
-			$lang_selected_raw = array_map('trim', explode("\n", $lang_selected_raw));
-			foreach ($lang_selected_raw as $lang_selected_item)
-			{
-				$lang_selected_item = array_map('trim', explode(',', $lang_selected_item));
-				if (count($lang_selected_item) && $lang_selected_item[0] !== '')
-				{
-					$lang_selected_item[0] = ($lang_selected_item[0] === 'jp' ? 'ja' : $lang_selected_item[0]);
-					$lang_selected[] = $lang_selected_item[0];
-				}
-			}
-			$lang_selected = array_unique($lang_selected);
-			unset($lang_selected_raw, $lang_selected_item);
-		}
-		else
-		{
-			$lang_selected = \Context::getLangType() === 'jp' ? 'ja' : \Context::getLangType();
-			$lang_selected = array($lang_selected);
-		}
-		
-		// Load defaults for the new configuration.
-		$config = (include RX_BASEDIR . 'common/defaults/config.php');
-		
-		// Convert database configuration.
-		if (!isset($db_info->master_db))
-		{
-			$db_info->master_db = array();
-			$db_info->master_db['db_type'] = $db_info->db_type;
-			$db_info->master_db['db_hostname'] = $db_info->db_hostname;
-			$db_info->master_db['db_port'] = $db_info->db_port;
-			$db_info->master_db['db_userid'] = $db_info->db_userid;
-			$db_info->master_db['db_password'] = $db_info->db_password;
-			$db_info->master_db['db_database'] = $db_info->db_database;
-			$db_info->master_db['db_table_prefix'] = $db_info->db_table_prefix;
-		}
-		
-		$config['db']['master']['type'] = strtolower($db_info->master_db['db_type']);
-		$config['db']['master']['host'] = $db_info->master_db['db_hostname'];
-		$config['db']['master']['port'] = $db_info->master_db['db_port'];
-		$config['db']['master']['user'] = $db_info->master_db['db_userid'];
-		$config['db']['master']['pass'] = $db_info->master_db['db_password'];
-		$config['db']['master']['database'] = $db_info->master_db['db_database'];
-		$config['db']['master']['prefix'] = $db_info->master_db['db_table_prefix'];
-		
-		if (substr($config['db']['master']['prefix'], -1) !== '_')
-		{
-			$config['db']['master']['prefix'] .= '_';
-		}
-		
-		$config['db']['master']['charset'] = $db_info->master_db['db_charset'] ?: 'utf8';
-		
-		if (strpos($config['db']['master']['type'], 'innodb') !== false)
-		{
-			$config['db']['master']['type'] = str_replace('_innodb', '', $config['db']['master']['type']);
-			$config['db']['master']['engine'] = 'innodb';
-		}
-		elseif (strpos($config['db']['master']['type'], 'mysql') !== false)
-		{
-			$config['db']['master']['engine'] = 'myisam';
-		}
-		
-		if (isset($db_info->slave_db) && count($db_info->slave_db))
-		{
-			foreach ($db_info->slave_db as $slave_id => $slave_db)
-			{
-				if ($slave_db !== $db_info->master_db)
-				{
-					$slave_id = 'slave' . $slave_id;
-					$config['db'][$slave_id]['type'] = strtolower($slave_db['db_type']);
-					$config['db'][$slave_id]['host'] = $slave_db['db_hostname'];
-					$config['db'][$slave_id]['port'] = $slave_db['db_type'];
-					$config['db'][$slave_id]['user'] = $slave_db['db_userid'];
-					$config['db'][$slave_id]['pass'] = $slave_db['db_password'];
-					$config['db'][$slave_id]['database'] = $slave_db['db_database'];
-					$config['db'][$slave_id]['prefix'] = $slave_db['db_table_prefix'];
-					
-					if (substr($config['db'][$slave_id]['prefix'], -1) !== '_')
-					{
-						$config['db'][$slave_id]['prefix'] .= '_';
-					}
-					
-					$config['db'][$slave_id]['charset'] = $slave_db['db_charset'] ?: 'utf8';
-					
-					if (strpos($config['db'][$slave_id]['type'], 'innodb') !== false)
-					{
-						$config['db'][$slave_id]['type'] = str_replace('_innodb', '', $config['db'][$slave_id]['type']);
-						$config['db'][$slave_id]['engine'] = 'innodb';
-					}
-					elseif (strpos($config['db'][$slave_id]['type'], 'mysql') !== false)
-					{
-						$config['db'][$slave_id]['engine'] = 'myisam';
-					}
-				}
-			}
-		}
-		
-		// Convert cache configuration.
-		if (isset($db_info->use_object_cache))
-		{
-			$config['cache'][] = $db_info->use_object_cache;
-		}
-		
-		// Convert FTP configuration.
-		if (isset($ftp_info))
-		{
-			$config['ftp']['host'] = $ftp_info->ftp_host;
-			$config['ftp']['port'] = $ftp_info->ftp_port;
-			$config['ftp']['path'] = $ftp_info->ftp_root_path;
-			$config['ftp']['user'] = $ftp_info->ftp_user;
-			$config['ftp']['pasv'] = $ftp_info->ftp_pasv;
-			$config['ftp']['sftp'] = $ftp_info->sftp === 'Y' ? true : false;
-		}
-		
-		// Create new crypto keys.
-		$config['crypto']['encryption_key'] = \Password::createSecureSalt(64, 'alnum');
-		$config['crypto']['authentication_key'] = \Password::createSecureSalt(64, 'alnum');
-		$config['crypto']['session_key'] = \Password::createSecureSalt(64, 'alnum');
-		
-		// Convert language configuration.
-		if (isset($db_info->lang_type))
-		{
-			$config['locale']['default_lang'] = str_replace('jp', 'ja', strtolower($db_info->lang_type));
-		}
-		elseif (count($lang_selected))
-		{
-			$config['locale']['default_lang'] = array_first($lang_selected);
-		}
-		$config['locale']['enabled_lang'] = array_values($lang_selected);
-		
-		// Convert timezone configuration.
-		$old_timezone = DateTime::getTimezoneOffsetByLegacyFormat($db_info->time_zone ?: '+0900');
-		switch ($old_timezone)
-		{
-			case 32400:
-				$config['locale']['default_timezone'] = 'Asia/Seoul'; break;
-			default:
-				$config['locale']['default_timezone'] = DateTime::getTimezoneNameByOffset($old_timezone);
-		}
-		$config['locale']['internal_timezone'] = intval(date('Z'));
-		
-		// Convert URL configuration.
-		$default_url = $db_info->default_url;
-		if (strpos($default_url, 'xn--') !== false)
-		{
-			$default_url = \Context::decodeIdna($default_url);
-		}
-		$config['url']['default'] = $default_url ?: \RX_BASEURL;
-		$config['url']['http_port'] = $db_info->http_port ?: null;
-		$config['url']['https_port'] = $db_info->https_port ?: null;
-		$config['url']['ssl'] = $db_info->use_ssl ?: 'none';
-		
-		// Convert session configuration.
-		$config['session']['delay'] = $db_info->delay_session === 'Y' ? true : false;
-		$config['session']['use_db'] = $db_info->use_db_session === 'Y' ? true : false;
-		
-		// Convert view configuration.
-		$config['view']['minify_scripts'] = $db_info->minify_scripts ?: 'common';
-		$config['view']['use_gzip'] = (defined('__OB_GZHANDLER_ENABLE__') && constant('__OB_GZHANDLER_ENABLE__'));
-		
-		// Convert admin IP whitelist.
-		if (isset($db_info->admin_ip_list) && is_array($db_info->admin_ip_list) && count($db_info->admin_ip_list))
-		{
-			$config['admin']['allow'] = array_values($db_info->admin_ip_list);
-		}
-		
-		// Convert sitelock configuration.
-		$config['lock']['locked'] = $db_info->use_sitelock === 'Y' ? true : false;
-		$config['lock']['title'] = strval($db_info->sitelock_title);
-		$config['lock']['message'] = strval($db_info->sitelock_message);
-		if (!is_array($db_info->sitelock_whitelist))
-		{
-			$db_info->sitelock_whitelist = $db_info->sitelock_whitelist ? array_map('trim', explode(',', trim($db_info->sitelock_whitelist))) : array();
-		}
-		if (!in_array('127.0.0.1', $db_info->sitelock_whitelist))
-		{
-			$db_info->sitelock_whitelist[] = '127.0.0.1';
-		}
-		$config['lock']['allow'] = array_values($db_info->sitelock_whitelist);
-		
-		// Convert debug configuration.
-		$config['debug']['enabled'] = true;
-		$config['debug']['log_errors'] = true;
-		$config['debug']['log_queries'] = (\__DEBUG__ & 4) ? true : false;
-		$config['debug']['log_slow_queries'] = floatval(\__LOG_SLOW_QUERY__);
-		$config['debug']['log_slow_triggers'] = floatval(\__LOG_SLOW_TRIGGER__ * 1000);
-		$config['debug']['log_slow_widgets'] = floatval(\__LOG_SLOW_WIDGET__ * 1000);
-		
-		// Convert embed filter configuration.
-		if (is_array($db_info->embed_white_iframe))
-		{
-			$whitelist = array_unique(array_map(function($item) {
-				return preg_match('@^https?://(.*)$@i', $item, $matches) ? $matches[1] : $item;
-			}, $db_info->embed_white_iframe));
-			natcasesort($whitelist);
-			$config['embedfilter']['iframe'] = $whitelist;
-		}
-		if (is_array($db_info->embed_white_object))
-		{
-			$whitelist = array_unique(array_map(function($item) {
-				return preg_match('@^https?://(.*)$@i', $item, $matches) ? $matches[1] : $item;
-			}, $db_info->embed_white_object));
-			natcasesort($whitelist);
-			$config['embedfilter']['object'] = $whitelist;
-		}
-		
-		// Convert miscellaneous configuration.
-		$config['use_mobile_view'] = $db_info->use_mobile_view === 'Y' ? true : false;
-		$config['use_prepared_statements'] = $db_info->use_prepared_statements === 'Y' ? true : false;
-		$config['use_rewrite'] = $db_info->use_rewrite === 'Y' ? true : false;
-		$config['use_sso'] = $db_info->use_sso === 'Y' ? true : false;
-		
-		// Copy other configuration.
-		unset($db_info->master_db, $db_info->slave_db);
-		unset($db_info->lang_type, $db_info->time_zone);
-		unset($db_info->default_url, $db_info->http_port, $db_info->https_port, $db_info->use_ssl);
-		unset($db_info->delay_session, $db_info->use_db_session);
-		unset($db_info->minify_scripts, $db_info->admin_ip_list);
-		unset($db_info->use_sitelock, $db_info->sitelock_title, $db_info->sitelock_message, $db_info->sitelock_whitelist);
-		unset($db_info->embed_white_iframe, $db_info->embed_white_object);
-		unset($db_info->use_object_cache, $db_info->use_mobile_view, $db_info->use_prepared_statements);
-		unset($db_info->use_rewrite, $db_info->use_sso);
-		foreach ($db_info as $key => $value)
-		{
-			$config['other'][$key] = $value;
-		}
-		
-		// Return the new configuration.
-		return $config;
-	}
-	
-	/**
 	 * Save the current system configuration.
 	 * 
 	 * @param array $config (optional)
@@ -380,8 +132,22 @@ class Config
 		{
 			self::setAll($config);
 		}
+		
+		// Save the main config file.
 		$buff = '<?php' . "\n" . '// Rhymix System Configuration' . "\n" . 'return ' . self::serialize(self::$_config) . ';' . "\n";
-		return \FileHandler::writeFile(RX_BASEDIR . 'files/config/config.php', $buff) ? true : false;
+		$result = \FileHandler::writeFile(RX_BASEDIR . self::$config_filename, $buff) ? true : false;
+		//if (!$result) return false;
+		
+		// Save XE-compatible config files.
+		$db_info = \Context::convertDBInfo(self::$_config);
+		$ftp_info = $db_info->ftp_info;
+		$db_info_without_ftp = clone $db_info;
+		unset($db_info_without_ftp->ftp_info);
+		$buff = '<?php' . "\n" . '$db_info = ' . self::serialize($db_info_without_ftp) . ';' . "\n";
+		\FileHandler::writeFile(RX_BASEDIR . self::$old_db_config_filename, $buff);
+		$buff = '<?php' . "\n" . '$ftp_info = ' . self::serialize($ftp_info) . ';' . "\n";
+		\FileHandler::writeFile(RX_BASEDIR . self::$old_ftp_config_filename, $buff);
+		return true;
 	}
 	
 	/**

--- a/common/framework/lang.php
+++ b/common/framework/lang.php
@@ -119,7 +119,7 @@ class Lang
 		}
 		elseif (file_exists("$dir/lang.xml"))
 		{
-			$filename = self::compileXMLtoPHP("$dir/lang.xml", $this->_language === 'ja' ? 'jp' : $this->_language);
+			$filename = Compat\LangParser::compileXMLtoPHP("$dir/lang.xml", $this->_language === 'ja' ? 'jp' : $this->_language);
 		}
 		
 		// Load the language file.
@@ -137,127 +137,6 @@ class Lang
 			$this->_loaded_directories[$dir] = true;
 			$this->_loaded_plugins[$plugin_name] = new \stdClass;
 			return false;
-		}
-	}
-	
-	/**
-	 * Convert a directory of old language files to the RhymiX format.
-	 * 
-	 * @param string $dir
-	 * @param array $xml_langs When converting XML to PHP, only convert these languages. (Optional)
-	 * @return void
-	 */
-	public static function convertDirectory($dir, $xml_langs = array())
-	{
-		if (file_exists("$dir/lang.xml"))
-		{
-			$langs = count($xml_langs) ? $xml_langs : array_keys(self::getSupportedList());
-			foreach ($langs as $lang)
-			{
-				self::compileXMLtoPHP("$dir/lang.xml", $lang === 'ja' ? 'jp' : $lang, "$dir/$lang.php");
-			}
-		}
-		else
-		{
-			$files = glob($dir . '/*.lang.php');
-			foreach ($files as $filename)
-			{
-				$new_filename = preg_replace('/\.lang\.php$/', '.php', str_replace('jp.lang', 'ja.lang', $filename));
-				\FileHandler::rename($filename, $new_filename);
-			}
-		}
-	}
-	
-	/**
-	 * Compile XE-compatible XML lang files into PHP.
-	 * 
-	 * @param string $filename
-	 * @param string $language
-	 * @return string|false
-	 */
-	public static function compileXMLtoPHP($filename, $language, $output_filename = null)
-	{
-		// Check if the cache file already exists.
-		if ($output_filename === null)
-		{
-			$output_filename = RX_BASEDIR . 'files/cache/lang/' . md5($filename) . '.' . $language . '.php';
-			if (file_exists($output_filename) && filemtime($output_filename) > filemtime($filename))
-			{
-				return $output_filename;
-			}
-		}
-		
-		// Load the XML lang file.
-		$xml = @simplexml_load_file($filename);
-		if ($xml === false)
-		{
-			\FileHandler::writeFile($output_filename, '');
-			return false;
-		}
-		
-		// Convert XML to a PHP array.
-		$lang = array();
-		self::_toArray($xml, $lang, $language);
-		unset($xml);
-		
-		// Save the array as a cache file.
-		$buff = "<?php\n";
-		foreach ($lang as $key => $value)
-		{
-			if (is_array($value))
-			{
-				foreach ($value as $subkey => $subvalue)
-				{
-					if (is_array($subvalue))
-					{
-						foreach ($subvalue as $subsubkey => $subsubvalue)
-						{
-							$buff .= '$lang->' . $key . "['$subkey']['$subsubkey']" . ' = ' . var_export($subsubvalue, true) . ";\n";
-						}
-					}
-					else
-					{
-						$buff .= '$lang->' . $key . "['$subkey']" . ' = ' . var_export($subvalue, true) . ";\n";
-					}
-				}
-			}
-			else
-			{
-				$buff .= '$lang->' . $key . ' = ' . var_export($value, true) . ";\n";
-			}
-		}
-		\FileHandler::writeFile($output_filename, $buff);
-		return $output_filename;
-	}
-	
-	/**
-	 * XML to array conversion callback.
-	 * 
-	 * @param array $items
-	 * @return void
-	 */
-	protected static function _toArray($items, &$lang, $language)
-	{
-		foreach ($items as $item)
-		{
-			$name = strval($item['name']);
-			if (count($item->item))
-			{
-				$lang[$name] = array();
-				self::_toArray($item->item, $lang[$name], $language);
-			}
-			else
-			{
-				foreach ($item->value as $value)
-				{
-					$attribs = $value->attributes('xml', true);
-					if (strval($attribs['lang']) === $language)
-					{
-						$lang[$name] = strval($value);
-						break;
-					}
-				}
-			}
 		}
 	}
 	

--- a/modules/install/install.controller.php
+++ b/modules/install/install.controller.php
@@ -236,8 +236,6 @@ class installController extends install
 		
 		// Save the new configuration.
 		Rhymix\Framework\Config::save();
-		$buff = '<?php' . "\n" . '$db_info = ' . Rhymix\Framework\Config::serialize(Context::getDBInfo()) . ';' . "\n";
-		FileHandler::writeFile(Context::getConfigFile(), $buff);
 		
 		// Unset temporary session variables.
 		unset($_SESSION['use_rewrite']);


### PR DESCRIPTION
- 기존 설정 및 기존 XML 언어파일을 새 포맷으로 변환하는 기능을 별도의 클래스로 분리하여, 평소에 불필요한 코드를 로딩하지 않도록 함
- 새 설정 변경시 기존 포맷의 파일도 함께 저장하도록 하여 다운그레이드하는 경우를 배려
- 새 설정의 gzip 압축 옵션을 실제로 DisplayHandler에서 사용하도록 조치