### PR TITLE
XML/JSON 반환 포맷의 XE 호환성 개선

### DIFF
--- a/classes/display/JSONDisplayHandler.php
+++ b/classes/display/JSONDisplayHandler.php
@@ -30,6 +30,10 @@ class JSONDisplayHandler
 	{
 		foreach ($array as $key => &$value)
 		{
+			if (is_object($value))
+			{
+				$value = get_object_vars($value);
+			}
 			if (is_array($value))
 			{
 				self::_convertCompat($value, $compat_type);

--- a/classes/display/JSONDisplayHandler.php
+++ b/classes/display/JSONDisplayHandler.php
@@ -15,20 +15,37 @@ class JSONDisplayHandler
 		$variables['error'] = $oModule->getError();
 		$variables['message'] = $oModule->getMessage();
 		
-		$temp = array();
-		foreach ($variables as $key => $value)
+		self::_convertCompat($variables, Context::getRequestMethod());
+		return json_encode($variables);
+	}
+	
+	/**
+	 * Convert arrays in a format that is compatible with XE.
+	 * 
+	 * @param array $array
+	 * @param string $compat_type
+	 * @return array
+	 */
+	protected static function _convertCompat(&$array, $compat_type = 'JSON')
+	{
+		foreach ($array as $key => &$value)
 		{
-			if (self::_isNumericArray($value))
+			if (is_array($value))
 			{
-				$temp[$key] = array_values($value);
-			}
-			else
-			{
-				$temp[$key] = $value;
+				self::_convertCompat($value, $compat_type);
+				if (self::_isNumericArray($value))
+				{
+					if ($compat_type === 'XMLRPC')
+					{
+						$value = array('item' => array_values($value));
+					}
+					else
+					{
+						$value = array_values($value);
+					}
+				}
 			}
 		}
-		
-		return json_encode($temp);
 	}
 	
 	/**

--- a/common/js/xml_handler.js
+++ b/common/js/xml_handler.js
@@ -69,11 +69,7 @@
 			var result = {};
 			$.each(data, function(key, val) {
 				if ($.inArray(key, ["error", "message", "act", "redirect_url"]) >= 0 || $.inArray(key, return_fields) >= 0) {
-					if ($.isArray(val)) {
-						result[key] = { item: val };
-					} else {
-						result[key] = val;
-					}
+					result[key] = val;
 				}
 			});
 			


### PR DESCRIPTION
라이믹스에서는 PHP 5 이상 버전에 내장된 `json_encode()` 함수를 사용하여 JSON 처리의 성능과 정확성을 향상시켰는데, 이게 PHP 4 시절에 만들어진 XE의 기존 JSON 인코딩 함수와 미묘한 차이가 있어서 그동안 서드파티 자료와의 호환성에 다소 문제가 있었습니다.

예를 들어 XE에서는 숫자 키가 연속되지 않더라도 인덱스 배열로 취급하여 `[]` 문법으로 인코딩했지만 `json_encode()` 함수에서는 연관 배열로 취급하여 `{}` 문법으로 인코딩하고, XMLRPC 요청인 경우 XE에서는 모든 인덱스 배열에 `item`이라는 속성을 기본으로 추가해 주었지만 라이믹스에서는 다차원 배열인 경우 최상위 차원에만 추가되고 하위 차원에서는 `item` 속성을 사용할 수 없었습니다.

이러한 문제를 모두 해결하기 위해, 다차원 배열을 처리할 때도 XE와 100% 호환되는 방식으로 JSON 인코딩을 하도록 변경합니다.