### PR TITLE
댓글 작성시 "등록되었습니다." alert이 뜨는 문제 수정

### DIFF
--- a/classes/display/VirtualXMLDisplayHandler.php
+++ b/classes/display/VirtualXMLDisplayHandler.php
@@ -39,8 +39,9 @@ class VirtualXMLDisplayHandler
 		}
 
 		$html = array();
-		$html[] = '<script type="text/javascript">';
-		$html[] = '//<![CDATA[';
+		$html[] = '<html>';
+		$html[] = '<head>';
+		$html[] = '<script>';
 
 		if($output->message)
 		{
@@ -49,12 +50,17 @@ class VirtualXMLDisplayHandler
 
 		if($output->url)
 		{
-			$url = preg_replace('/#(.+)$/', '', $output->url);
-			$html[] = 'self.location.href = "' . $request_url . 'common/tpl/redirect.html?redirect_url=' . urlencode($url) . '";';
+			$output->url = preg_replace('/#(.+)$/', '', $output->url);
+			$html[] = 'if (opener) {';
+			$html[] = '  opener.location.href = ' . json_encode($output->url) . ';';
+			$html[] = '} else {';
+			$html[] = '  parent.location.href = ' . json_encode($output->url) . ';';
+			$html[] = '}';
 		}
-		$html[] = '//]]>';
+		
 		$html[] = '</script>';
-
+		$html[] = '</head><body></body></html>';
+		
 		return join(PHP_EOL, $html);
 	}
 

--- a/classes/display/VirtualXMLDisplayHandler.php
+++ b/classes/display/VirtualXMLDisplayHandler.php
@@ -24,11 +24,6 @@ class VirtualXMLDisplayHandler
 
 		if($error === 0)
 		{
-			if($message != 'success')
-			{
-				$output->message = $message;
-			}
-
 			if($redirect_url)
 			{
 				$output->url = $redirect_url;
@@ -40,10 +35,7 @@ class VirtualXMLDisplayHandler
 		}
 		else
 		{
-			if($message != 'fail')
-			{
-				$output->message = $message;
-			}
+			$output->message = $message;
 		}
 
 		$html = array();
@@ -52,12 +44,12 @@ class VirtualXMLDisplayHandler
 
 		if($output->message)
 		{
-			$html[] = 'alert("' . $output->message . '");';
+			$html[] = 'alert(' . json_encode($output->message) . ');';
 		}
 
 		if($output->url)
 		{
-			$url = preg_replace('/#(.+)$/i', '', $output->url);
+			$url = preg_replace('/#(.+)$/', '', $output->url);
 			$html[] = 'self.location.href = "' . $request_url . 'common/tpl/redirect.html?redirect_url=' . urlencode($url) . '";';
 		}
 		$html[] = '//]]>';

--- a/common/js/xml_handler.js
+++ b/common/js/xml_handler.js
@@ -134,11 +134,13 @@
 			// Hide the waiting message and display an error notice.
 			clearTimeout(wfsr_timeout);
 			waiting_obj.hide().trigger("cancel_confirm");
+			var error_info;
+			
 			if ($(".x_modal-body").size()) {
-				var error_info = xhr.status + " " + xhr.statusText + " (" + textStatus + ")" + "<br><br><pre>" + xhr.responseText + "</pre>";
+				error_info = xhr.status + " " + xhr.statusText + " (" + textStatus + ")" + "<br><br><pre>" + xhr.responseText + "</pre>";
 				alert("AJAX communication error while requesting " + params.module + "." + params.act + "<br><br>" + error_info);
 			} else {
-				var error_info = xhr.status + " " + xhr.statusText + " (" + textStatus + ")" + "\n\n" + xhr.responseText;
+				error_info = xhr.status + " " + xhr.statusText + " (" + textStatus + ")" + "\n\n" + xhr.responseText;
 				alert("AJAX communication error while requesting " + params.module + "." + params.act + "\n\n" + error_info);
 			}
 		};
@@ -232,8 +234,15 @@
 		var errorHandler = function(xhr, textStatus) {
 			clearTimeout(wfsr_timeout);
 			waiting_obj.hide().trigger("cancel_confirm");
-			var error_info = xhr.status + " " + xhr.statusText + " (" + textStatus + ")";
-			alert("AJAX communication error while requesting " + params.module + "." + params.act + "\n\n" + error_info);
+			var error_info;
+			
+			if ($(".x_modal-body").size()) {
+				error_info = xhr.status + " " + xhr.statusText + " (" + textStatus + ")" + "<br><br><pre>" + xhr.responseText + "</pre>";
+				alert("AJAX communication error while requesting " + params.module + "." + params.act + "<br><br>" + error_info);
+			} else {
+				error_info = xhr.status + " " + xhr.statusText + " (" + textStatus + ")" + "\n\n" + xhr.responseText;
+				alert("AJAX communication error while requesting " + params.module + "." + params.act + "\n\n" + error_info);
+			}
 		};
 		
 		// Send the AJAX request.


### PR DESCRIPTION
버그 리포트: https://www.xetown.com/qna/201149

`$error`가 0이면 당연히 성공이고, 성공 메시지는 `success`, `success_registed`, `success_updated` 등 다양하게 있을 수 있는데, `success`가 아니면 무조건 알럿창을 띄우도록 해둔 코드를 변경합니다.

반대로, `$error`가 0이 아닌 경우에는 당연히 에러 상황이므로 에러 메시지가 `fail`이든 아니든 항상 알럿창을 띄우도록 변경합니다.

아울러, redirect.html을 경유하여 2번 리디렉트하는 것을 1번으로 줄입니다.
