### PR TITLE
디버그 IP 제한에 localhost는 항상 포함시킴

### DIFF
--- a/common/framework/debug.php
+++ b/common/framework/debug.php
@@ -449,6 +449,14 @@ class Debug
 				{
 					return $cache = true;
 				}
+				if (\RX_CLIENT_IP === '127.0.0.1' || \RX_CLIENT_IP === '::1')
+				{
+					return $cache = true;
+				}
+				if (\RX_CLIENT_IP === $_SERVER['SERVER_ADDR'] || \RX_CLIENT_IP === $_SERVER['LOCAL_ADDR'])
+				{
+					return $cache = true;
+				}
 				return $cache = false;
 			
 			case 'admin':

--- a/common/tpl/debug_comment.html
+++ b/common/tpl/debug_comment.html
@@ -6,6 +6,7 @@
 Request / Response
 ==================
 Request URL:         <?php echo $data->url . "\n"; ?>
+Request IP Address:  <?php echo \RX_CLIENT_IP . "\n"; ?>
 Request Method:      <?php echo $data->request->method . "\n" ?>
 Request Body Size:   <?php echo $data->request->size . "\n" ?>
 Response Method:     <?php echo $data->response->method . "\n"; ?>


### PR DESCRIPTION
디버그 편의를 위해 localhost 또는 서버 자신의 IP에서는 항상 디버그 기능을 사용할 수 있도록 합니다.