### PR TITLE
오래된 lang 파일 로딩 우선순위를 XE와 호환되도록 변경

### DIFF
--- a/common/framework/compat/langparser.php
+++ b/common/framework/compat/langparser.php
@@ -70,7 +70,7 @@ class LangParser
 		unset($xml);
 		
 		// Save the array as a cache file.
-		$buff = "<?php\n";
+		$buff = "<?php\n// $filename\n";
 		foreach ($lang as $key => $value)
 		{
 			if (is_array($value))

--- a/common/framework/lang.php
+++ b/common/framework/lang.php
@@ -102,24 +102,20 @@ class Lang
 		{
 			$filename = $dir . '/' . $this->_language . '.php';
 		}
-		elseif (file_exists($dir . '/' . ($this->_language === 'ja' ? 'jp' : $this->_language) . '.lang.php'))
-		{
-			$filename = $dir . '/' . ($this->_language === 'ja' ? 'jp' : $this->_language) . '.lang.php';
-		}
 		elseif (($hyphen = strpos($this->_language, '-')) !== false)
 		{
 			if (file_exists($dir . '/' . substr($this->_language, 0, $hyphen) . '.php'))
 			{
 				$filename = $dir . '/' . substr($this->_language, 0, $hyphen) . '.php';
 			}
-			elseif (file_exists($dir . '/' . substr($this->_language, 0, $hyphen) . '.lang.php'))
-			{
-				$filename = $dir . '/' . substr($this->_language, 0, $hyphen) . '.lang.php';
-			}
 		}
 		elseif (file_exists("$dir/lang.xml"))
 		{
 			$filename = Compat\LangParser::compileXMLtoPHP("$dir/lang.xml", $this->_language === 'ja' ? 'jp' : $this->_language);
+		}
+		elseif (file_exists($dir . '/' . ($this->_language === 'ja' ? 'jp' : $this->_language) . '.lang.php'))
+		{
+			$filename = $dir . '/' . ($this->_language === 'ja' ? 'jp' : $this->_language) . '.lang.php';
 		}
 		
 		// Load the language file.


### PR DESCRIPTION
XE 초창기 방식인 `ko.lang.php` 언어파일과 비교적 최근 방식인 `lang.xml` 파일이 한 폴더에 같이 있는 경우, XE에서는 `lang.xml`을 먼저 로딩하고 `ko.lang.php`를 로딩하지만 라이믹스에서는 순서가 거꾸로였습니다.

대부분의 자료에서는 아무 차이도 없지만, `ko.lang.php`와 `lang.xml`의 내용이 서로 다르면 문제가 일어나더군요. #277 

라이믹스에서 새로 도입한 `ko.php` 방식의 언어파일은 여전히 최우선순위에 배치합니다.