### PR TITLE
절대 경로 변환 함수 추가

### DIFF
--- a/common/functions.php
+++ b/common/functions.php
@@ -132,9 +132,7 @@ function path($path, $web = false, $auto_fix = false)
 		
 		if($sub > 0)
 		{
-			$abs_array = explode('/', $called_path);
-			array_splice($abs_array, $sub * -1);
-			$abs_path = implode('/', $abs_array);
+			$abs_path = dirname($called_path, $sub);
 		}
 		else
 		{

--- a/common/functions.php
+++ b/common/functions.php
@@ -65,7 +65,7 @@ function path($path, $check = true, $web = false)
 		return;
 	}
 	
-	$called_info = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
+	$called_info = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 1);
 	$called_path = pathinfo(str_replace('\\', '/',$called_info[0]['file']), PATHINFO_DIRNAME);
 	
 	if(strpos($called_path, 'files/cache/template_compiled') !== false)

--- a/common/functions.php
+++ b/common/functions.php
@@ -139,7 +139,7 @@ function path($path, $web = false, $auto_fix = false)
 			$abs_path = $called_path;
 		}
 		
-		$compath = $abs_path . '/' . implode('/', $path_array);
+		$compath = $abs_path . (!empty($path_array) ? '/':'') . implode('/', $path_array);
 	}
 	else if($work_step === 2)
 	{

--- a/common/functions.php
+++ b/common/functions.php
@@ -110,51 +110,38 @@ function path($path, $web = false, $auto_fix = false)
 	
 	if($work_step === 1)
 	{
-		$result = array();
-		$path_array = explode('/', $filtered);
-		krsort($path_array);
-		
 		$sub = 0;
-		$end = false;
+		$path_array = explode('/', $filtered);
+		
 		foreach($path_array as $key => $val)
 		{
-			if($val === '..')
+			if($val === '.' || $val === '..')
 			{
-				++$sub;
+				unset($path_array[$key]);
 				
-				if($key === 0)
+				if($val === '.' && $key === 0 && $path_array[1] !== '..')
 				{
-					$end = true;
-				}
-			}
-			else if($val === '.')
-			{
-				if($path_array[$key + 1] === '..')
-				{
-					$end = true;
-				}
-				else
-				{
-					$result[] = $called_path;
 					break;
 				}
-			}
-			else
-			{
-				$result[] = $val;
-			}
-			
-			if($end)
-			{
-				$cpath_array = explode('/', $called_path);
-				array_splice($cpath_array, $sub * -1);
-				$result[] = implode('/', $cpath_array);
-				break;
+				else if($val === '..')
+				{
+					++$sub;
+				}
 			}
 		}
 		
-		krsort($result);
-		$compath = implode('/', $result);
+		if($sub > 0)
+		{
+			$abs_array = explode('/', $called_path);
+			array_splice($abs_array, $sub * -1);
+			$abs_path = implode('/', $abs_array);
+		}
+		else
+		{
+			$abs_path = $called_path;
+		}
+		
+		$compath = $abs_path . '/' . implode('/', $path_array);
 	}
 	else if($work_step === 2)
 	{

--- a/common/functions.php
+++ b/common/functions.php
@@ -54,11 +54,11 @@ function lang($code, $value = null)
  * Convert always absolute path
  *
  * @param string $path Absolute path or Relative path
- * @param bool $check if the path does not exist, return false
  * @param bool $web if true, return web path
+ * @param bool $auto_fix if true, fixed the path
  * @return mixed
  */
-function path($path, $check = true, $web = false)
+function path($path, $web = false, $auto_fix = false)
 {
 	if(!$path)
 	{
@@ -75,11 +75,14 @@ function path($path, $check = true, $web = false)
 	}
 	
 	$filtered = trim($path, '/');
-	$filtered = preg_replace('@\s*|\.{3,}@', '', $filtered);
-	$filtered = preg_replace('@/(\./)+@', '/', $filtered);
-	$filtered = preg_replace('@/{2,}@', '/', $filtered);
-	$filtered = preg_replace('@([^./]+)/(\.\./)+@', '$1/', $filtered);
-	
+	if($auto_fix)
+	{
+		$filtered = preg_replace('@\s*|\.{3,}@', '', $filtered);
+		$filtered = preg_replace('@/(\./)+@', '/', $filtered);
+		$filtered = preg_replace('@/{2,}@', '/', $filtered);
+		$filtered = preg_replace('@([^./]+)/(\.\./)+@', '$1/', $filtered);
+	}
+
 	if(!$filtered && $path !== '/')
 	{
 		return;
@@ -142,11 +145,6 @@ function path($path, $check = true, $web = false)
 	else if(strpos($filtered, trim(RX_BASEDIR, '/')) === false)
 	{
 		$compath = RX_BASEDIR . $filtered;
-	}
-	
-	if($check && !file_exists($compath))
-	{
-		return false;
 	}
 	
 	if($web)

--- a/common/functions.php
+++ b/common/functions.php
@@ -65,27 +65,6 @@ function path($path, $web = false, $auto_fix = false)
 		return;
 	}
 	
-	if(version_compare(PHP_VERSION, '5.3.6') < 0)
-	{
-		$called_info = debug_backtrace();
-	}
-	else if(version_compare(PHP_VERSION, '5.4.0') < 0)
-	{
-		$called_info = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
-	}
-	else
-	{
-		$called_info = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 1);
-	}
-	
-	$called_path = pathinfo(str_replace('\\', '/',$called_info[0]['file']), PATHINFO_DIRNAME);
-	
-	if(strpos($called_path, 'files/cache/template_compiled') !== false)
-	{
-		$tpl_path = trim(Context::get('tpl_path'), '/');
-		$called_path = RX_BASEDIR . preg_replace('@^' . preg_quote(RX_BASEDIR, '@') . '|\./@', '', $tpl_path);
-	}
-	
 	$filtered = trim($path, '/');
 	if($auto_fix)
 	{
@@ -98,6 +77,13 @@ function path($path, $web = false, $auto_fix = false)
 	if(!$filtered && $path !== '/')
 	{
 		return;
+	}
+	
+	$current_path = str_replace('\\', '/', dirname($_SERVER['SCRIPT_FILENAME']));
+	if(strpos($current_path, 'files/cache/template_compiled') !== false)
+	{
+		$tpl_path = trim(Context::get('tpl_path'), '/');
+		$current_path = RX_BASEDIR . preg_replace('@^' . preg_quote(RX_BASEDIR, '@') . '|\./@', '', $tpl_path);
 	}
 	
 	$compath = '/' . $filtered;
@@ -129,7 +115,7 @@ function path($path, $web = false, $auto_fix = false)
 				}
 				else
 				{
-					$result[] = $called_path;
+					$result[] = $current_path;
 					break;
 				}
 			}
@@ -140,7 +126,7 @@ function path($path, $web = false, $auto_fix = false)
 			
 			if($end)
 			{
-				$cpath_array = explode('/', $called_path);
+				$cpath_array = explode('/', $current_path);
 				array_splice($cpath_array, $sub * -1);
 				$result[] = implode('/', $cpath_array);
 				break;
@@ -152,7 +138,7 @@ function path($path, $web = false, $auto_fix = false)
 	}
 	else if(substr_compare($path, '/', 0, 1) !== 0)
 	{
-		$compath = $called_path . '/' . $filtered;
+		$compath = $current_path . '/' . $filtered;
 	}
 	else if(strpos($filtered, trim(RX_BASEDIR, '/')) === false)
 	{

--- a/common/functions.php
+++ b/common/functions.php
@@ -65,7 +65,19 @@ function path($path, $web = false, $auto_fix = false)
 		return;
 	}
 	
-	$called_info = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 1);
+	if(version_compare(PHP_VERSION, '5.3.6') < 0)
+	{
+		$called_info = debug_backtrace();
+	}
+	else if(version_compare(PHP_VERSION, '5.4.0') < 0)
+	{
+		$called_info = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
+	}
+	else
+	{
+		$called_info = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 1);
+	}
+	
 	$called_path = pathinfo(str_replace('\\', '/',$called_info[0]['file']), PATHINFO_DIRNAME);
 	
 	if(strpos($called_path, 'files/cache/template_compiled') !== false)
@@ -82,7 +94,7 @@ function path($path, $web = false, $auto_fix = false)
 		$filtered = preg_replace('@/{2,}@', '/', $filtered);
 		$filtered = preg_replace('@([^./]+)/(\.\./)+@', '$1/', $filtered);
 	}
-
+	
 	if(!$filtered && $path !== '/')
 	{
 		return;


### PR DESCRIPTION
어떤 경로를 넣더라도 현재 파일을 기준으로 절대 경로로 변환하여, 반환해주는 `path()` 함수입니다.
* `realpath()` 함수와는 다르게 존재하지않은 경로도 변환 가능 ($check 옵션)
* 절대경로 빼고, 웹 경로로도 반환 가능 ($web 옵션)
* 템플릿 파일에서도 사용 가능
* `path('.')`나 `path('..')` 도 가능
* `//`, `.././` 와 같이 지저분하거나 잘못된 경로도 자동 수정해줌.

유용할 것 같아서 추가해봤습니다.

ex) include path('../class/class.php');