### PR TITLE
호환되지 않거나 불필요한 애드온과 모듈의 실행을 방지

### DIFF
--- a/addons/member_communication/conf/info.xml
+++ b/addons/member_communication/conf/info.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon version="0.2">
-    <title xml:lang="ko">[DEPRECATED] 커뮤니케이션</title>
-    <title xml:lang="jp">[DEPRECATED] コミュニケーション</title>
-    <title xml:lang="zh-CN">[DEPRECATED] 会员交流</title>
-    <title xml:lang="en">[DEPRECATED] Communication</title>
-    <title xml:lang="vi">[DEPRECATED] Truyền thông</title>
-    <title xml:lang="ge">[DEPRECATED] Communication</title>
-    <title xml:lang="es">[DEPRECATED] Communication</title>
-    <title xml:lang="ru">[DEPRECATED] Общение</title>
-    <title xml:lang="zh-TW">[DEPRECATED] 交流</title>
+    <title xml:lang="ko">커뮤니케이션</title>
+    <title xml:lang="jp">コミュニケーション</title>
+    <title xml:lang="zh-CN">会员交流</title>
+    <title xml:lang="en">Communication</title>
+    <title xml:lang="vi">Truyền thông</title>
+    <title xml:lang="ge">Communication</title>
+    <title xml:lang="es">Communication</title>
+    <title xml:lang="ru">Общение</title>
+    <title xml:lang="zh-TW">交流</title>
     <description xml:lang="ko">
-        [DEPRECATED] 이 애드온은 빈 애드온입니다. 모든 기능은 커뮤니케이션 모듈로 이전되었습니다.
+        이 애드온은 빈 애드온입니다. 모든 기능은 커뮤니케이션 모듈로 이전되었습니다.
     </description>
     <version>1.7</version>
     <date>2013-11-27</date>

--- a/classes/context/Context.class.php
+++ b/classes/context/Context.class.php
@@ -158,6 +158,11 @@ class Context
 	public $isSuccessInit = TRUE;
 
 	/**
+	 * Plugin blacklist cache
+	 */
+	private static $_blacklist = null;
+
+	/**
 	 * Singleton instance
 	 * @var object
 	 */
@@ -2564,6 +2569,26 @@ class Context
 	public static function isAllowRewrite()
 	{
 		return self::$_instance->allow_rewrite;
+	}
+
+	/**
+	 * Check whether an addon, module, or widget is blacklisted
+	 * 
+	 * @param string $plugin_name
+	 * @return bool
+	 */
+	public static function isBlacklistedPlugin($plugin_name)
+	{
+		if (self::$_blacklist === null)
+		{
+			self::$_blacklist = (include RX_BASEDIR . 'common/defaults/blacklist.php');
+			if (!is_array(self::$_blacklist))
+			{
+				self::$_blacklist = array();
+			}
+		}
+		
+		return isset(self::$_blacklist[$plugin_name]);
 	}
 
 	/**

--- a/classes/module/ModuleHandler.class.php
+++ b/classes/module/ModuleHandler.class.php
@@ -1191,6 +1191,12 @@ class ModuleHandler extends Handler
 			$type = $item->type;
 			$called_method = $item->called_method;
 
+			// do not call if module is blacklisted
+			if (Context::isBlacklistedPlugin($module))
+			{
+				continue;
+			}
+
 			// todo why don't we call a normal class object ?
 			$oModule = getModule($module, $type);
 			if(!$oModule || !method_exists($oModule, $called_method))

--- a/common/defaults/blacklist.php
+++ b/common/defaults/blacklist.php
@@ -1,0 +1,11 @@
+<?php
+
+/**
+ * Rhymix Default Blacklist for Deprecated Plugins
+ * 
+ * Copyright (c) Rhymix Developers and Contributors
+ */
+return array(
+	'member_communication' => true,
+	'zipperupper' => true,
+);

--- a/common/defaults/blacklist.php
+++ b/common/defaults/blacklist.php
@@ -7,5 +7,6 @@
  */
 return array(
 	'member_communication' => true,
+	'smartphone' => true,
 	'zipperupper' => true,
 );

--- a/modules/addon/addon.admin.model.php
+++ b/modules/addon/addon.admin.model.php
@@ -46,13 +46,23 @@ class addonAdminModel extends addon
 		$oAutoinstallModel = getModel('autoinstall');
 		foreach($addonList as $key => $addon)
 		{
+			// check blacklist
+			$addonList[$key]->isBlacklisted = Context::isBlacklistedPlugin($addon->addon);
+			
 			// get easyinstall remove url
 			$packageSrl = $oAutoinstallModel->getPackageSrlByPath($addon->path);
 			$addonList[$key]->remove_url = $oAutoinstallModel->getRemoveUrlByPackageSrl($packageSrl);
 
 			// get easyinstall need update
-			$package = $oAutoinstallModel->getInstalledPackages($packageSrl);
-			$addonList[$key]->need_update = $package[$packageSrl]->need_update;
+			if($addonList[$key]->isBlacklisted)
+			{
+				$addonList[$key]->need_update = 'N';
+			}
+			else
+			{
+				$package = $oAutoinstallModel->getInstalledPackages($packageSrl);
+				$addonList[$key]->need_update = $package[$packageSrl]->need_update;
+			}
 
 			// get easyinstall update url
 			if($addonList[$key]->need_update == 'Y')

--- a/modules/addon/addon.class.php
+++ b/modules/addon/addon.class.php
@@ -19,7 +19,6 @@ class addon extends ModuleObject
 		$oAddonController = getAdminController('addon');
 		$oAddonController->doInsert('autolink', 0, 'site', 'Y');
 		$oAddonController->doInsert('blogapi');
-		$oAddonController->doInsert('member_communication', 0, 'site', 'Y');
 		$oAddonController->doInsert('member_extra_info', 0, 'site', 'Y');
 		$oAddonController->doInsert('mobile', 0, 'site', 'Y');
 		$oAddonController->doInsert('resize_image', 0, 'site', 'Y');

--- a/modules/addon/addon.controller.php
+++ b/modules/addon/addon.controller.php
@@ -84,7 +84,7 @@ class addonController extends addon
 		$addon_list = $oAddonModel->getInsertedAddons($site_srl, $gtype);
 		foreach($addon_list as $addon => $val)
 		{
-			if($val->addon == "smartphone"
+			if($val->addon == "smartphone" || Context::isBlacklistedPlugin($addon)
 				|| ($type == "pc" && $val->is_used != 'Y') 
 				|| ($type == "mobile" && $val->is_used_m != 'Y') 
 				|| ($gtype == 'global' && $val->is_fixed != 'Y')

--- a/modules/addon/addon.controller.php
+++ b/modules/addon/addon.controller.php
@@ -1,4 +1,4 @@
-s<?php
+<?php
 /* Copyright (C) NAVER <http://www.navercorp.com> */
 
 /**

--- a/modules/addon/addon.controller.php
+++ b/modules/addon/addon.controller.php
@@ -1,4 +1,4 @@
-<?php
+s<?php
 /* Copyright (C) NAVER <http://www.navercorp.com> */
 
 /**
@@ -84,7 +84,7 @@ class addonController extends addon
 		$addon_list = $oAddonModel->getInsertedAddons($site_srl, $gtype);
 		foreach($addon_list as $addon => $val)
 		{
-			if($val->addon == "smartphone" || Context::isBlacklistedPlugin($addon)
+			if(Context::isBlacklistedPlugin($addon)
 				|| ($type == "pc" && $val->is_used != 'Y') 
 				|| ($type == "mobile" && $val->is_used_m != 'Y') 
 				|| ($gtype == 'global' && $val->is_fixed != 'Y')

--- a/modules/addon/tpl/addon_list.html
+++ b/modules/addon/tpl/addon_list.html
@@ -34,23 +34,29 @@
 		<tbody>
 			<tr loop="$addon_list => $addon">
 				<td class="title">
-					<p><strong>{$addon->title}</strong></p>
+					<p><strong style="color:#aaa"|cond="$addon->isBlacklisted">{$addon->title}</strong></p>
 					<p>{$addon->description}</p>
 					<p cond="$addon->need_update == 'Y'" class="update">
 						{$lang->msg_avail_easy_update} <a href="{$addon->update_url}&amp;return_url={urlencode(getRequestUriByServerEnviroment())}">{$lang->msg_do_you_like_update}</a>
 					</p>
 				</td>
-				<td>{$addon->version}</td>
+				<td><span style="color:#aaa"|cond="$addon->isBlacklisted">{$addon->version}</span></td>
 				<td class="nowr">
 					<block loop="$addon->author => $author">
 						<a cond="$author->homepage" href="{$author->homepage}" target="_blank">{$author->name}</a>
 						<block cond="!$author->homepage">{$author->name}</block>
 					</block>
 				</td>
-				<td>{$addon->path}</td>
-				<td><a href="{getUrl('act', 'dispAddonAdminSetup', 'selected_addon', $addon->addon_name)}">{$lang->cmd_setup}</a></td>
-				<td><input type="checkbox" name="pc_on[]" title="PC" value="{htmlspecialchars($addon->addon_name, ENT_COMPAT | ENT_HTML401, 'UTF-8', false)}" checked="checked"|cond="$addon->activated" /></td>
-				<td><input type="checkbox" name="mobile_on[]" title="Mobile" value="{htmlspecialchars($addon->addon_name, ENT_COMPAT | ENT_HTML401, 'UTF-8', false)}" checked="checked"|cond="$addon->mactivated" /></td>
+				<td><span style="color:#aaa"|cond="$addon->isBlacklisted">{$addon->path}</span></td>
+				<td>
+					<!--@if($addon->isBlacklisted)-->
+						<span style="color:#aaa">{$lang->cmd_setup}</span>
+					<!--@else-->
+						<a href="{getUrl('act', 'dispAddonAdminSetup', 'selected_addon', $addon->addon_name)}">{$lang->cmd_setup}</a>
+					<!--@end-->
+				</td>
+				<td><input type="checkbox" name="pc_on[]" title="PC" value="{htmlspecialchars($addon->addon_name, ENT_COMPAT | ENT_HTML401, 'UTF-8', false)}" checked="checked"|cond="$addon->activated && !$addon->isBlacklisted" disabled="disabled"|cond="$addon->isBlacklisted" /></td>
+				<td><input type="checkbox" name="mobile_on[]" title="Mobile" value="{htmlspecialchars($addon->addon_name, ENT_COMPAT | ENT_HTML401, 'UTF-8', false)}" checked="checked"|cond="$addon->mactivated && !$addon->isBlacklisted" disabled="disabled"|cond="$addon->isBlacklisted" /></td>
 				<td><a cond="$addon->remove_url" href="{$addon->remove_url}&amp;return_url={urlencode(getRequestUriByServerEnviroment())}">{$lang->cmd_delete}</a></td>
 			</tr>
 		</tbody>


### PR DESCRIPTION
회원 모듈에 통합된 `member_communication` 애드온을 비롯하여, 더이상 필요하지 않거나 라이믹스의 새 기능과 충돌할 위험이 있으나 서버에 여전히 설치되어 있는 서드파티 자료의 실행을 방지하기 위한 "블랙리스트" 기능을 추가했습니다.

우선 `member_communication` 애드온과 `zipperupper` 서드파티 애드온을 블랙리스트에 등록해 보았습니다. (후자는 라이믹스의 CSS/JS 자동 압축 기능과 충돌할 위험이 있어서...)

블랙리스트에 등록된 애드온은 설정 화면에서 선택할 수도 없고, 선택하더라도 실행되지 않습니다. 블랙리스트에 등록된 모듈은 우선 트리거만 제외시키는 것으로 해두었습니다. 라이믹스 전환에 불편이 없도록 배려하면서, 제외되는 기능을 점점 추가해 나갈 예정입니다.