### PR TITLE
#297 회원가입 확장변수가 누락되는 문제 수정

### DIFF
--- a/modules/member/member.admin.view.php
+++ b/modules/member/member.admin.view.php
@@ -631,7 +631,7 @@ class memberAdminView extends member
 					}
 
 					$replace = array_merge($extentionReplace, $replace);
-					$inputTag = preg_replace_callback('@%(\w+)%@', function($n) { return $replace[$n[1]]; }, $template);
+					$inputTag = preg_replace_callback('@%(\w+)%@', function($n) use($replace) { return $replace[$n[1]]; }, $template);
 
 					if($extendForm->description)
 						$inputTag .= '<p class="help-block">'.$extendForm->description.'</p>';


### PR DESCRIPTION
클로져에 `$replace`가 전달되지 않아 확장변수 필드의 name 값이 공백으로 남는 문제를 고칩니다.