### PR TITLE
#275 기본 URL 변경에 따른 오류 해소

### DIFF
--- a/modules/admin/admin.admin.controller.php
+++ b/modules/admin/admin.admin.controller.php
@@ -690,7 +690,7 @@ class adminAdminController extends admin
 		Rhymix\Framework\Config::save();
 		
 		$this->setMessage('success_updated');
-		$this->setRedirectUrl(Context::get('success_return_url') ?: getNotEncodedUrl('', 'act', 'dispAdminConfigAdvanced'));
+		$this->setRedirectUrl(Context::get('success_return_url') ?: $default_url . 'index.php?act=dispAdminConfigAdvanced');
 	}
 	
 	/**


### PR DESCRIPTION
기본 URL을 변경할 경우 발생할 수 있는 #275 "잘못된 요청입니다." 에러의 원인을 제거합니다.

- 기본 URL과 무관하게, 동일한 도메인 내에서의 요청은 항상 허용하도록 `checkCSRF()` 함수 변경 (동일한 도메인 내에서의 요청은 CSRF가 될 수 없음)
- 기본 URL 변경시 변경된 주소로 자동 전달되도록 하여, 예전 URL에 계속 남아서 작업하는 일을 방지

### TODO (별도 이슈로 처리 예정)

- 기본 URL을 변경하기 전에 실제로 같은 사이트인지 확인하는 절차가 필요함
- 변경된 주소로 전달시 관리자 로그인이 풀리지 않도록 조치해야 함