### PR TITLE
member_communication 애드온이 켜져 있는 것처럼 훼이크

### DIFF
--- a/modules/addon/addon.admin.model.php
+++ b/modules/addon/addon.admin.model.php
@@ -451,6 +451,21 @@ class addonAdminModel extends addon
 	 */
 	function isActivatedAddon($addon, $site_srl = 0, $type = "pc", $gtype = 'site')
 	{
+		$always_return_true_for_compatibility = array(
+			'member_communication' => true,
+		);
+		$always_return_false_for_compatibility = array(
+		);
+		
+		if(isset($always_return_true_for_compatibility[$addon]))
+		{
+			return true;
+		}
+		if(isset($always_return_false_for_compatibility[$addon]))
+		{
+			return false;
+		}
+		
 		$args = new stdClass();
 		$args->addon = $addon;
 		if($gtype == 'global')


### PR DESCRIPTION
member_communication 애드온은 member 모듈에 흡수되었으나, `isActivatedAddon()` 메소드를 호출하여 member_communication 애드온 사용 여부를 확인하는 일부 서드파티 자료 때문에 문제가 발생한다는 제보가 있습니다. 그래서 member_communication 애드온은 항상 켜져 있는 것처럼 훼이크를 치겠습니다.