### PR TITLE
DocumentModel에서 페이징 계산 중 0으로 나누는 문제 수정

### DIFF
--- a/modules/document/document.model.php
+++ b/modules/document/document.model.php
@@ -621,7 +621,7 @@ class documentModel extends document
 
 		$this->_setSearchOption($opt, $args, $query_id, $use_division);
 
-		if($sort_check->isExtraVars)
+		if($sort_check->isExtraVars || !$opt->list_count)
 		{
 			return 1;
 		}


### PR DESCRIPTION
`$opt->list_count`가 0인 경우 650번째 줄에서 경고가 나올 수 있습니다.

```
Warning: division by zero 
```