### PR TITLE
#323 게시판에서 글이나 댓글을 작성 또는 삭제한 후 짧은 주소로 redirect하도록 변경

### DIFF
--- a/classes/module/ModuleObject.class.php
+++ b/classes/module/ModuleObject.class.php
@@ -60,7 +60,7 @@ class ModuleObject extends Object
 	function setRedirectUrl($url = './', $output = NULL)
 	{
 		$ajaxRequestMethod = array_flip($this->ajaxRequestMethod);
-		if(!isset($ajaxRequestMethod[Context::getRequestMethod()]))
+		if(isset($ajaxRequestMethod[Context::getRequestMethod()]))
 		{
 			$this->add('redirect_url', $url);
 		}

--- a/classes/module/ModuleObject.class.php
+++ b/classes/module/ModuleObject.class.php
@@ -59,11 +59,7 @@ class ModuleObject extends Object
 	 * */
 	function setRedirectUrl($url = './', $output = NULL)
 	{
-		$ajaxRequestMethod = array_flip($this->ajaxRequestMethod);
-		if(isset($ajaxRequestMethod[Context::getRequestMethod()]))
-		{
-			$this->add('redirect_url', $url);
-		}
+		$this->add('redirect_url', $url);
 
 		if($output !== NULL && is_object($output))
 		{

--- a/common/js/common.js
+++ b/common/js/common.js
@@ -378,6 +378,21 @@ function sendMailTo(to) {
 }
 
 /**
+ * @brief url이동 (Rhymix 개선된 버전)
+ */
+function redirect(url) {
+	if (url === window.location.href || url.indexOf(window.location.href.replace(/#.+$/, "") + "#") === 0)
+	{
+		window.location.href = url;
+		window.location.reload();
+	}
+	else
+	{
+		window.location.href = url;
+	}
+}
+
+/**
  * @brief url이동 (open_window 값이 N 가 아니면 새창으로 띄움)
  **/
 function move_url(url, open_window) {
@@ -394,7 +409,7 @@ function move_url(url, open_window) {
 	if(open_window) {
 		winopen(url);
 	} else {
-		location.href=url;
+		redirect(url);
 	}
 
 	return false;

--- a/common/js/xml_handler.js
+++ b/common/js/xml_handler.js
@@ -106,16 +106,7 @@
 				data.redirect_url = data.redirect_url.replace(/&amp;/g, "&");
 			}
 			if (data.redirect_url && !$.isFunction(callback_success)) {
-				if (data.redirect_url.indexOf(window.location.href.replace(/#.+$/, "") + "#") === 0)
-				{
-					window.location = data.redirect_url;
-					window.location.reload();
-				}
-				else
-				{
-					window.location = data.redirect_url;
-				}
-				return;
+				return redirect(data.redirect_url);
 			}
 			
 			// If there was a success callback, call it.
@@ -236,16 +227,7 @@
 				data.redirect_url = data.redirect_url.replace(/&amp;/g, "&");
 			}
 			if (data.redirect_url && !$.isFunction(callback_success)) {
-				if (data.redirect_url.indexOf(window.location.href.replace(/#.+$/, "") + "#") === 0)
-				{
-					window.location = data.redirect_url;
-					window.location.reload();
-				}
-				else
-				{
-					window.location = data.redirect_url;
-				}
-				return;
+				return redirect(data.redirect_url);
 			}
 			
 			// If there was a success callback, call it.

--- a/common/js/xml_handler.js
+++ b/common/js/xml_handler.js
@@ -102,9 +102,18 @@
 			}
 			
 			// If the response contains a redirect URL, redirect immediately.
-			if (result.redirect_url) {
-				window.location = result.redirect_url.replace(/&amp;/g, "&");
-				return null;
+			if (data.redirect_url) {
+				data.redirect_url = data.redirect_url.replace(/&amp;/g, "&");
+				if (data.redirect_url.indexOf(window.location.href.replace(/#.+$/, "") + "#") === 0)
+				{
+					window.location = data.redirect_url;
+					window.location.reload();
+				}
+				else
+				{
+					window.location = data.redirect_url;
+				}
+				return;
 			}
 			
 			// If there was a success callback, call it.
@@ -218,6 +227,21 @@
 					}
 					return;
 				}
+			}
+			
+			// If the response contains a redirect URL, redirect immediately.
+			if (data.redirect_url) {
+				data.redirect_url = data.redirect_url.replace(/&amp;/g, "&");
+				if (data.redirect_url.indexOf(window.location.href.replace(/#.+$/, "") + "#") === 0)
+				{
+					window.location = data.redirect_url;
+					window.location.reload();
+				}
+				else
+				{
+					window.location = data.redirect_url;
+				}
+				return;
 			}
 			
 			// If there was a success callback, call it.

--- a/common/js/xml_handler.js
+++ b/common/js/xml_handler.js
@@ -104,6 +104,8 @@
 			// If the response contains a redirect URL, redirect immediately.
 			if (data.redirect_url) {
 				data.redirect_url = data.redirect_url.replace(/&amp;/g, "&");
+			}
+			if (data.redirect_url && !$.isFunction(callback_success)) {
 				if (data.redirect_url.indexOf(window.location.href.replace(/#.+$/, "") + "#") === 0)
 				{
 					window.location = data.redirect_url;
@@ -232,6 +234,8 @@
 			// If the response contains a redirect URL, redirect immediately.
 			if (data.redirect_url) {
 				data.redirect_url = data.redirect_url.replace(/&amp;/g, "&");
+			}
+			if (data.redirect_url && !$.isFunction(callback_success)) {
 				if (data.redirect_url.indexOf(window.location.href.replace(/#.+$/, "") + "#") === 0)
 				{
 					window.location = data.redirect_url;

--- a/modules/board/board.controller.php
+++ b/modules/board/board.controller.php
@@ -191,6 +191,7 @@ class boardController extends board
 		}
 
 		// return the results
+		$this->setRedirectUrl(getNotEncodedUrl('', 'mid', Context::get('mid'), 'act', '', 'document_srl', $output->get('document_srl')));
 		$this->add('mid', Context::get('mid'));
 		$this->add('document_srl', $output->get('document_srl'));
 
@@ -399,6 +400,7 @@ class boardController extends board
 		}
 
 		$this->setMessage('success_registed');
+		$this->setRedirectUrl(getNotEncodedUrl('', 'mid', Context::get('mid'), 'act', '', 'document_srl', $obj->document_srl) . '#comment_' . $obj->comment_srl);
 		$this->add('mid', Context::get('mid'));
 		$this->add('document_srl', $obj->document_srl);
 		$this->add('comment_srl', $obj->comment_srl);
@@ -449,6 +451,7 @@ class boardController extends board
 		$this->add('page', Context::get('page'));
 		$this->add('document_srl', $output->get('document_srl'));
 		$this->setMessage('success_deleted');
+		$this->setRedirectUrl(getNotEncodedUrl('', 'mid', Context::get('mid'), 'act', '', 'page', Context::get('page'), 'document_srl', $output->get('document_srl')));
 	}
 
 	/**
@@ -473,6 +476,7 @@ class boardController extends board
 		$this->add('page', Context::get('page'));
 		$this->add('document_srl', $output->get('document_srl'));
 		$this->setMessage('success_deleted');
+		$this->setRedirectUrl(getNotEncodedUrl('', 'mid', Context::get('mid'), 'act', '', 'page', Context::get('page'), 'document_srl', $output->get('document_srl')));
 	}
 
 	/**

--- a/modules/board/tpl/js/board.js
+++ b/modules/board/tpl/js/board.js
@@ -13,19 +13,21 @@ function completeDocumentInserted(ret_obj)
 	var document_srl = ret_obj.document_srl;
 	var category_srl = ret_obj.category_srl;
 
-	//alert(message);
-
-	var url;
-	if(!document_srl)
-	{
-		url = current_url.setQuery('mid',mid).setQuery('act','');
+	if (ret_obj.redirect_url) {
+		location.href = ret_obj.redirect_url;
+	} else {
+		var url;
+		if(!document_srl)
+		{
+			url = current_url.setQuery('mid',mid).setQuery('act','');
+		}
+		else
+		{
+			url = current_url.setQuery('mid',mid).setQuery('document_srl',document_srl).setQuery('act','');
+		}
+		if(category_srl) url = url.setQuery('category',category_srl);
+		location.href = url;
 	}
-	else
-	{
-		url = current_url.setQuery('mid',mid).setQuery('document_srl',document_srl).setQuery('act','');
-	}
-	if(category_srl) url = url.setQuery('category',category_srl);
-	location.href = url;
 }
 
 /* delete the document */
@@ -38,9 +40,6 @@ function completeDeleteDocument(ret_obj)
 
 	var url = current_url.setQuery('mid',mid).setQuery('act','').setQuery('document_srl','');
 	if(page) url = url.setQuery('page',page);
-
-	//alert(message);
-
 	location.href = url;
 }
 
@@ -75,13 +74,21 @@ function completeInsertComment(ret_obj)
 	var mid = ret_obj.mid;
 	var document_srl = ret_obj.document_srl;
 	var comment_srl = ret_obj.comment_srl;
-
-	var url = current_url.setQuery('mid',mid).setQuery('document_srl',document_srl).setQuery('act','');
-	if(comment_srl) url = url.setQuery('rnd',comment_srl)+"#comment_"+comment_srl;
-
-	//alert(message);
-
-	location.href = url;
+	if (ret_obj.redirect_url) {
+		if (ret_obj.redirect_url.indexOf(window.location.href.replace(/#.+$/, "") + "#") === 0)
+		{
+			window.location = ret_obj.redirect_url;
+			window.location.reload();
+		}
+		else
+		{
+			window.location = ret_obj.redirect_url;
+		}
+	} else {
+		var url = current_url.setQuery('mid',mid).setQuery('document_srl',document_srl).setQuery('act','');
+		if (comment_srl) url = url.setQuery('rnd',comment_srl)+"#comment_"+comment_srl;
+		window.location.href = url;
+	}
 }
 
 /* delete the comment */
@@ -93,12 +100,21 @@ function completeDeleteComment(ret_obj)
 	var document_srl = ret_obj.document_srl;
 	var page = ret_obj.page;
 
-	var url = current_url.setQuery('mid',mid).setQuery('document_srl',document_srl).setQuery('act','');
-	if(page) url = url.setQuery('page',page);
-
-	//alert(message);
-
-	location.href = url;
+	if (ret_obj.redirect_url) {
+		if (ret_obj.redirect_url.indexOf(window.location.href.replace(/#.+$/, "") + "#") === 0)
+		{
+			window.location = ret_obj.redirect_url;
+			window.location.reload();
+		}
+		else
+		{
+			window.location = ret_obj.redirect_url;
+		}
+	} else {
+		var url = current_url.setQuery('mid',mid).setQuery('document_srl',document_srl).setQuery('act','');
+		if (page) url = url.setQuery('page',page);
+		window.location.href = url;
+	}
 }
 
 /* delete the trackback */
@@ -110,12 +126,21 @@ function completeDeleteTrackback(ret_obj)
 	var document_srl = ret_obj.document_srl;
 	var page = ret_obj.page;
 
-	var url = current_url.setQuery('mid',mid).setQuery('document_srl',document_srl).setQuery('act','');
-	if(page) url = url.setQuery('page',page);
-
-	//alert(message);
-
-	location.href = url;
+	if (ret_obj.redirect_url) {
+		if (ret_obj.redirect_url.indexOf(window.location.href.replace(/#.+$/, "") + "#") === 0)
+		{
+			window.location = ret_obj.redirect_url;
+			window.location.reload();
+		}
+		else
+		{
+			window.location = ret_obj.redirect_url;
+		}
+	} else {
+		var url = current_url.setQuery('mid',mid).setQuery('document_srl',document_srl).setQuery('act','');
+		if (page) url = url.setQuery('page',page);
+		window.location.href = url;
+	}
 }
 
 /* change category */

--- a/modules/board/tpl/js/board.js
+++ b/modules/board/tpl/js/board.js
@@ -14,7 +14,7 @@ function completeDocumentInserted(ret_obj)
 	var category_srl = ret_obj.category_srl;
 
 	if (ret_obj.redirect_url) {
-		location.href = ret_obj.redirect_url;
+		redirect(ret_obj.redirect_url);
 	} else {
 		var url;
 		if(!document_srl)
@@ -26,7 +26,7 @@ function completeDocumentInserted(ret_obj)
 			url = current_url.setQuery('mid',mid).setQuery('document_srl',document_srl).setQuery('act','');
 		}
 		if(category_srl) url = url.setQuery('category',category_srl);
-		location.href = url;
+		redirect(url);
 	}
 }
 
@@ -40,7 +40,7 @@ function completeDeleteDocument(ret_obj)
 
 	var url = current_url.setQuery('mid',mid).setQuery('act','').setQuery('document_srl','');
 	if(page) url = url.setQuery('page',page);
-	location.href = url;
+	redirect(url);
 }
 
 /* document search */
@@ -53,8 +53,7 @@ function completeVote(ret_obj)
 {
 	var error = ret_obj.error;
 	var message = ret_obj.message;
-	alert(message);
-	location.href = location.href;
+	redirect(window.location.href);
 }
 
 // current page reload
@@ -62,8 +61,7 @@ function completeReload(ret_obj)
 {
 	var error = ret_obj.error;
 	var message = ret_obj.message;
-
-	location.href = location.href;
+	redirect(window.location.href);
 }
 
 /* complete to insert comment*/
@@ -75,19 +73,11 @@ function completeInsertComment(ret_obj)
 	var document_srl = ret_obj.document_srl;
 	var comment_srl = ret_obj.comment_srl;
 	if (ret_obj.redirect_url) {
-		if (ret_obj.redirect_url.indexOf(window.location.href.replace(/#.+$/, "") + "#") === 0)
-		{
-			window.location = ret_obj.redirect_url;
-			window.location.reload();
-		}
-		else
-		{
-			window.location = ret_obj.redirect_url;
-		}
+		redirect(ret_obj.redirect_url);
 	} else {
 		var url = current_url.setQuery('mid',mid).setQuery('document_srl',document_srl).setQuery('act','');
 		if (comment_srl) url = url.setQuery('rnd',comment_srl)+"#comment_"+comment_srl;
-		window.location.href = url;
+		redirect(url);
 	}
 }
 
@@ -101,19 +91,11 @@ function completeDeleteComment(ret_obj)
 	var page = ret_obj.page;
 
 	if (ret_obj.redirect_url) {
-		if (ret_obj.redirect_url.indexOf(window.location.href.replace(/#.+$/, "") + "#") === 0)
-		{
-			window.location = ret_obj.redirect_url;
-			window.location.reload();
-		}
-		else
-		{
-			window.location = ret_obj.redirect_url;
-		}
+		redirect(ret_obj.redirect_url);
 	} else {
 		var url = current_url.setQuery('mid',mid).setQuery('document_srl',document_srl).setQuery('act','');
 		if (page) url = url.setQuery('page',page);
-		window.location.href = url;
+		redirect(url);
 	}
 }
 
@@ -127,19 +109,11 @@ function completeDeleteTrackback(ret_obj)
 	var page = ret_obj.page;
 
 	if (ret_obj.redirect_url) {
-		if (ret_obj.redirect_url.indexOf(window.location.href.replace(/#.+$/, "") + "#") === 0)
-		{
-			window.location = ret_obj.redirect_url;
-			window.location.reload();
-		}
-		else
-		{
-			window.location = ret_obj.redirect_url;
-		}
+		redirect(ret_obj.redirect_url);
 	} else {
 		var url = current_url.setQuery('mid',mid).setQuery('document_srl',document_srl).setQuery('act','');
 		if (page) url = url.setQuery('page',page);
-		window.location.href = url;
+		redirect(url);
 	}
 }
 


### PR DESCRIPTION
현재 게시판에서 글쓰기, 댓글쓰기, 댓글 삭제 등의 작업을 수행한 후에는 mid, document_srl 등의 변수들을 각각 돌려받은 후 JS에서 다시 조합하여 redirect하도록 되어 있습니다. 그러나 JS에서는 짧은 주소 사용 여부를 파악할 수 없기 때문에 지저분한 주소로 redirect됩니다. #323 

우선 해당 액션에서 `setRedirectUrl()`을 호출하여 짧은 주소 사용시 짧은 주소로 redirect해 주도록 변경했으나, 아직 두 가지 문제가 남아 있습니다.

1. `ModuleObject` 클래스에서 XMLRPC 또는 JSON 요청인 경우 `setRedirectUrl()`을 무시하도록 되어 있네요. 일단 이 부분을 삭제하여 `setRedirectUrl()`이 항상 작동하도록 고쳐 보았으나, 왜 이렇게 해두었는지 확인이 필요합니다.
2. 댓글 작성 후 redirect되는 주소가 원글의 주소와 똑같고 `#comment_<댓글번호>`만 추가되기 때문에 실제로 redirect가 발생하지 않습니다.

