### PR TITLE
ignore error_log files by cpanel.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,5 @@ composer.phar
 *.sublime-workspace
 *.sublime-project
 .codeintel
+error_log
 


### PR DESCRIPTION
cpanel을 사용하게되면, 웹공간에 곧 error_log가 쌓이도록 세팅되어있습니다.(루아틱기준)

그래서 해당 파일은 git에서 인식하지 않도록 만들어야 할 것 같아요.
