### PR TITLE
SSL정보를 아에 가져오지 않아 애드온세팅에서 SSL주소로 잡히지 않는 문제점

### DIFF
--- a/classes/context/Context.class.php
+++ b/classes/context/Context.class.php
@@ -472,16 +472,16 @@ class Context
 		{
 			return;
 		}
-		
+
 		// Copy to old format for backward compatibility.
 		self::$_instance->db_info = self::convertDBInfo($config);
 		self::$_instance->allow_rewrite = self::$_instance->db_info->use_rewrite;
-		self::set('_http_port', $db_info->http_port ?: null);
-		self::set('_https_port', $db_info->https_port ?: null);
-		self::set('_use_ssl', $db_info->use_ssl);
-		$GLOBALS['_time_zone'] = $db_info->time_zone;
+		self::set('_http_port', self::$_instance->db_info->http_port ?: null);
+		self::set('_https_port', self::$_instance->db_info->https_port ?: null);
+		self::set('_use_ssl', self::$_instance->db_info->use_ssl);
+		$GLOBALS['_time_zone'] = self::$_instance->db_info->time_zone;
 	}
-	
+
 	/**
 	 * Convert Rhymix configuration to XE DBInfo format
 	 * 


### PR DESCRIPTION
@kijin 님께서 수정하신 Config 관련 이슈 #231 에서 수정하신 부분
`Context::loadDBInfo`메소드에서 `Context::set('_use_ssl');` 및 모든정보가 빈값으로만 나와서 관련 애드온 작동이나 SSL주소를 전혀 사용하지 않던 문제점이 있었습니다. (심지어 주소도 첫접속이 `https://`연결이 전혀 안됬고, 관련 이미지 및 전부 `https://`으로 접속하였더라도 `http://`으로 로드 하고 있었습니다.)

기진곰님이 직접 만드신 것이라.. 사실 기진곰님께서 알아보시고 고치셨어야 했던 부분인데 ㅠ.ㅠ 너무 급하게 업데이트 했는데 SSL이 작동안해서 부...불..법자가 되버릴뻔 한지라 ㅠㅠ 제가 미리 고쳐놓고 일딴 PR올려뒀어요.

이 방법이 맞는지 모르겠지만, 저는 일단 이렇게 고쳐놨습니다.. 기진곰님이 만드시던 기능이니 이 방법이 맞다면 머지 해주세요 :)