### PR TITLE
#320 그룹 이미지 마크에 항상 상대경로를 사용

### DIFF
--- a/modules/member/member.model.php
+++ b/modules/member/member.model.php
@@ -1051,9 +1051,13 @@ class memberModel extends member
 							$info->title = $group_info->title;
 							$info->description = $group_info->description;
 							$info->src = $group_info->image_mark;
-							if(parse_url($info->src, PHP_URL_HOST) === parse_url(Context::getDefaultUrl(), PHP_URL_HOST))
+							if(preg_match('@^https?://@', $info->src))
 							{
-								$info->src = preg_replace('@^https?://[^/]+@i', '', $info->src);
+								$localpath = str_replace('/./', '/', parse_url($info->src, PHP_URL_PATH));
+								if(file_exists($_SERVER['DOCUMENT_ROOT'] . $localpath))
+								{
+									$info->src = $localpath . '?' . date('YmdHis', filemtime($_SERVER['DOCUMENT_ROOT'] . $localpath));
+								}
 							}
 							$GLOBALS['__member_info__']['group_image_mark'][$member_srl] = $info;
 							break;


### PR DESCRIPTION
#346 에서 완전히 고쳐지지 않은 부분을 마무리합니다.

서버측의 해당 경로에 파일이 존재하는지 확인하고, 존재한다면 상대경로를 사용합니다.

고치는 김에 정확한 캐싱 처리를 위한 `mtime`도 표시하도록 변경했습니다.