### PR TITLE
경로↔URL 변환 및 정리 함수 추가

### DIFF
--- a/common/framework/filters/filenamefilter.php
+++ b/common/framework/filters/filenamefilter.php
@@ -65,16 +65,16 @@ class FilenameFilter
 		$path = str_replace('\\', '/', $path);
 		
 		// Remove querystrings and URL fragments.
-		$path = preg_replace('@[\?#].+$@', '', $path);
+		if (($querystring = strpbrk($path, '?#')) !== false)
+		{
+			$path = substr($path, 0, -1 * strlen($querystring));
+		}
 		
-		// Remove duplicate slashes, except at the beginning of a URL.
-		$path = preg_replace('@(?<!^|^http:|^https:)/{2,}@', '/', $path);
-		
-		// Remove sequences of three or more dots.
-		$path = preg_replace('@/\.{3,}/@', '/', $path);
-		
-		// Remove single dots.
-		$path = preg_replace('@/(\./)+@', '/', $path);
+		// Remove single dots, three or more dots, and duplicate slashes.
+		$path = preg_replace(array(
+			'@(?<!^|^http:|^https:)/{2,}@',
+			'@/(?:(?:\.|\.{3,})/)+@',
+		), '/', $path);
 		
 		// Remove double dots and the preceding directory.
 		while (preg_match('@/(?!\.\.)[^/]+/\.\.(?:/|$)@', $path, $matches))

--- a/common/framework/filters/filenamefilter.php
+++ b/common/framework/filters/filenamefilter.php
@@ -55,6 +55,10 @@ class FilenameFilter
 	 */
 	public static function cleanPath($path)
 	{
+		if (!preg_match('@^(?:[a-z]:[\\\\/]|\\\\|/)@i', $path))
+		{
+			$path = \RX_BASEDIR . $path;
+		}
 		$path = str_replace('\\', '/', $path);
 		$path = preg_replace('@[\?#].+$@', '', $path);
 		$path = preg_replace('@/{2,}@', '/', $path);

--- a/common/framework/filters/filenamefilter.php
+++ b/common/framework/filters/filenamefilter.php
@@ -46,4 +46,24 @@ class FilenameFilter
 		
 		return $filename;
 	}
+	
+	/**
+	 * Clean a path to remove ./, ../, trailing slashes, etc.
+	 * 
+	 * @param string $path
+	 * @return string
+	 */
+	public static function cleanPath($path)
+	{
+		$path = str_replace('\\', '/', $path);
+		$path = preg_replace('@[\?#].+$@', '', $path);
+		$path = preg_replace('@/{2,}@', '/', $path);
+		$path = preg_replace('@/\.{3,}/@', '/', $path);
+		$path = preg_replace('@/(\./)+@', '/', $path);
+		while (preg_match('@/[^/]+/\.\.(?:/|$)@', $path, $matches))
+		{
+			$path = str_replace($matches[0], '/', $path);
+		}
+		return rtrim($path, '/');
+	}
 }

--- a/common/framework/filters/filenamefilter.php
+++ b/common/framework/filters/filenamefilter.php
@@ -77,7 +77,7 @@ class FilenameFilter
 		$path = preg_replace('@/(\./)+@', '/', $path);
 		
 		// Remove double dots and the preceding directory.
-		while (preg_match('@/[^/]+/\.\.(?:/|$)@', $path, $matches))
+		while (preg_match('@/(?!\.\.)[^/]+/\.\.(?:/|$)@', $path, $matches))
 		{
 			$path = str_replace($matches[0], '/', $path);
 		}

--- a/common/framework/filters/filenamefilter.php
+++ b/common/framework/filters/filenamefilter.php
@@ -55,19 +55,34 @@ class FilenameFilter
 	 */
 	public static function cleanPath($path)
 	{
-		if (!preg_match('@^(?:[a-z]:[\\\\/]|\\\\|/)@i', $path))
+		// Convert relative paths to absolute paths.
+		if (!preg_match('@^(?:/|[a-z]:[\\\\/]|\\\\|https?:)@i', $path))
 		{
 			$path = \RX_BASEDIR . $path;
 		}
+		
+		// Convert backslashes to forward slashes.
 		$path = str_replace('\\', '/', $path);
+		
+		// Remove querystrings and URL fragments.
 		$path = preg_replace('@[\?#].+$@', '', $path);
-		$path = preg_replace('@/{2,}@', '/', $path);
+		
+		// Remove duplicate slashes, except at the beginning of a URL.
+		$path = preg_replace('@(?<!^|^http:|^https:)/{2,}@', '/', $path);
+		
+		// Remove sequences of three or more dots.
 		$path = preg_replace('@/\.{3,}/@', '/', $path);
+		
+		// Remove single dots.
 		$path = preg_replace('@/(\./)+@', '/', $path);
+		
+		// Remove double dots and the preceding directory.
 		while (preg_match('@/[^/]+/\.\.(?:/|$)@', $path, $matches))
 		{
 			$path = str_replace($matches[0], '/', $path);
 		}
+		
+		// Trim trailing slashes.
 		return rtrim($path, '/');
 	}
 }

--- a/common/framework/storage.php
+++ b/common/framework/storage.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rhymix\Framework;
+
+/**
+ * The storage class.
+ */
+class Storage
+{
+	
+}

--- a/common/functions.php
+++ b/common/functions.php
@@ -134,6 +134,19 @@ function class_basename($class)
 }
 
 /**
+ * Clean a path to remove ./, ../, trailing slashes, etc.
+ * 
+ * This function is an alias to Rhymix\Framework\Filters\FilenameFilter::cleanPath().
+ * 
+ * @param string $path
+ * @return string
+ */
+function clean_path($path)
+{
+	return Rhymix\Framework\Filters\FilenameFilter::cleanPath($path);
+}
+
+/**
  * This function is a shortcut to htmlspecialchars().
  * 
  * @param string $str The string to escape
@@ -335,6 +348,34 @@ function base64_encode_urlsafe($str)
 function base64_decode_urlsafe($str)
 {
 	return @base64_decode(str_pad(strtr($str, '-_', '+/'), ceil(strlen($str) / 4) * 4, '=', STR_PAD_RIGHT));
+}
+
+/**
+ * Convert a server-side path to a URL.
+ * 
+ * This function is an alias to Rhymix\Framework\URL::fromServerPath().
+ * It returns false if the path cannot be converted.
+ * 
+ * @param string $path
+ * @return string|false
+ */
+function path2url($path)
+{
+	return Rhymix\Framework\URL::fromServerPath($path);
+}
+
+/**
+ * Convert a URL to a server-side path.
+ * 
+ * This function is an alias to Rhymix\Framework\URL::toServerPath().
+ * It returns false if the URL cannot be converted.
+ * 
+ * @param string $url
+ * @return string|false
+ */
+function url2path($url)
+{
+	return Rhymix\Framework\URL::toServerPath($url);
 }
 
 /**

--- a/tests/_bootstrap.php
+++ b/tests/_bootstrap.php
@@ -1,6 +1,17 @@
 <?php
-// This is global bootstrap for autoloading
-require dirname(__DIR__) . '/common/autoload.php';
+
+// Set some superglobal variables for unit tests.
+$_SERVER['HTTPS'] = 'on';
+$_SERVER['HTTP_HOST'] = 'www.rhymix.org';
+$_SERVER['SERVER_NAME'] = 'www.rhymix.org';
+$_SERVER['REMOTE_ADDR'] = '127.0.0.1';
+$_SERVER['DOCUMENT_ROOT'] = dirname(dirname(__DIR__));
+$_SERVER['SCRIPT_FILENAME'] = dirname(__DIR__) . '/index.php';
+$_SERVER['SCRIPT_NAME'] = '/rhymix/index.php';
+$_SERVER['REQUEST_URI'] = '/rhymix/index.php';
+
+// Include the autoloader.
+require_once dirname(__DIR__) . '/common/autoload.php';
 
 function _debug() {
 	$args = func_get_args();

--- a/tests/unit/_bootstrap.php
+++ b/tests/unit/_bootstrap.php
@@ -1,3 +1,2 @@
 <?php
 // Here you can initialize variables that will be available to your tests
-$_SERVER['SCRIPT_NAME'] = '/xe/index.php';

--- a/tests/unit/classes/ContextTest.php
+++ b/tests/unit/classes/ContextTest.php
@@ -1,7 +1,4 @@
 <?php
-require_once _XE_PATH_.'classes/context/Context.class.php';
-require_once _XE_PATH_.'classes/handler/Handler.class.php';
-require_once _XE_PATH_.'classes/frontendfile/FrontEndFileHandler.class.php';
 
 class ContextTest extends \Codeception\TestCase\Test
 {

--- a/tests/unit/classes/FileHandlerTest.php
+++ b/tests/unit/classes/FileHandlerTest.php
@@ -1,5 +1,4 @@
 <?php
-require_once _XE_PATH_.'classes/file/FileHandler.class.php';
 
 class FileHandlerTest extends \Codeception\TestCase\Test
 {

--- a/tests/unit/classes/FrontEndFileHandlerTest.php
+++ b/tests/unit/classes/FrontEndFileHandlerTest.php
@@ -1,5 +1,4 @@
 <?php
-require_once _XE_PATH_.'classes/frontendfile/FrontEndFileHandler.class.php';
 
 class FrontEndFileHandlerTest extends \Codeception\TestCase\Test
 {
@@ -23,8 +22,8 @@ class FrontEndFileHandlerTest extends \Codeception\TestCase\Test
 			$handler->loadFile(array('./common/js/common.js', 'body'));
 			$handler->loadFile(array('./common/js/common.js', 'head'));
 			$handler->loadFile(array('./common/js/xml_js_filter.js', 'body'));
-			$expected[] = array('file' => '/xe/common/js/js_app.js' . $this->_filemtime('common/js/js_app.js'), 'targetie' => null);
-			$expected[] = array('file' => '/xe/common/js/common.js' . $this->_filemtime('common/js/common.js'), 'targetie' => null);
+			$expected[] = array('file' => '/rhymix/common/js/js_app.js' . $this->_filemtime('common/js/js_app.js'), 'targetie' => null);
+			$expected[] = array('file' => '/rhymix/common/js/common.js' . $this->_filemtime('common/js/common.js'), 'targetie' => null);
 			$this->assertEquals($handler->getJsFileList(), $expected);
 		});
 
@@ -39,8 +38,8 @@ class FrontEndFileHandlerTest extends \Codeception\TestCase\Test
 			$handler = new FrontEndFileHandler();
 			$handler->loadFile(array('./common/css/xe.css'));
 			$handler->loadFile(array('./common/css/mobile.css'));
-			$expected[] = array('file' => '/xe/common/css/xe.css' . $this->_filemtime('common/css/xe.css'), 'media' => 'all', 'targetie' => null);
-			$expected[] = array('file' => '/xe/common/css/mobile.css' . $this->_filemtime('common/css/mobile.css'), 'media' => 'all', 'targetie' => null);
+			$expected[] = array('file' => '/rhymix/common/css/xe.css' . $this->_filemtime('common/css/xe.css'), 'media' => 'all', 'targetie' => null);
+			$expected[] = array('file' => '/rhymix/common/css/mobile.css' . $this->_filemtime('common/css/mobile.css'), 'media' => 'all', 'targetie' => null);
 			$this->assertEquals($handler->getCssFileList(), $expected);
 		});
 
@@ -54,10 +53,10 @@ class FrontEndFileHandlerTest extends \Codeception\TestCase\Test
 			$handler->loadFile(array('./common/js/common.js', 'head', '', -100000));
 			$handler->loadFile(array('./common/js/xml_handler.js', 'head', '', -100000));
 			$handler->loadFile(array('./common/js/xml_js_filter.js', 'head', '', -100000));
-			$expected[] = array('file' => '/xe/common/js/js_app.js' . $this->_filemtime('common/js/js_app.js'), 'targetie' => null);
-			$expected[] = array('file' => '/xe/common/js/common.js' . $this->_filemtime('common/js/common.js'), 'targetie' => null);
-			$expected[] = array('file' => '/xe/common/js/xml_handler.js' . $this->_filemtime('common/js/xml_handler.js'), 'targetie' => null);
-			$expected[] = array('file' => '/xe/common/js/xml_js_filter.js' . $this->_filemtime('common/js/xml_js_filter.js'), 'targetie' => null);
+			$expected[] = array('file' => '/rhymix/common/js/js_app.js' . $this->_filemtime('common/js/js_app.js'), 'targetie' => null);
+			$expected[] = array('file' => '/rhymix/common/js/common.js' . $this->_filemtime('common/js/common.js'), 'targetie' => null);
+			$expected[] = array('file' => '/rhymix/common/js/xml_handler.js' . $this->_filemtime('common/js/xml_handler.js'), 'targetie' => null);
+			$expected[] = array('file' => '/rhymix/common/js/xml_js_filter.js' . $this->_filemtime('common/js/xml_js_filter.js'), 'targetie' => null);
 			$this->assertEquals($handler->getJsFileList(), $expected);
 		});
 
@@ -67,10 +66,10 @@ class FrontEndFileHandlerTest extends \Codeception\TestCase\Test
 			$handler->loadFile(array('./common/js/js_app.js', 'head', '', -100000));
 			$handler->loadFile(array('./common/js/common.js', 'head', '', -100000));
 			$handler->loadFile(array('./common/js/xml_js_filter.js', 'head', '', -100000));
-			$expected[] = array('file' => '/xe/common/js/js_app.js' . $this->_filemtime('common/js/js_app.js'), 'targetie' => null);
-			$expected[] = array('file' => '/xe/common/js/common.js' . $this->_filemtime('common/js/common.js'), 'targetie' => null);
-			$expected[] = array('file' => '/xe/common/js/xml_js_filter.js' . $this->_filemtime('common/js/xml_js_filter.js'), 'targetie' => null);
-			$expected[] = array('file' => '/xe/common/js/xml_handler.js' . $this->_filemtime('common/js/xml_handler.js'), 'targetie' => null);
+			$expected[] = array('file' => '/rhymix/common/js/js_app.js' . $this->_filemtime('common/js/js_app.js'), 'targetie' => null);
+			$expected[] = array('file' => '/rhymix/common/js/common.js' . $this->_filemtime('common/js/common.js'), 'targetie' => null);
+			$expected[] = array('file' => '/rhymix/common/js/xml_js_filter.js' . $this->_filemtime('common/js/xml_js_filter.js'), 'targetie' => null);
+			$expected[] = array('file' => '/rhymix/common/js/xml_handler.js' . $this->_filemtime('common/js/xml_handler.js'), 'targetie' => null);
 			$this->assertEquals($handler->getJsFileList(), $expected);
 		});
 
@@ -81,9 +80,9 @@ class FrontEndFileHandlerTest extends \Codeception\TestCase\Test
 			$handler->loadFile(array('./common/js/xml_handler.js', 'head', '', -100000));
 			$handler->loadFile(array('./common/js/xml_js_filter.js', 'head', '', -100000));
 			$handler->unloadFile('./common/js/js_app.js', '', 'all');
-			$expected[] = array('file' => '/xe/common/js/common.js' . $this->_filemtime('common/js/common.js'), 'targetie' => null);
-			$expected[] = array('file' => '/xe/common/js/xml_handler.js' . $this->_filemtime('common/js/xml_handler.js'), 'targetie' => null);
-			$expected[] = array('file' => '/xe/common/js/xml_js_filter.js' . $this->_filemtime('common/js/xml_js_filter.js'), 'targetie' => null);
+			$expected[] = array('file' => '/rhymix/common/js/common.js' . $this->_filemtime('common/js/common.js'), 'targetie' => null);
+			$expected[] = array('file' => '/rhymix/common/js/xml_handler.js' . $this->_filemtime('common/js/xml_handler.js'), 'targetie' => null);
+			$expected[] = array('file' => '/rhymix/common/js/xml_js_filter.js' . $this->_filemtime('common/js/xml_js_filter.js'), 'targetie' => null);
 			$this->assertEquals($handler->getJsFileList(), $expected);
 		});
 
@@ -92,9 +91,9 @@ class FrontEndFileHandlerTest extends \Codeception\TestCase\Test
 			$handler->loadFile(array('./common/js/js_app.js', 'head', 'ie6'));
 			$handler->loadFile(array('./common/js/js_app.js', 'head', 'ie7'));
 			$handler->loadFile(array('./common/js/js_app.js', 'head', 'ie8'));
-			$expected[] = array('file' => '/xe/common/js/js_app.js' . $this->_filemtime('common/js/js_app.js'), 'targetie' => 'ie6');
-			$expected[] = array('file' => '/xe/common/js/js_app.js' . $this->_filemtime('common/js/js_app.js'), 'targetie' => 'ie7');
-			$expected[] = array('file' => '/xe/common/js/js_app.js' . $this->_filemtime('common/js/js_app.js'), 'targetie' => 'ie8');
+			$expected[] = array('file' => '/rhymix/common/js/js_app.js' . $this->_filemtime('common/js/js_app.js'), 'targetie' => 'ie6');
+			$expected[] = array('file' => '/rhymix/common/js/js_app.js' . $this->_filemtime('common/js/js_app.js'), 'targetie' => 'ie7');
+			$expected[] = array('file' => '/rhymix/common/js/js_app.js' . $this->_filemtime('common/js/js_app.js'), 'targetie' => 'ie8');
 			$this->assertEquals($handler->getJsFileList(), $expected);
 		});
 
@@ -127,9 +126,9 @@ class FrontEndFileHandlerTest extends \Codeception\TestCase\Test
 			$handler->loadFile(array('./common/css/common.css', null, 'ie7'));
 			$handler->loadFile(array('./common/css/common.css', null, 'ie8'));
 
-			$expected[] = array('file' => '/xe/common/css/common.css', 'media'=>'all', 'targetie' => 'ie6');
-			$expected[] = array('file' => '/xe/common/css/common.css','media'=>'all',  'targetie' => 'ie7');
-			$expected[] = array('file' => '/xe/common/css/common.css', 'media'=>'all', 'targetie' => 'ie8');
+			$expected[] = array('file' => '/rhymix/common/css/common.css', 'media'=>'all', 'targetie' => 'ie6');
+			$expected[] = array('file' => '/rhymix/common/css/common.css','media'=>'all',  'targetie' => 'ie7');
+			$expected[] = array('file' => '/rhymix/common/css/common.css', 'media'=>'all', 'targetie' => 'ie8');
 			$this->assertEquals($handler->getCssFileList(), $expected);
 		});
 
@@ -139,9 +138,9 @@ class FrontEndFileHandlerTest extends \Codeception\TestCase\Test
 			$handler->loadFile(array('./common/css/common.css', 'screen'));
 			$handler->loadFile(array('./common/css/common.css', 'handled'));
 
-			$expected[] = array('file' => '/xe/common/css/common.css', 'media'=>'all', 'targetie' => null);
-			$expected[] = array('file' => '/xe/common/css/common.css','media'=>'screen',  'targetie' => null);
-			$expected[] = array('file' => '/xe/common/css/common.css', 'media'=>'handled', 'targetie' => null);
+			$expected[] = array('file' => '/rhymix/common/css/common.css', 'media'=>'all', 'targetie' => null);
+			$expected[] = array('file' => '/rhymix/common/css/common.css','media'=>'screen',  'targetie' => null);
+			$expected[] = array('file' => '/rhymix/common/css/common.css', 'media'=>'handled', 'targetie' => null);
 			$this->assertEquals($handler->getCssFileList(), $expected);
 		});
 
@@ -151,8 +150,8 @@ class FrontEndFileHandlerTest extends \Codeception\TestCase\Test
 			$handler = new FrontEndFileHandler();
 			$handler->loadFile(array('./common/css/xe.css'));
 			$handler->loadFile(array('./common/css/mobile.css'));
-			$expected[] = array('file' => '/xe/files/cache/minify/common.css.xe.min.css', 'media' => 'all', 'targetie' => null);
-			$expected[] = array('file' => '/xe/files/cache/minify/common.css.mobile.min.css', 'media' => 'all', 'targetie' => null);
+			$expected[] = array('file' => '/rhymix/files/cache/minify/common.css.xe.min.css', 'media' => 'all', 'targetie' => null);
+			$expected[] = array('file' => '/rhymix/files/cache/minify/common.css.mobile.min.css', 'media' => 'all', 'targetie' => null);
 			$result = $handler->getCssFileList();
 			$result[0]['file'] = preg_replace('/\?\d+$/', '', $result[0]['file']);
 			$result[1]['file'] = preg_replace('/\?\d+$/', '', $result[1]['file']);

--- a/tests/unit/classes/OldSecurityTest.php
+++ b/tests/unit/classes/OldSecurityTest.php
@@ -1,5 +1,4 @@
 <?php
-require_once _XE_PATH_.'classes/security/Security.class.php';
 
 class OldSecurityTest extends \Codeception\TestCase\Test
 {

--- a/tests/unit/classes/TemplateHandlerTest.php
+++ b/tests/unit/classes/TemplateHandlerTest.php
@@ -1,7 +1,4 @@
 <?php
-require_once _XE_PATH_.'classes/file/FileHandler.class.php';
-require_once _XE_PATH_.'classes/template/TemplateHandler.class.php';
-$_SERVER['SCRIPT_NAME'] = '/xe/tests/unit/classes/template/index.php';
 
 class TemplateHandlerTest extends \Codeception\TestCase\Test
 {
@@ -148,12 +145,12 @@ class TemplateHandlerTest extends \Codeception\TestCase\Test
             // relative path1
             array(
                 '<img src="http://naver.com/naver.gif"><input type="image" src="../local.gif" />',
-                '?><img src="http://naver.com/naver.gif"><input type="image" src="/xe/tests/unit/classes/local.gif" />'
+                '?><img src="http://naver.com/naver.gif"><input type="image" src="/rhymix/tests/unit/classes/local.gif" />'
             ),
             // relative path2
             array(
                 '<img src="http://naver.com/naver.gif"><input type="image" src="../../../dir/local.gif" />',
-                '?><img src="http://naver.com/naver.gif"><input type="image" src="/xe/tests/dir/local.gif" />'
+                '?><img src="http://naver.com/naver.gif"><input type="image" src="/rhymix/tests/dir/local.gif" />'
             ),
             // error case
             array(
@@ -213,7 +210,7 @@ class TemplateHandlerTest extends \Codeception\TestCase\Test
             // issue 584
             array(
                 '<img cond="$oBodex->display_extra_images[\'mobile\'] && $arr_extra && $arr_extra->bodex->mobile" src="./images/common/mobile.gif" title="mobile" alt="mobile" />',
-                PHP_EOL . 'if($__Context->oBodex->display_extra_images[\'mobile\'] && $__Context->arr_extra && $__Context->arr_extra->bodex->mobile){ ?><img src="/xe/tests/unit/classes/template/images/common/mobile.gif" title="mobile" alt="mobile" /><?php } ?>'
+                PHP_EOL . 'if($__Context->oBodex->display_extra_images[\'mobile\'] && $__Context->arr_extra && $__Context->arr_extra->bodex->mobile){ ?><img src="/rhymix/tests/unit/classes/template/images/common/mobile.gif" title="mobile" alt="mobile" /><?php } ?>'
             ),
             // issue 831
             array(
@@ -222,8 +219,8 @@ class TemplateHandlerTest extends \Codeception\TestCase\Test
             ),
             // issue 746
             array(
-                '<img src="../myxe/xe/img.png" />',
-                '?><img src="/xe/tests/unit/classes/myxe/xe/img.png" />'
+                '<img src="../whatever/img.png" />',
+                '?><img src="/rhymix/tests/unit/classes/whatever/img.png" />'
             ),
             // issue 696
             array(
@@ -233,47 +230,47 @@ class TemplateHandlerTest extends \Codeception\TestCase\Test
             // https://github.com/xpressengine/xe-core/issues/1510
             array(
                 '<img cond="$foo->bar" src="../common/mobile.gif" />',
-                PHP_EOL . 'if($__Context->foo->bar){ ?><img src="/xe/tests/unit/classes/common/mobile.gif" /><?php } ?>'
+                PHP_EOL . 'if($__Context->foo->bar){ ?><img src="/rhymix/tests/unit/classes/common/mobile.gif" /><?php } ?>'
             ),
             // https://github.com/xpressengine/xe-core/issues/1510
             array(
                 '<img cond="$foo->bar > 100" alt="a!@#$%^&*()_-=[]{}?/" src="../common/mobile.gif" />',
-                PHP_EOL . 'if($__Context->foo->bar > 100){ ?><img alt="a!@#$%^&*()_-=[]{}?/" src="/xe/tests/unit/classes/common/mobile.gif" /><?php } ?>'
+                PHP_EOL . 'if($__Context->foo->bar > 100){ ?><img alt="a!@#$%^&*()_-=[]{}?/" src="/rhymix/tests/unit/classes/common/mobile.gif" /><?php } ?>'
             ),
             // https://github.com/xpressengine/xe-core/issues/1510
             array(
                 '<img src="../common/mobile.gif" cond="$foo->bar" />',
-                PHP_EOL . 'if($__Context->foo->bar){ ?><img src="/xe/tests/unit/classes/common/mobile.gif" /><?php } ?>'
+                PHP_EOL . 'if($__Context->foo->bar){ ?><img src="/rhymix/tests/unit/classes/common/mobile.gif" /><?php } ?>'
             ),
             // https://github.com/xpressengine/xe-core/issues/1510
             array(
                 '<img class="tmp_class" cond="!$module_info->title" src="../img/common/blank.gif" />',
-                PHP_EOL . 'if(!$__Context->module_info->title){ ?><img class="tmp_class" src="/xe/tests/unit/classes/img/common/blank.gif" /><?php } ?>'
+                PHP_EOL . 'if(!$__Context->module_info->title){ ?><img class="tmp_class" src="/rhymix/tests/unit/classes/img/common/blank.gif" /><?php } ?>'
             ),
             // https://github.com/xpressengine/xe-core/issues/1510
             array(
                 '<img cond="$mi->title" class="tmp_class"|cond="$mi->use" src="../img/common/blank.gif" />',
-                PHP_EOL . 'if($__Context->mi->title){ ?><img<?php if($__Context->mi->use){ ?> class="tmp_class"<?php } ?> src="/xe/tests/unit/classes/img/common/blank.gif" /><?php } ?>'
+                PHP_EOL . 'if($__Context->mi->title){ ?><img<?php if($__Context->mi->use){ ?> class="tmp_class"<?php } ?> src="/rhymix/tests/unit/classes/img/common/blank.gif" /><?php } ?>'
             ),
             array(
                 '<input foo="bar" /> <img cond="$foo->bar" alt="alt"   src="../common/mobile.gif" />',
-                '?><input foo="bar" /> <?php if($__Context->foo->bar){ ?><img alt="alt"   src="/xe/tests/unit/classes/common/mobile.gif" /><?php } ?>'
+                '?><input foo="bar" /> <?php if($__Context->foo->bar){ ?><img alt="alt"   src="/rhymix/tests/unit/classes/common/mobile.gif" /><?php } ?>'
             ),
             array(
                 '<input foo="bar" />' . "\n" . '<input foo="bar" /> <img cond="$foo->bar" alt="alt"   src="../common/mobile.gif" />',
-                '?><input foo="bar" />' . PHP_EOL . '<input foo="bar" /> <?php if($__Context->foo->bar){ ?><img alt="alt"   src="/xe/tests/unit/classes/common/mobile.gif" /><?php } ?>'
+                '?><input foo="bar" />' . PHP_EOL . '<input foo="bar" /> <?php if($__Context->foo->bar){ ?><img alt="alt"   src="/rhymix/tests/unit/classes/common/mobile.gif" /><?php } ?>'
             ),
             array(
                 'asf <img src="{$foo->bar}" />',
                 '?>asf <img src="<?php echo $__Context->foo->bar ?>" />'
             ),
             array(
-                '<img alt="" '.PHP_EOL.' src="../myxe/xe/img.png" />',
-                '?><img alt="" '.PHP_EOL.' src="/xe/tests/unit/classes/myxe/xe/img.png" />'
+                '<img alt="" '.PHP_EOL.' src="../whatever/img.png" />',
+                '?><img alt="" '.PHP_EOL.' src="/rhymix/tests/unit/classes/whatever/img.png" />'
             ),
             array(
-                '<input>asdf src="../img/img.gif" asdf</input> <img alt="src" src="../myxe/xe/img.png" /> <input>asdf src="../img/img.gif" asdf</input>',
-                '?><input>asdf src="../img/img.gif" asdf</input> <img alt="src" src="/xe/tests/unit/classes/myxe/xe/img.png" /> <input>asdf src="../img/img.gif" asdf</input>'
+                '<input>asdf src="../img/img.gif" asdf</input> <img alt="src" src="../whatever/img.png" /> <input>asdf src="../img/img.gif" asdf</input>',
+                '?><input>asdf src="../img/img.gif" asdf</input> <img alt="src" src="/rhymix/tests/unit/classes/whatever/img.png" /> <input>asdf src="../img/img.gif" asdf</input>'
             ),
             array(
                 '<input>asdf src="../img/img.gif" asdf</input>',

--- a/tests/unit/framework/SecurityTest.php
+++ b/tests/unit/framework/SecurityTest.php
@@ -100,11 +100,9 @@ class SecurityTest extends \Codeception\TestCase\Test
 		$_SERVER['REQUEST_METHOD'] = 'POST';
 		$this->assertTrue(Rhymix\Framework\Security::checkCSRF());
 		
-		$_SERVER['HTTP_HOST'] = 'www.rhymix.org';
 		$_SERVER['HTTP_REFERER'] = 'http://www.foobar.com/';
 		$this->assertFalse(Rhymix\Framework\Security::checkCSRF());
 		
-		$_SERVER['HTTP_HOST'] = 'www.rhymix.org';
 		$this->assertTrue(Rhymix\Framework\Security::checkCSRF('http://www.rhymix.org/'));
 	}
 	

--- a/tests/unit/framework/URLTest.php
+++ b/tests/unit/framework/URLTest.php
@@ -98,9 +98,10 @@ class URLTest extends \Codeception\TestCase\Test
 		$protocol = \RX_SSL ? 'https://' : 'http://';
 		$_SERVER['HTTP_HOST'] = 'www.rhymix.org';
 		
-		$this->assertEquals($protocol . $_SERVER['HTTP_HOST'] . \RX_BASEURL, Rhymix\Framework\URL::fromServerPath(\RX_BASEDIR));
-		$this->assertEquals($protocol . $_SERVER['HTTP_HOST'] . \RX_BASEURL . 'index.php', Rhymix\Framework\URL::fromServerPath(\RX_BASEDIR . 'index.php'));
-		$this->assertEquals($protocol . $_SERVER['HTTP_HOST'] . \RX_BASEURL . 'foo/bar', Rhymix\Framework\URL::fromServerPath(\RX_BASEDIR . '/foo/bar'));
+		$this->assertEquals($protocol . $_SERVER['HTTP_HOST'] . '/', Rhymix\Framework\URL::fromServerPath(\RX_BASEDIR));
+		$this->assertEquals($protocol . $_SERVER['HTTP_HOST'] . '/index.php', Rhymix\Framework\URL::fromServerPath(\RX_BASEDIR . 'index.php'));
+		$this->assertEquals($protocol . $_SERVER['HTTP_HOST'] . '/foo/bar', Rhymix\Framework\URL::fromServerPath(\RX_BASEDIR . '/foo/bar'));
+		$this->assertEquals(false, Rhymix\Framework\URL::fromServerPath(dirname(dirname(\RX_BASEDIR))));
 		$this->assertEquals(false, Rhymix\Framework\URL::fromServerPath('C:/Windows'));
 	}
 	

--- a/tests/unit/framework/URLTest.php
+++ b/tests/unit/framework/URLTest.php
@@ -4,48 +4,42 @@ class URLTest extends \Codeception\TestCase\Test
 {
 	public function testGetCurrentURL()
 	{
-		$protocol = \RX_SSL ? 'https://' : 'http://';
-		$_SERVER['HTTP_HOST'] = 'www.rhymix.org';
-		$_SERVER['REQUEST_URI'] = '/index.php?foo=bar&xe=sucks';
-		$full_url = $protocol . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
+		$old_request_uri = $_SERVER['REQUEST_URI'];
+		$_SERVER['REQUEST_URI'] = '/rhymix/index.php?foo=bar&xe=sucks';
 		
 		// Getting the current URL
-		$this->assertEquals($full_url, Rhymix\Framework\URL::getCurrentURL());
+		$this->assertEquals('https://www.rhymix.org/rhymix/index.php?foo=bar&xe=sucks', Rhymix\Framework\URL::getCurrentURL());
 		
 		// Adding items to the query string
-		$this->assertEquals($full_url . '&var=1&arr%5B0%5D=2&arr%5B1%5D=3', Rhymix\Framework\URL::getCurrentURL(array('var' => '1', 'arr' => array(2, 3))));
+		$this->assertEquals('https://www.rhymix.org/rhymix/index.php?foo=bar&xe=sucks&var=1&arr%5B0%5D=2&arr%5B1%5D=3', Rhymix\Framework\URL::getCurrentURL(array('var' => '1', 'arr' => array(2, 3))));
 		
 		// Removing item from the query string
-		$this->assertEquals($protocol . $_SERVER['HTTP_HOST'] . '/index.php?xe=sucks', Rhymix\Framework\URL::getCurrentURL(array('foo' => null)));
+		$this->assertEquals('https://www.rhymix.org/rhymix/index.php?xe=sucks', Rhymix\Framework\URL::getCurrentURL(array('foo' => null)));
 		
 		// Removing all items from the query string
-		$this->assertEquals($protocol . $_SERVER['HTTP_HOST'] . '/index.php', Rhymix\Framework\URL::getCurrentURL(array('foo' => null, 'xe' => null)));
+		$this->assertEquals('https://www.rhymix.org/rhymix/index.php', Rhymix\Framework\URL::getCurrentURL(array('foo' => null, 'xe' => null)));
 		
 		// Adding and removing parameters at the same time
-		$this->assertEquals($protocol . $_SERVER['HTTP_HOST'] . '/index.php?xe=sucks&l=ko', Rhymix\Framework\URL::getCurrentURL(array('l' => 'ko', 'foo' => null)));
+		$this->assertEquals('https://www.rhymix.org/rhymix/index.php?xe=sucks&l=ko', Rhymix\Framework\URL::getCurrentURL(array('l' => 'ko', 'foo' => null)));
+		
+		$_SERVER['REQUEST_URI'] = $old_request_uri;
 	}
 	
 	public function testGetCurrentDomainURL()
 	{
-		$protocol = \RX_SSL ? 'https://' : 'http://';
-		$_SERVER['HTTP_HOST'] = 'www.rhymix.org';
-		
-		$this->assertEquals($protocol . $_SERVER['HTTP_HOST'] . '/', Rhymix\Framework\URL::getCurrentDomainURL());
-		$this->assertEquals($protocol . $_SERVER['HTTP_HOST'] . '/', Rhymix\Framework\URL::getCurrentDomainURL('/'));
-		$this->assertEquals($protocol . $_SERVER['HTTP_HOST'] . '/foo/bar', Rhymix\Framework\URL::getCurrentDomainURL('/foo/bar'));
-		$this->assertEquals($protocol . $_SERVER['HTTP_HOST'] . '/index.php?foo=bar', Rhymix\Framework\URL::getCurrentDomainURL('index.php?foo=bar'));
+		$this->assertEquals('https://www.rhymix.org/', Rhymix\Framework\URL::getCurrentDomainURL());
+		$this->assertEquals('https://www.rhymix.org/', Rhymix\Framework\URL::getCurrentDomainURL('/'));
+		$this->assertEquals('https://www.rhymix.org/foo/bar', Rhymix\Framework\URL::getCurrentDomainURL('/foo/bar'));
+		$this->assertEquals('https://www.rhymix.org/rhymix/index.php?foo=bar', Rhymix\Framework\URL::getCurrentDomainURL('rhymix/index.php?foo=bar'));
 	}
 	
 	public function testGetCanonicalURL()
 	{
-		$protocol = \RX_SSL ? 'https://' : 'http://';
-		$_SERVER['HTTP_HOST'] = 'www.rhymix.org';
-		
         $tests = array(
-        	'foo/bar' => $protocol . $_SERVER['HTTP_HOST'] . \RX_BASEURL . 'foo/bar',
-        	'./foo/bar' => $protocol . $_SERVER['HTTP_HOST'] . \RX_BASEURL . 'foo/bar',
-        	'/foo/bar' => $protocol . $_SERVER['HTTP_HOST'] . \RX_BASEURL . 'foo/bar',
-        	'//www.example.com/foo' => $protocol . 'www.example.com/foo',
+        	'foo/bar' => 'https://www.rhymix.org/rhymix/foo/bar',
+        	'./foo/bar' => 'https://www.rhymix.org/rhymix/foo/bar',
+        	'/foo/bar' => 'https://www.rhymix.org/rhymix/foo/bar',
+        	'//www.example.com/foo' => 'https://www.example.com/foo',
         	'http://xn--cg4bkiv2oina.com/' => 'http://삼성전자.com/',
 		);
 		
@@ -71,21 +65,17 @@ class URLTest extends \Codeception\TestCase\Test
 	
 	public function testModifyURL()
 	{
-		$protocol = \RX_SSL ? 'https://' : 'http://';
-		$_SERVER['HTTP_HOST'] = 'www.rhymix.org';
-		$url = $protocol . $_SERVER['HTTP_HOST'] . \RX_BASEURL . 'index.php?foo=bar';
-		
 		// Conversion to absolute
-		$this->assertEquals($url, Rhymix\Framework\URL::modifyURL('./index.php?foo=bar'));
+		$this->assertEquals('https://www.rhymix.org/rhymix/index.php?foo=bar', $url = Rhymix\Framework\URL::modifyURL('./index.php?foo=bar'));
 		
 		// Adding items to the query string
-		$this->assertEquals($url . '&var=1&arr%5B0%5D=2&arr%5B1%5D=3', Rhymix\Framework\URL::modifyURL($url, array('var' => '1', 'arr' => array(2, 3))));
+		$this->assertEquals('https://www.rhymix.org/rhymix/index.php?foo=bar&var=1&arr%5B0%5D=2&arr%5B1%5D=3', Rhymix\Framework\URL::modifyURL($url, array('var' => '1', 'arr' => array(2, 3))));
 		
 		// Removing item from the query string
-		$this->assertEquals($protocol . $_SERVER['HTTP_HOST'] . \RX_BASEURL . 'index.php', Rhymix\Framework\URL::modifyURL($url, array('foo' => null)));
+		$this->assertEquals('https://www.rhymix.org/rhymix/index.php', Rhymix\Framework\URL::modifyURL($url, array('foo' => null)));
 		
 		// Adding and removing parameters at the same time
-		$this->assertEquals($protocol . $_SERVER['HTTP_HOST'] . \RX_BASEURL . 'index.php?l=ko', Rhymix\Framework\URL::modifyURL($url, array('l' => 'ko', 'foo' => null)));
+		$this->assertEquals('https://www.rhymix.org/rhymix/index.php?l=ko', Rhymix\Framework\URL::modifyURL($url, array('l' => 'ko', 'foo' => null)));
 	}
 	
 	public function testIsInternalURL()
@@ -95,23 +85,17 @@ class URLTest extends \Codeception\TestCase\Test
 	
 	public function testURLFromServerPath()
 	{
-		$protocol = \RX_SSL ? 'https://' : 'http://';
-		$_SERVER['HTTP_HOST'] = 'www.rhymix.org';
-		
-		$this->assertEquals($protocol . $_SERVER['HTTP_HOST'] . '/', Rhymix\Framework\URL::fromServerPath(\RX_BASEDIR));
-		$this->assertEquals($protocol . $_SERVER['HTTP_HOST'] . '/index.php', Rhymix\Framework\URL::fromServerPath(\RX_BASEDIR . 'index.php'));
-		$this->assertEquals($protocol . $_SERVER['HTTP_HOST'] . '/foo/bar', Rhymix\Framework\URL::fromServerPath(\RX_BASEDIR . '/foo/bar'));
+		$this->assertEquals('https://www.rhymix.org/rhymix/', Rhymix\Framework\URL::fromServerPath(\RX_BASEDIR));
+		$this->assertEquals('https://www.rhymix.org/rhymix/index.php', Rhymix\Framework\URL::fromServerPath(\RX_BASEDIR . 'index.php'));
+		$this->assertEquals('https://www.rhymix.org/rhymix/foo/bar', Rhymix\Framework\URL::fromServerPath(\RX_BASEDIR . '/foo/bar'));
 		$this->assertEquals(false, Rhymix\Framework\URL::fromServerPath(dirname(dirname(\RX_BASEDIR))));
 		$this->assertEquals(false, Rhymix\Framework\URL::fromServerPath('C:/Windows'));
 	}
 	
 	public function testURLToServerPath()
 	{
-		$protocol = \RX_SSL ? 'https://' : 'http://';
-		$_SERVER['HTTP_HOST'] = 'www.rhymix.org';
-		
-		$this->assertEquals(\RX_BASEDIR . 'index.php', Rhymix\Framework\URL::toServerPath($protocol . $_SERVER['HTTP_HOST'] . \RX_BASEURL . 'index.php'));
-		$this->assertEquals(\RX_BASEDIR . 'foo/bar', Rhymix\Framework\URL::toServerPath($protocol . $_SERVER['HTTP_HOST'] . \RX_BASEURL . '/foo/bar?arg=baz'));
+		$this->assertEquals(\RX_BASEDIR . 'index.php', Rhymix\Framework\URL::toServerPath('http://www.rhymix.org/rhymix/index.php'));
+		$this->assertEquals(\RX_BASEDIR . 'foo/bar', Rhymix\Framework\URL::toServerPath('http://www.rhymix.org/rhymix/foo/bar?arg=baz'));
 		$this->assertEquals(\RX_BASEDIR . 'foo/bar', Rhymix\Framework\URL::toServerPath('./foo/bar'));
 		$this->assertEquals(\RX_BASEDIR . 'foo/bar', Rhymix\Framework\URL::toServerPath('foo/bar/../bar'));
 		$this->assertEquals(false, Rhymix\Framework\URL::toServerPath('http://other.domain.com/'));

--- a/tests/unit/framework/URLTest.php
+++ b/tests/unit/framework/URLTest.php
@@ -25,6 +25,17 @@ class URLTest extends \Codeception\TestCase\Test
 		$this->assertEquals($protocol . $_SERVER['HTTP_HOST'] . '/index.php?xe=sucks&l=ko', Rhymix\Framework\URL::getCurrentURL(array('l' => 'ko', 'foo' => null)));
 	}
 	
+	public function testGetCurrentDomainURL()
+	{
+		$protocol = \RX_SSL ? 'https://' : 'http://';
+		$_SERVER['HTTP_HOST'] = 'www.rhymix.org';
+		
+		$this->assertEquals($protocol . $_SERVER['HTTP_HOST'] . '/', Rhymix\Framework\URL::getCurrentDomainURL());
+		$this->assertEquals($protocol . $_SERVER['HTTP_HOST'] . '/', Rhymix\Framework\URL::getCurrentDomainURL('/'));
+		$this->assertEquals($protocol . $_SERVER['HTTP_HOST'] . '/foo/bar', Rhymix\Framework\URL::getCurrentDomainURL('/foo/bar'));
+		$this->assertEquals($protocol . $_SERVER['HTTP_HOST'] . '/index.php?foo=bar', Rhymix\Framework\URL::getCurrentDomainURL('index.php?foo=bar'));
+	}
+	
 	public function testGetCanonicalURL()
 	{
 		$protocol = \RX_SSL ? 'https://' : 'http://';
@@ -80,6 +91,30 @@ class URLTest extends \Codeception\TestCase\Test
 	public function testIsInternalURL()
 	{
 		// This function is checked in Security::checkCSRF()
+	}
+	
+	public function testURLFromServerPath()
+	{
+		$protocol = \RX_SSL ? 'https://' : 'http://';
+		$_SERVER['HTTP_HOST'] = 'www.rhymix.org';
+		
+		$this->assertEquals($protocol . $_SERVER['HTTP_HOST'] . \RX_BASEURL, Rhymix\Framework\URL::fromServerPath(\RX_BASEDIR));
+		$this->assertEquals($protocol . $_SERVER['HTTP_HOST'] . \RX_BASEURL . 'index.php', Rhymix\Framework\URL::fromServerPath(\RX_BASEDIR . 'index.php'));
+		$this->assertEquals($protocol . $_SERVER['HTTP_HOST'] . \RX_BASEURL . 'foo/bar', Rhymix\Framework\URL::fromServerPath(\RX_BASEDIR . '/foo/bar'));
+		$this->assertEquals(false, Rhymix\Framework\URL::fromServerPath('C:/Windows'));
+	}
+	
+	public function testURLToServerPath()
+	{
+		$protocol = \RX_SSL ? 'https://' : 'http://';
+		$_SERVER['HTTP_HOST'] = 'www.rhymix.org';
+		
+		$this->assertEquals(\RX_BASEDIR . 'index.php', Rhymix\Framework\URL::toServerPath($protocol . $_SERVER['HTTP_HOST'] . \RX_BASEURL . 'index.php'));
+		$this->assertEquals(\RX_BASEDIR . 'foo/bar', Rhymix\Framework\URL::toServerPath($protocol . $_SERVER['HTTP_HOST'] . \RX_BASEURL . '/foo/bar?arg=baz'));
+		$this->assertEquals(\RX_BASEDIR . 'foo/bar', Rhymix\Framework\URL::toServerPath('./foo/bar'));
+		$this->assertEquals(\RX_BASEDIR . 'foo/bar', Rhymix\Framework\URL::toServerPath('foo/bar/../bar'));
+		$this->assertEquals(false, Rhymix\Framework\URL::toServerPath('http://other.domain.com/'));
+		$this->assertEquals(false, Rhymix\Framework\URL::toServerPath('//other.domain.com/'));
 	}
 	
 	public function testEncodeIdna()

--- a/tests/unit/framework/filters/FilenameFilterTest.php
+++ b/tests/unit/framework/filters/FilenameFilterTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Rhymix\Framework\Filters\FilenameFilter;
+
 class FilenameFilterTest extends \Codeception\TestCase\Test
 {
 	public function testFilenameFilterClean()
@@ -35,8 +37,28 @@ class FilenameFilterTest extends \Codeception\TestCase\Test
         
 		foreach ($tests as $from => $to)
 		{
-			$result = Rhymix\Framework\Filters\FilenameFilter::clean($from);
+			$result = FilenameFilter::clean($from);
 			$this->assertEquals($to, $result);
 		}
+	}
+	
+	public function testFilenameFilterCleanPath()
+	{
+		// Remove extra dots and slashes.
+		$this->assertEquals('/usr/share/foo/bar.jpg', FilenameFilter::cleanPath('/usr/share/foo//./baz/../bar.jpg'));
+		$this->assertEquals('/usr/share/foo/bar.jpg', FilenameFilter::cleanPath('/usr/share/foo/././baz/../../foo/bar.jpg'));
+		$this->assertEquals('/usr/share', FilenameFilter::cleanPath('/usr/share/foo/..'));
+		$this->assertEquals('/usr/share', FilenameFilter::cleanPath('/usr/share/foo/bar/../baz/../../'));
+		
+		// Test Windows paths.
+		$this->assertEquals('C:/Windows/Notepad.exe', FilenameFilter::cleanPath('C:\\Windows\\System32\\..\\Notepad.exe'));
+		
+		// Do not remove .. if there is no parent directory.
+		$this->assertEquals('C:/../foobar', FilenameFilter::cleanPath('C:\\..\foobar\\'));
+		$this->assertEquals('/../foobar', FilenameFilter::cleanPath('/../foobar/'));
+		
+		// Remove query strings and URL fragments.
+		$this->assertEquals('index.php', FilenameFilter::cleanPath('index.php?foo=bar'));
+		$this->assertEquals('index.php', FilenameFilter::cleanPath('index.php#baz'));
 	}
 }

--- a/tests/unit/framework/filters/FilenameFilterTest.php
+++ b/tests/unit/framework/filters/FilenameFilterTest.php
@@ -50,6 +50,10 @@ class FilenameFilterTest extends \Codeception\TestCase\Test
 		$this->assertEquals('/usr/share', FilenameFilter::cleanPath('/usr/share/foo/..'));
 		$this->assertEquals('/usr/share', FilenameFilter::cleanPath('/usr/share/foo/bar/../baz/../../'));
 		
+		// Test internal paths.
+		$this->assertEquals(\RX_BASEDIR . 'common/js/debug.js', FilenameFilter::cleanPath('common/js/debug.js'));
+		$this->assertEquals(\RX_BASEDIR . 'common/js/debug.js', FilenameFilter::cleanPath('./common/js/debug.js'));
+		
 		// Test Windows paths.
 		$this->assertEquals('C:/Windows/Notepad.exe', FilenameFilter::cleanPath('C:\\Windows\\System32\\..\\Notepad.exe'));
 		
@@ -58,7 +62,7 @@ class FilenameFilterTest extends \Codeception\TestCase\Test
 		$this->assertEquals('/../foobar', FilenameFilter::cleanPath('/../foobar/'));
 		
 		// Remove query strings and URL fragments.
-		$this->assertEquals('index.php', FilenameFilter::cleanPath('index.php?foo=bar'));
-		$this->assertEquals('index.php', FilenameFilter::cleanPath('index.php#baz'));
+		$this->assertEquals(\RX_BASEDIR . 'index.php', FilenameFilter::cleanPath('index.php?foo=bar'));
+		$this->assertEquals(\RX_BASEDIR . 'index.php', FilenameFilter::cleanPath('index.php#baz'));
 	}
 }

--- a/tests/unit/framework/filters/FilenameFilterTest.php
+++ b/tests/unit/framework/filters/FilenameFilterTest.php
@@ -56,6 +56,11 @@ class FilenameFilterTest extends \Codeception\TestCase\Test
 		
 		// Test Windows paths.
 		$this->assertEquals('C:/Windows/Notepad.exe', FilenameFilter::cleanPath('C:\\Windows\\System32\\..\\Notepad.exe'));
+		$this->assertEquals('//vboxsrv/hello/world', FilenameFilter::cleanPath('\\\\vboxsrv\\hello\\world'));
+		
+		// Test absolute URLs.
+		$this->assertEquals('https://www.rhymix.org/foo/bar', FilenameFilter::cleanPath('https://www.rhymix.org/foo/.//bar'));
+		$this->assertEquals('//www.rhymix.org/foo/bar', FilenameFilter::cleanPath('//www.rhymix.org/foo/.//bar'));
 		
 		// Do not remove .. if there is no parent directory.
 		$this->assertEquals('C:/../foobar', FilenameFilter::cleanPath('C:\\..\foobar\\'));


### PR DESCRIPTION
#368 에서 제안하셨던 기능들을 몇 개의 함수로 분리하여 구현해 보았습니다.

### clean_path()

주어진 경로에서 `./`, `../`, `//` 등을 제거하고 절대경로로 바꾸어 깨끗하게 정리합니다. `realpath()`와 비슷한 기능이지만 실제 파일 존재 여부를 체크하지 않습니다.

아래와 같은 경로는 이미 절대경로인 것으로 인식합니다.

- 리눅스 등 유닉스계열 O/S에서 `/`로 시작하는 경로
- 윈도우에서 `C:\`, `D:\`, `\\Network\Share` 등으로 시작하는 경로
- 도메인을 포함한 URL (`https://www.rhymix.org/`, `//www.rhymix.org/` 등)

윈도우 공유 폴더 경로에 포함된 `\\`, URL에서 도메인 앞에 사용되는 `//`는 정리되지 않습니다.

### path2url()

주어진 서버측 로컬 경로를 URL로 변환합니다.

입력: `/home/username/public_html/rx/common/js/debug.js`
출력: `https://www.rhymix.org/rx/common/js/debug.js`

Document root 외부에 있는 로컬 경로는 URL을 가질 수 없으므로 false를 반환합니다.

라이믹스 설치 경로를 기준으로 한 상대경로도 인식합니다. 예: `common/js/debug.js`

### url2path()

주어진 URL을 서버측 로컬 경로로 변환합니다. 로컬 경로에서 무의미한 쿼리 부분은 제거됩니다.

입력: `https://www.rhymix.org/rx/common/js/debug.js?1234567890#foo`
출력: `/home/username/public_html/rx/common/js/debug.js`

현재 사이트에서 사용하지 않는 도메인은 로컬 경로를 가질 수 없으므로 false를 반환합니다.

라이믹스 설치 경로를 기준으로 한 상대경로도 인식합니다. 예: `common/js/debug.js`
