### PR TITLE
#320 그룹 이미지 마크를 상대경로로 출력하도록 변경

### DIFF
--- a/modules/member/member.model.php
+++ b/modules/member/member.model.php
@@ -1047,6 +1047,10 @@ class memberModel extends member
 							$info->title = $group_info->title;
 							$info->description = $group_info->description;
 							$info->src = $group_info->image_mark;
+							if(parse_url($info->src, PHP_URL_HOST) === parse_url(Context::getDefaultUrl(), PHP_URL_HOST))
+							{
+								$info->src = preg_replace('@^https?://[^/]+@i', '', $info->src);
+							}
 							$GLOBALS['__member_info__']['group_image_mark'][$member_srl] = $info;
 							break;
 						}


### PR DESCRIPTION
그룹 이미지 마크 주소가 절대경로로 저장되어 있어서, http 사이트를 https로 변경하거나 여러 도메인을 사용하는 경우 문제가 발생합니다. #320

그룹 이미지 마크 주소가 기본 URL과 같은 도메인인 경우 상대주소로 출력하도록 변경합니다. 외부 이미지를 그룹 이미지 마크로 지정한 경우에는 기존 방식처럼 절대경로로 출력됩니다.