### PR TITLE
비회원의 닉네임이 나타나지 않던 문제점 개선

### DIFF
--- a/modules/document/tpl/document_list.html
+++ b/modules/document/tpl/document_list.html
@@ -46,13 +46,14 @@ xe.lang.msg_empty_search_keyword = '{$lang->msg_empty_search_keyword}';
 		</thead>
 		<tbody>
 			<tr loop="$document_list => $no, $oDocument">
+
 				<td class="title">
 				<block cond="isset($module_list[$oDocument->get('module_srl')])">
 				<a href="{getUrl('', 'mid', $module_list[$oDocument->get('module_srl')]->mid)}" target="_blank">{$module_list[$oDocument->get('module_srl')]->browser_title}</a> - 
 				</block>
 				<a href="{getUrl('','document_srl',$oDocument->document_srl)}" target="_blank"><!--@if(trim($oDocument->getTitleText()))-->{htmlspecialchars($oDocument->getTitleText())}<!--@else--><em>{$lang->no_title_document}</em><!--@end--></a></td>
 				<td class="nowr">
-					<a href="#popup_menu_area" class="member_{$oDocument->get('member_srl')}" cond="$oDocument->get('member_srl') > 0">{$oDocument->getNickName()}</a>
+					<a href="#popup_menu_area" class="member_{$oDocument->get('member_srl')}" cond="$oDocument->get('member_srl') > 0 || $oDocument->get('member_srl') == 0">{$oDocument->getNickName()}</a>
 					<a href="#popup_menu_area" class="member_{abs($oDocument->get('member_srl'))}" cond="$oDocument->get('member_srl') < 0 && $member_nick_name[abs($oDocument->get('member_srl'))]">({$lang->anonymous}) {$member_nick_name[abs($oDocument->get('member_srl'))]}</a>
 				</td>
 				<td class="nowr">{$oDocument->get('readed_count')}</td>


### PR DESCRIPTION
비회원으로 작성한 글이, 관리자 페이지 내에서 확인을 할 수 없던 문제점이 있었습니다.
익명관련 함수조작으로 인해서 생겨난 부분이네요..

수정조치했습니다. 