### PR TITLE
#286 서드파티 자료의 설정 중 `lang`이라는 이름이 있는 경우 에러 수정

### DIFF
--- a/classes/context/Context.class.php
+++ b/classes/context/Context.class.php
@@ -476,6 +476,7 @@ class Context
 		}
 		if (!count($config))
 		{
+			self::$_instance->db_info = self::$_instance->db_info ?: new stdClass;
 			return;
 		}
 

--- a/classes/context/Context.class.php
+++ b/classes/context/Context.class.php
@@ -222,7 +222,6 @@ class Context
 		
 		// Set global variables for backward compatibility.
 		$GLOBALS['__Context__'] = $this;
-		$GLOBALS['lang'] = &$this->lang;
 		$this->_COOKIE = $_COOKIE;
 		
 		// Set information about the current request.
@@ -299,6 +298,7 @@ class Context
 		$this->lang = Rhymix\Framework\Lang::getInstance($this->lang_type);
 		$this->lang->loadDirectory(RX_BASEDIR . 'common/lang', 'common');
 		$this->lang->loadDirectory(RX_BASEDIR . 'modules/module/lang', 'module');
+		$GLOBALS['lang'] = $this->lang;
 		
 		// set session handler
 		if(self::isInstalled() && config('session.use_db'))
@@ -859,7 +859,7 @@ class Context
 	 * Load language file according to language type
 	 *
 	 * @param string $path Path of the language file
-	 * @return void
+	 * @return bool
 	 */
 	public static function loadLang($path)
 	{
@@ -871,7 +871,16 @@ class Context
 		{
 			$plugin_name = null;
 		}
-		return self::$_instance->lang->loadDirectory($path, $plugin_name);
+		
+		if ($GLOBALS['lang'] instanceof Rhymix\Framework\Lang)
+		{
+			return $GLOBALS['lang']->loadDirectory($path, $plugin_name);
+			return true;
+		}
+		else
+		{
+			return false;
+		}
 	}
 
 	/**
@@ -914,9 +923,9 @@ class Context
 	 */
 	public static function getLang($code)
 	{
-		if (self::$_instance->lang)
+		if ($GLOBALS['lang'] instanceof Rhymix\Framework\Lang)
 		{
-			return self::$_instance->lang->get($code);
+			return $GLOBALS['lang']->get($code);
 		}
 		else
 		{
@@ -929,13 +938,18 @@ class Context
 	 *
 	 * @param string $code Language variable name
 	 * @param string $val `$code`s value
-	 * @return void
+	 * @return bool
 	 */
 	public static function setLang($code, $val)
 	{
-		if (self::$_instance->lang)
+		if ($GLOBALS['lang'] instanceof Rhymix\Framework\Lang)
 		{
-			self::$_instance->lang->set($code, $val);
+			$GLOBALS['lang']->set($code, $val);
+			return true;
+		}
+		else
+		{
+			return false;
 		}
 	}
 

--- a/classes/context/Context.class.php
+++ b/classes/context/Context.class.php
@@ -859,7 +859,7 @@ class Context
 	 * Load language file according to language type
 	 *
 	 * @param string $path Path of the language file
-	 * @return bool
+	 * @return void
 	 */
 	public static function loadLang($path)
 	{
@@ -872,15 +872,13 @@ class Context
 			$plugin_name = null;
 		}
 		
-		if ($GLOBALS['lang'] instanceof Rhymix\Framework\Lang)
+		if (!$GLOBALS['lang'] instanceof Rhymix\Framework\Lang)
 		{
-			return $GLOBALS['lang']->loadDirectory($path, $plugin_name);
-			return true;
+			$GLOBALS['lang'] = Rhymix\Framework\Lang::getInstance(self::$_instance->lang_type ?: config('locale.default_lang') ?: 'ko');
+			$GLOBALS['lang']->loadDirectory(RX_BASEDIR . 'common/lang', 'common');
 		}
-		else
-		{
-			return false;
-		}
+		
+		return $GLOBALS['lang']->loadDirectory($path, $plugin_name);
 	}
 
 	/**
@@ -923,14 +921,13 @@ class Context
 	 */
 	public static function getLang($code)
 	{
-		if ($GLOBALS['lang'] instanceof Rhymix\Framework\Lang)
+		if (!$GLOBALS['lang'] instanceof Rhymix\Framework\Lang)
 		{
-			return $GLOBALS['lang']->get($code);
+			$GLOBALS['lang'] = Rhymix\Framework\Lang::getInstance(self::$_instance->lang_type ?: config('locale.default_lang') ?: 'ko');
+			$GLOBALS['lang']->loadDirectory(RX_BASEDIR . 'common/lang', 'common');
 		}
-		else
-		{
-			return $code;
-		}
+		
+		return $GLOBALS['lang']->get($code);
 	}
 
 	/**
@@ -938,19 +935,17 @@ class Context
 	 *
 	 * @param string $code Language variable name
 	 * @param string $val `$code`s value
-	 * @return bool
+	 * @return void
 	 */
 	public static function setLang($code, $val)
 	{
-		if ($GLOBALS['lang'] instanceof Rhymix\Framework\Lang)
+		if (!$GLOBALS['lang'] instanceof Rhymix\Framework\Lang)
 		{
-			$GLOBALS['lang']->set($code, $val);
-			return true;
+			$GLOBALS['lang'] = Rhymix\Framework\Lang::getInstance(self::$_instance->lang_type ?: config('locale.default_lang') ?: 'ko');
+			$GLOBALS['lang']->loadDirectory(RX_BASEDIR . 'common/lang', 'common');
 		}
-		else
-		{
-			return false;
-		}
+		
+		$GLOBALS['lang']->set($code, $val);
 	}
 
 	/**

--- a/tests/unit/classes/ValidatorTest.php
+++ b/tests/unit/classes/ValidatorTest.php
@@ -1,20 +1,11 @@
 <?php
-require_once _XE_PATH_.'classes/context/Context.class.php';
-require_once _XE_PATH_.'classes/xml/XmlParser.class.php';
-require_once _XE_PATH_.'classes/handler/Handler.class.php';
-require_once _XE_PATH_.'classes/file/FileHandler.class.php';
-require_once _XE_PATH_.'classes/validator/Validator.class.php';
 
 class ValidatorTest extends \Codeception\TestCase\Test
 {
     public function _before()
     {
-        global $lang;
-        if(!$lang) $lang = new stdClass();
-        $lang->filter = new stdClass();
-        $lang->filter->isnull = 'isnull';
-        $lang->filter->outofrange = 'outofrange';
-        $lang->filter->equalto = 'equalto';
+    	$oContext = Context::getInstance();
+    	$oContext->init();
     }
 
     public function testRequired()
@@ -187,7 +178,7 @@ class ValidatorTest extends \Codeception\TestCase\Test
         // javascript
         $vd->setCacheDir(__DIR__ . '/validator');
         $js = $vd->getJsPath();
-        $this->assertFileEquals($js, __DIR__ . '/validator/condition.en.js');
+        $this->assertEquals(trim(file_get_contents(__DIR__ . '/validator/condition.en.js')), trim(file_get_contents($js)));
     }
 
     protected function tearDown()

--- a/tests/unit/classes/validator/condition.en.js
+++ b/tests/unit/classes/validator/condition.en.js
@@ -2,7 +2,20 @@
 v=xe.getApp('validator')[0];if(!v)return;
 
 v.cast('ADD_FILTER',['condition', {'greeting1':{required:true},'greeting2':{'if':[{test:'$greeting1 == \'Hello\'', attr:'required', value:'true'}]}}]);
-v.cast('ADD_MESSAGE',['isnull','isnull']);
-v.cast('ADD_MESSAGE',['outofrange','outofrange']);
-v.cast('ADD_MESSAGE',['equalto','equalto']);
+v.cast('ADD_MESSAGE',['isnull','%s 값은 필수입니다.']);
+v.cast('ADD_MESSAGE',['outofrange','%s의 글자 수를 맞추어 주세요.']);
+v.cast('ADD_MESSAGE',['equalto','%s이(가) 잘못되었습니다.']);
+v.cast('ADD_MESSAGE',['invalid','%s의 값이 올바르지 않습니다.']);
+v.cast('ADD_MESSAGE',['invalid_email','%s의 값은 올바른 메일 주소가 아닙니다.']);
+v.cast('ADD_MESSAGE',['invalid_userid','%s의 값은 영문, 숫자, _만 가능하며 첫 글자는 영문이어야 합니다.']);
+v.cast('ADD_MESSAGE',['invalid_user_id','%s의 값은 영문, 숫자, _만 가능하며 첫 글자는 영문이어야 합니다.']);
+v.cast('ADD_MESSAGE',['invalid_homepage','%s의 형식이 잘못되었습니다.(예: https://www.rhymix.org/)']);
+v.cast('ADD_MESSAGE',['invalid_url','%s의 형식이 잘못되었습니다.(예: https://www.rhymix.org/)']);
+v.cast('ADD_MESSAGE',['invalid_korean','%s의 형식이 잘못되었습니다. 한글로만 입력해야 합니다.']);
+v.cast('ADD_MESSAGE',['invalid_korean_number','%s의 형식이 잘못되었습니다. 한글과 숫자로만 입력해야 합니다.']);
+v.cast('ADD_MESSAGE',['invalid_alpha','%s의 형식이 잘못되었습니다. 영문으로만 입력해야 합니다.']);
+v.cast('ADD_MESSAGE',['invalid_alpha_number','%s의 형식이 잘못되었습니다. 영문과 숫자로만 입력해야 합니다.']);
+v.cast('ADD_MESSAGE',['invalid_mid','%s의 형식이 잘못되었습니다. 첫 글자는 영문으로 시작해야 하며 \'영문+숫자+_\'로만 입력해야 합니다.']);
+v.cast('ADD_MESSAGE',['invalid_number','%s의 형식이 잘못되었습니다. 숫자로만 입력해야 합니다.']);
+v.cast('ADD_MESSAGE',['invalid_extension','%s의 형식이 잘못되었습니다. *.* 나 *.jpg;*.gif; 처럼 입력해야 합니다.']);
 })(jQuery);

--- a/tests/unit/framework/DateTimeTest.php
+++ b/tests/unit/framework/DateTimeTest.php
@@ -77,8 +77,8 @@ class DateTimeTest extends \Codeception\TestCase\Test
 	
 	public function testGetTimeGap()
 	{
-		Context::getInstance()->lang = Rhymix\Framework\Lang::getInstance('en');
-		Context::getInstance()->lang->loadPlugin('common');
+		$GLOBALS['lang'] = Rhymix\Framework\Lang::getInstance('en');
+		$GLOBALS['lang']->loadPlugin('common');
 		
 		// Test getTimeGap() when the internal time zone is different from the default time zone.
 		Rhymix\Framework\Config::set('locale.internal_timezone', 10800);


### PR DESCRIPTION
`Context` 클래스의 기본 속성과 겹치는 `lang`이라는 설정 이름을 사용하면 안 되지만, 억지로 사용하는 서드파티 자료가 있는 경우 (예: #286) XE에서는 그냥 봐주었기 때문에... 라이믹스에서도 봐주는 것으로 바꿉니다.

언어 처리를 위해서는 XE처럼 전역변수 `$GLOBALS['lang']`을 사용하도록 되돌렸으니 `lang`과 관련된 호환성 문제는 더이상 발생하지 않을 것으로 보입니다.