### PR TITLE
RhymiX 설치시 회원가입시 캡차 기능을 활성화

### DIFF
--- a/modules/addon/addon.admin.controller.php
+++ b/modules/addon/addon.admin.controller.php
@@ -227,7 +227,7 @@ class addonAdminController extends addonController
 	 * @param string $isUsed Whether to use
 	 * @return Object
 	 */
-	function doInsert($addon, $site_srl = 0, $gtype = 'site', $isUsed = 'N')
+	function doInsert($addon, $site_srl = 0, $gtype = 'site', $isUsed = 'N', $extra_vars)
 	{
 		$args = new stdClass;
 		$args->addon = $addon;
@@ -236,6 +236,7 @@ class addonAdminController extends addonController
 		{
 			return executeQuery('addon.insertAddon', $args);
 		}
+		$args->extra_vars = serialize($extra_vars);
 		$args->site_srl = $site_srl;
 		return executeQuery('addon.insertSiteAddon', $args);
 	}

--- a/modules/addon/addon.class.php
+++ b/modules/addon/addon.class.php
@@ -25,6 +25,11 @@ class addon extends ModuleObject
 		$oAddonController->doInsert('resize_image', 0, 'site', 'Y');
 		$oAddonController->doInsert('openid_delegation_id');
 		$oAddonController->doInsert('point_level_icon');
+		$args = new stdClass();
+		$args->xe_validator_id = 'module/addon/tpl/setup_addon/1';
+		$args->apply_signup = 'apply';
+		$args->xe_run_method = 'run_selected';
+		$oAddonController->doInsert('captcha_member', 0, 'site', 'Y', $args);
 
 		$oAddonController->makeCacheFile(0);
 		return new Object();

--- a/modules/addon/queries/insertAddon.xml
+++ b/modules/addon/queries/insertAddon.xml
@@ -6,5 +6,6 @@
       <column name="addon" var="addon" notnull="notnull" />
       <column name="is_used" var="is_used" default="N" notnull="notnull" />
       <column name="regdate" var="regdate" default="curdate()" />
+      <column name="extra_vars" var="extra_vars" />
     </columns>
 </query>


### PR DESCRIPTION
Rhymix를 인스톨 할때, 회원가입 캡차 기능을 활성화 합니다.
이렇게 설정하는 이유는 다음과 같습니다.
봇의 스팸성 글이나, 등등은 보통은 대부분 회원가입 공격도 이루어지게 됩니다.
이 공격은 기본 캡차 기능만 On시켜두면, 하루에 몇십개 회원가입 공격을 단 0~1개로 줄일 수 있습니다.
무제한으로 계속적으로 액션을 실행시켜 서버를 부하 시키는 모든 게시글 Insert공격, 회원가입 공격 모두 이것으로 어느정도 해결가능할 것으로 보여집니다.

인스톨하자마자 바로 공격당하는 특유의 (bjrambo.com가 그랫슴..) 사태도 있는만큼 이 부분은 조금 생각해보고 고려할 필요가 있다고 생각되어서 만들어봤습니다.

install실행시에 실행되는 doInsert메소드를 이용해서 해당 메소드에서 extra_var 까지 받도록 하여 설치할 수 있도록 하였습니다.

문제점 확인해보고 이상없으면 머지하도록 하겠습니다 :) 