### PR TITLE
SEO에 좋은 301 redirection 으로 변경

### DIFF
--- a/classes/module/ModuleHandler.class.php
+++ b/classes/module/ModuleHandler.class.php
@@ -96,10 +96,13 @@ class ModuleHandler extends Handler
 		{
 			if(Context::get('_use_ssl') == 'optional' && Context::isExistsSSLAction($this->act) && !RX_SSL)
 			{
-				if(Context::get('_https_port')!=null) {
-					header('location:https://' . $_SERVER['HTTP_HOST'] . ':' . Context::get('_https_port') . $_SERVER['REQUEST_URI']);
-				} else {
-					header('location:https://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI']);
+				if(Context::get('_https_port') != null)
+				{
+					header('location: https://' . $_SERVER['HTTP_HOST'] . ':' . Context::get('_https_port') . $_SERVER['REQUEST_URI']);
+				}
+				else
+				{
+					header('location: https://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI']);
 				}
 				return;
 			}
@@ -182,7 +185,7 @@ class ModuleHandler extends Handler
 					if(Context::getRequestMethod() == 'GET')
 					{
 						$this->mid = $module_info->mid;
-						header('location:' . getNotEncodedSiteUrl($site_module_info->domain, 'mid', $this->mid, 'document_srl', $this->document_srl));
+						header('location: ' . getNotEncodedSiteUrl($site_module_info->domain, 'mid', $this->mid, 'document_srl', $this->document_srl), true, 301);
 						return FALSE;
 					}
 					else
@@ -212,7 +215,7 @@ class ModuleHandler extends Handler
 		if(!$this->module && !$module_info && $site_module_info->site_srl == 0 && $site_module_info->module_site_srl > 0)
 		{
 			$site_info = $oModuleModel->getSiteInfo($site_module_info->module_site_srl);
-			header("location:" . getNotEncodedSiteUrl($site_info->domain, 'mid', $site_module_info->mid));
+			header('location: ' . getNotEncodedSiteUrl($site_info->domain, 'mid', $site_module_info->mid), true, 301);
 			return FALSE;
 		}
 
@@ -241,7 +244,7 @@ class ModuleHandler extends Handler
 			{
 				$redirect_url = getNotEncodedSiteUrl(Context::getDefaultUrl(), 'mid', Context::get('mid'), 'document_srl', Context::get('document_srl'), 'module_srl', Context::get('module_srl'), 'entry', Context::get('entry'));
 			}
-			header("Location: $redirect_url");
+			header("Location: $redirect_url", true, 301);
 			return FALSE;
 		}
 
@@ -884,7 +887,7 @@ class ModuleHandler extends Handler
 
 			if($_SESSION['XE_VALIDATOR_RETURN_URL'])
 			{
-				header('location:' . $_SESSION['XE_VALIDATOR_RETURN_URL']);
+				header('location: ' . $_SESSION['XE_VALIDATOR_RETURN_URL']);
 				return;
 			}
 

--- a/classes/module/ModuleHandler.class.php
+++ b/classes/module/ModuleHandler.class.php
@@ -184,6 +184,7 @@ class ModuleHandler extends Handler
 					
 					if(Context::getRequestMethod() == 'GET')
 					{
+						Context::setCacheControl(0);
 						$this->mid = $module_info->mid;
 						header('location: ' . getNotEncodedSiteUrl($site_module_info->domain, 'mid', $this->mid, 'document_srl', $this->document_srl), true, 301);
 						return FALSE;
@@ -214,6 +215,7 @@ class ModuleHandler extends Handler
 		// redirect, if module_site_srl and site_srl are different
 		if(!$this->module && !$module_info && $site_module_info->site_srl == 0 && $site_module_info->module_site_srl > 0)
 		{
+			Context::setCacheControl(0);
 			$site_info = $oModuleModel->getSiteInfo($site_module_info->module_site_srl);
 			header('location: ' . getNotEncodedSiteUrl($site_info->domain, 'mid', $site_module_info->mid), true, 301);
 			return FALSE;
@@ -244,6 +246,8 @@ class ModuleHandler extends Handler
 			{
 				$redirect_url = getNotEncodedSiteUrl(Context::getDefaultUrl(), 'mid', Context::get('mid'), 'document_srl', Context::get('document_srl'), 'module_srl', Context::get('module_srl'), 'entry', Context::get('entry'));
 			}
+			
+			Context::setCacheControl(0);
 			header("Location: $redirect_url", true, 301);
 			return FALSE;
 		}


### PR DESCRIPTION
예) https://www.xetown.com/221175 -> https://www.xetown.com/qna/221175

예시처럼 이동할 경우 302 redirection 의해 이동됩니다. 하지만 `header('location: ~)` 의 기본값인 302 redirection 은 SEO에서 별로 좋지않기 때문에 301로 변경 했습니다.