### PR TITLE
닉네임 변경을 기록하지 않을경우 회원메뉴를 추가하지 않도록 개선

### DIFF
--- a/modules/member/member.controller.php
+++ b/modules/member/member.controller.php
@@ -1845,6 +1845,7 @@ class memberController extends member
 	function setSessionInfo()
 	{
 		$oMemberModel = getModel('member');
+		$config = $oMemberModel->getMemberConfig();
 		// If your information came through the current session information to extract information from the users
 		if(!$this->memberInfo && $_SESSION['member_srl'] && $oMemberModel->isLogged() )
 		{
@@ -1891,7 +1892,10 @@ class memberController extends member
 		$this->addMemberMenu( 'dispMemberScrappedDocument', 'cmd_view_scrapped_document');
 		$this->addMemberMenu( 'dispMemberSavedDocument', 'cmd_view_saved_document');
 		$this->addMemberMenu( 'dispMemberOwnDocument', 'cmd_view_own_document');
-		$this->addMemberMenu( 'dispMemberModifyNicknameLog', 'cmd_modify_nickname_log');
+		if($config->update_nick_log == 'Y')
+		{
+			$this->addMemberMenu( 'dispMemberModifyNicknameLog', 'cmd_modify_nickname_log');
+		}
 	}
 
 	/**


### PR DESCRIPTION
#266 닉네임 변경을 기록하지 않는 옵션을 사용하고 있는데, 회원 메뉴 목록에서 닉네임 변경기록이 나오는 문제점이 있었습니다.

해당 옵션을 읽어들여 옵션에 맞게 노출여부를 정하도록 하였습니다.
