### PR TITLE
PHP 5.3에서 다차원 배열을 제출할 수 없는 문제 수정

### DIFF
--- a/classes/context/Context.class.php
+++ b/classes/context/Context.class.php
@@ -1377,10 +1377,21 @@ class Context
 
 				if($do_stripslashes && version_compare(PHP_VERSION, '5.4.0', '<') && get_magic_quotes_gpc())
 				{
-					$result[$k] = stripslashes($result[$k]);
+					if (is_array($result[$k]))
+					{
+						array_walk_recursive($result[$k], function(&$val) { $val = stripslashes($val); });
+					}
+					else
+					{
+						$result[$k] = stripslashes($result[$k]);
+					}
 				}
 
-				if(!is_array($result[$k]))
+				if(is_array($result[$k]))
+				{
+					array_walk_recursive($result[$k], function(&$val) { $val = trim($val); });
+				}
+				else
 				{
 					$result[$k] = trim($result[$k]);
 				}

--- a/classes/context/Context.class.php
+++ b/classes/context/Context.class.php
@@ -1182,7 +1182,7 @@ class Context
 			{
 				continue;
 			}
-			$key = htmlentities($key);
+			$key = escape($key);
 			$val = $this->_filterRequestVar($key, $val);
 
 			if($requestMethod == 'GET' && isset($_GET[$key]))
@@ -1358,7 +1358,7 @@ class Context
 		$result = array();
 		foreach($val as $k => $v)
 		{
-			$k = htmlentities($k);
+			$k = escape($k);
 			if($key === 'page' || $key === 'cpage' || substr_compare($key, 'srl', -3) === 0)
 			{
 				$result[$k] = !preg_match('/^[0-9,]+$/', $v) ? (int) $v : $v;


### PR DESCRIPTION
PHP 5.3에서 magic quotes를 사용할 경우, 불필요한 백슬래시를 제거하는 과정에서 다차원 배열이 뭉개져 버리는 문제를 수정합니다.

@qw5414 님이 제보해 주셨습니다 ^^