### PR TITLE
임시저장시 익명 설정이 반영되지 않던 문제점을 고칩니다.

### DIFF
--- a/modules/document/document.controller.php
+++ b/modules/document/document.controller.php
@@ -524,7 +524,6 @@ class documentController extends document
 			$obj->member_srl = -1*$logged_info->member_srl;
 			$obj->email_address = $obj->homepage = $obj->user_id = '';
 			$obj->user_name = $obj->nick_name = 'anonymous';
-			debugPrint($obj);
 		}
 
 		$document_config = $oModuleModel->getModulePartConfig('document', $module_srl);

--- a/modules/document/document.controller.php
+++ b/modules/document/document.controller.php
@@ -517,6 +517,16 @@ class documentController extends document
 		$oModuleModel = getModel('module');
 		if(!$obj->module_srl) $obj->module_srl = $source_obj->get('module_srl');
 		$module_srl = $obj->module_srl;
+		$module_info = $oModuleModel->getModuleInfoByModuleSrl($module_srl);
+		if($module_info->use_anonymous == 'Y')
+		{
+			$obj->notify_message = 'N';
+			$obj->member_srl = -1*$logged_info->member_srl;
+			$obj->email_address = $obj->homepage = $obj->user_id = '';
+			$obj->user_name = $obj->nick_name = 'anonymous';
+			debugPrint($obj);
+		}
+
 		$document_config = $oModuleModel->getModulePartConfig('document', $module_srl);
 		if(!$document_config)
 		{
@@ -588,7 +598,7 @@ class documentController extends document
 			$obj->password = getModel('member')->hashPassword($obj->password);
 		}
 		// If an author is identical to the modifier or history is used, use the logged-in user's information.
-		if(Context::get('is_logged'))
+		if(Context::get('is_logged') && $module_info->use_anonymous != 'Y')
 		{
 			$logged_info = Context::get('logged_info');
 			if($source_obj->get('member_srl')==$logged_info->member_srl)

--- a/modules/document/document.controller.php
+++ b/modules/document/document.controller.php
@@ -518,13 +518,6 @@ class documentController extends document
 		if(!$obj->module_srl) $obj->module_srl = $source_obj->get('module_srl');
 		$module_srl = $obj->module_srl;
 		$module_info = $oModuleModel->getModuleInfoByModuleSrl($module_srl);
-		if($module_info->use_anonymous == 'Y')
-		{
-			$obj->notify_message = 'N';
-			$obj->member_srl = -1*$logged_info->member_srl;
-			$obj->email_address = $obj->homepage = $obj->user_id = '';
-			$obj->user_name = $obj->nick_name = 'anonymous';
-		}
 
 		$document_config = $oModuleModel->getModulePartConfig('document', $module_srl);
 		if(!$document_config)


### PR DESCRIPTION
#313 
임시 저장할 경우 익명 설정을 반영하지 않던 문제점이 있었습니다.
이 문제점을 확인 해보니, 임시저장시에는 일단 익명설정없이 모든 정보를 입력 하는 과정인듯 합니다.

그래서 documentUpdate 뒷부분 확인해보니 아에 닉네임을 계속 주입하고 있더군요..
그래서 익명일때는 더이상 닉네임정보를 입력하지 않도록 하였습니다. 