### PR TITLE
피라미터가 없어도 오류없도록 고침

### DIFF
--- a/modules/communication/communication.model.php
+++ b/modules/communication/communication.model.php
@@ -233,7 +233,7 @@ class communicationModel extends communication
 		return $message;
 	}
 
-	function getNewMessageCount($member_srl)
+	function getNewMessageCount($member_srl = null)
 	{
 		if(!$member_srl)
 		{


### PR DESCRIPTION
communication 에서 새로운 쪽지 항목을 검색하는 과정에서 피라미터가 필수여야 했는데, 이를 필수가 아니더라도 오류가 나지 않도록 고쳤습니다.
