### PR TITLE
애드온이 중요한 변수를 함부로 덮어쓰지 못하도록 조치

### DIFF
--- a/classes/display/DisplayHandler.class.php
+++ b/classes/display/DisplayHandler.class.php
@@ -60,12 +60,17 @@ class DisplayHandler extends Handler
 
 		// call a trigger before display
 		ModuleHandler::triggerCall('display', 'before', $output);
-		
+		$original_output = $output;
+
 		// execute add-on
 		$called_position = 'before_display_content';
 		$oAddonController = getController('addon');
 		$addon_file = $oAddonController->getCacheFilePath(Mobile::isFromMobilePhone() ? "mobile" : "pc");
 		if(file_exists($addon_file)) include($addon_file);
+		if($output === false || $output === null)
+		{
+			$output = $original_output;
+		}
 
 		if(method_exists($handler, "prepareToPrint"))
 		{

--- a/classes/display/DisplayHandler.class.php
+++ b/classes/display/DisplayHandler.class.php
@@ -67,7 +67,7 @@ class DisplayHandler extends Handler
 		$oAddonController = getController('addon');
 		$addon_file = $oAddonController->getCacheFilePath(Mobile::isFromMobilePhone() ? "mobile" : "pc");
 		if(file_exists($addon_file)) include($addon_file);
-		if($output === false || $output === null)
+		if($output === false || $output === null || $output instanceof Object)
 		{
 			$output = $original_output;
 		}

--- a/classes/module/ModuleObject.class.php
+++ b/classes/module/ModuleObject.class.php
@@ -447,6 +447,18 @@ class ModuleObject extends Object
 			return FALSE;
 		}
 
+		// check return value of action
+		if($output instanceof Object)
+		{
+			$this->setError($output->getError());
+			$this->setMessage($output->getMessage());
+			$original_output = clone $output;
+		}
+		else
+		{
+			$original_output = null;
+		}
+
 		// trigger call
 		$triggerOutput = ModuleHandler::triggerCall('moduleObject.proc', 'after', $this);
 		if(!$triggerOutput->toBool())
@@ -462,16 +474,17 @@ class ModuleObject extends Object
 		$addon_file = $oAddonController->getCacheFilePath(Mobile::isFromMobilePhone() ? "mobile" : "pc");
 		if(FileHandler::exists($addon_file)) include($addon_file);
 
-		if(is_a($output, 'Object') || is_subclass_of($output, 'Object'))
+		if($original_output instanceof Object && !$original_output->toBool())
+		{
+			return FALSE;
+		}
+		elseif($output instanceof Object && $output->getError())
 		{
 			$this->setError($output->getError());
 			$this->setMessage($output->getMessage());
-
-			if(!$output->toBool())
-			{
-				return FALSE;
-			}
+			return FALSE;
 		}
+
 		// execute api methods of the module if view action is and result is XMLRPC or JSON
 		if($this->module_info->module_type == 'view' || $this->module_info->module_type == 'mobile')
 		{


### PR DESCRIPTION
#235 와 비슷한 문제의 재발을 막기 위한 PR입니다.

`after_module_proc` 및 `before_display_content` 시점에 실행되는 애드온은 `$output`이라는 로컬 변수에 접근할 수 있게 됩니다. 그런데 XE에서 쿼리를 실행할 때도 흔히 `$output`이라는 변수를 사용하기 때문에, 쿼리를 사용하는 애드온은 실수로 `$output`을 덮어써 버릴 위험이 있습니다.

`after_module_proc` 시점에서 `$output`을 덮어쓰면 #235 와 같이 모듈에서 반환한 에러 메시지가 증발하는 문제가 생깁니다.

`before_display_content` 시점에서 `$output`을 덮어쓰면 백지 현상이 발생합니다.

이 PR에서는 위의 두 시점에서 애드온 실행 후 `$output` 변수의 상태를 점검하여, 모듈에서 반환한 에러 메시지를 덮어쓰거나 화면에 출력할 내용을 `false`, `null`, `Object` 객체 등 무의미한 내용으로 덮어쓴 경우 원래의 값을 복구하도록 하였습니다. 액션 실행 후 아무 반응이 없거나 화면이 백지로 보이는 등, 사용하는 애드온의 조합에 따라 재현이 쉽지 않은 문제들이 이 PR로 어느 정도는 해결될 것으로 보입니다. (단, 모듈에서는 에러를 반환하지 않았는데 애드온에서 의도적으로 에러를 반환하는 경우에는 그대로 인정합니다.)