### PR TITLE
개인정보 이메일 보호 (메일주소 가리기, 친구만 메일 보내기)

### DIFF
--- a/modules/member/member.model.php
+++ b/modules/member/member.model.php
@@ -155,10 +155,14 @@ class memberModel extends member
 			}
 
 			// Send an email only if email address is public
-			if(($logged_info->is_admin == 'Y' || $email_config->isPublic == 'Y') && $member_info->email_address)
+			if($email_config->isPublic == 'Y' && $member_info->email_address)
 			{
-				$url = 'mailto:'.htmlspecialchars($member_info->email_address, ENT_COMPAT | ENT_HTML401, 'UTF-8', false);
-				$oMemberController->addMemberPopupMenu($url,'cmd_send_email',$icon_path);
+				$oCommunicationModel = getModel('communication');
+				if($logged_info->is_admin == 'Y' || $oCommunicationModel->isFriend($member_info->member_srl))
+				{
+					$url = 'mailto:'.htmlspecialchars($member_info->email_address, ENT_COMPAT | ENT_HTML401, 'UTF-8', false);
+					$oMemberController->addMemberPopupMenu($url,'cmd_send_email',$icon_path);
+				}
 			}
 		}
 		// View homepage info

--- a/modules/member/member.view.php
+++ b/modules/member/member.view.php
@@ -84,9 +84,9 @@ class memberView extends member
 
 		if($logged_info->is_admin != 'Y' && ($member_info->member_srl != $logged_info->member_srl))
 		{
-			$start = strpos($member_info->email_address, '@')+1;
-			$replaceStr = str_repeat('*', (strlen($member_info->email_address) - $start));
-			$member_info->email_address = substr_replace($member_info->email_address, $replaceStr, $start);
+			list($email_id, $email_host) = explode('@', $member_info->email_address);
+			$protect_id = substr($email_id, 0, 2) . str_repeat('*', strlen($email_id)-2);
+			$member_info->email_address = sprintf('%s@%s', $protect_id, $email_host);
 		}
 
 		if(!$member_info->member_srl) return $this->dispMemberSignUpForm();


### PR DESCRIPTION
#325

* 회원정보에서 메일주소의 ID부분 가리기 (ex. rh******@gmail.com)
* 회원 팝업메뉴에서 친구에게만 "메일보내기" 표시

쪽지를 통해 메일을 보낼 수 있으니, 메일주소를 모른다고 메일 연락방법이 사라지는 건 아닙니다.