### PR TITLE
#243 댓글 갯수 집계 오류 수정 및 DB 커넥션 관리 개선

### DIFF
--- a/classes/db/DB.class.php
+++ b/classes/db/DB.class.php
@@ -999,7 +999,7 @@ class DB
 	 */
 	function _getConnection($type = 'master', $indx = NULL)
 	{
-		if($type == 'master')
+		if($type == 'master' || $this->transactionNestedLevel)
 		{
 			if(!$this->master_db['is_connected'])
 			{
@@ -1014,11 +1014,20 @@ class DB
 			$indx = $this->_getSlaveConnectionStringIndex($type);
 		}
 
+		if($this->slave_db[$indx]['host'] == $this->master_db['host'] && $this->slave_db[$indx]['port'] == $this->master_db['port'])
+		{
+			if(!$this->master_db['is_connected'])
+			{
+				$this->_connect($type);
+			}
+			$this->connection = 'Master ' . $this->master_db['host'];
+			return $this->master_db["resource"];
+		}
+		
 		if(!$this->slave_db[$indx]['is_connected'])
 		{
 			$this->_connect($type, $indx);
 		}
-
 		$this->connection = 'Slave ' . $this->slave_db[$indx]['host'];
 		return $this->slave_db[$indx]["resource"];
 	}
@@ -1271,7 +1280,7 @@ class DB
 		{
 			$connection = &$this->slave_db[$indx];
 		}
-
+		
 		$result = $this->__connect($connection);
 		if($result === NULL || $result === FALSE)
 		{


### PR DESCRIPTION
#243 댓글 갯수 집계 오류의 원인은 아래와 같습니다.

1. 트랜잭션 시작
2. 새 댓글을 저장하거나 기존 댓글을 삭제함
3. 해당 문서의 댓글 갯수를 다시 셈
4. 문서의 `comment_count`를 업데이트
5. 트랜잭션 커밋

이 때 1, 2, 4, 5단계는 쓰기 쿼리이므로 마스터 DB에서 실행되는데, 3단계는 읽기 쿼리이므로 슬레이브 DB에서 실행됩니다. 마스터 DB의 트랜잭션이 아직 종료되지 않았으므로 슬레이브 DB에서 새 댓글을 볼 수 없습니다. 그래서 트랜잭션을 지원하는 InnoDB 환경에서는 일관성 없는 결과가 나오게 됩니다. 특히 첫 번째 댓글이 증발하는 것처럼 보이는 이유는 `comment_count = 0`인 경우 스킨에서 아예 댓글을 불러오지 않기 때문입니다.

### 해결책

- 트랜잭션이 진행중인 경우 읽기 쿼리라도 무조건 마스터 DB에서 실행하도록 변경
- 마스터 DB와 슬레이브 DB가 같은 경우 슬레이브 DB를 사용하지 않도록 변경 (아마 이 기능이 얼마 전 리팩토링 과정에서 지워졌던 모양입니다.)
