### PR TITLE
언어 처리 성능 및 기능 개선

### DIFF
--- a/common/framework/lang.php
+++ b/common/framework/lang.php
@@ -176,7 +176,19 @@ class Lang
 	{
 		$args = func_get_args();
 		array_shift($args);
-		return $this->__call($key, $args);
+		if (count($args) === 1 && is_array($args[0]))
+		{
+			$args = $args[0];
+		}
+		
+		// Get the translation.
+		$translation = $this->__get($key);
+		
+		// If there are no arguments, return the translation.
+		if (!count($args)) return $translation;
+		
+		// If there are arguments, interpolate them into the translation and return the result.
+		return vsprintf($translation, $args);
 	}
 	
 	/**
@@ -338,16 +350,6 @@ class Lang
 	 */
 	public function __call($key, $args = array())
 	{
-		// Remove a colon from the beginning of the string.
-		if ($key !== '' && $key[0] === ':') $key = substr($key, 1);
-		
-		// Find the translation.
-		$translation = $this->__get($key);
-		
-		// If there are no arguments, return the translation.
-		if (!count($args)) return $translation;
-		
-		// If there are arguments, interpolate them into the translation and return the result.
-		return vsprintf($translation, $args);
+		return $this->get($key, $args);
 	}
 }

--- a/tests/unit/framework/LangTest.php
+++ b/tests/unit/framework/LangTest.php
@@ -41,6 +41,19 @@ class LangTest extends \Codeception\TestCase\Test
 		$this->assertEquals('admin.help', $ko->get('admin.help'));
 		$this->assertEquals('admin.help', $en->get('admin.help'));
 		
+		// Test setting new keys with and without namespacing.
+		$ko->set('foo', 'FOO!');
+		$this->assertEquals('FOO!', $ko->get('foo'));
+		$ko->set('common.foobar', 'FOOBAR!');
+		$this->assertEquals('FOOBAR!', $ko->get('common.foobar'));
+		$this->assertEquals('FOOBAR!', $ko->get('foobar'));
+		
+		// Test setting new keys with multidimensional arrays.
+		$ko->set('common.time_gap.foobar', 'FOOBAR!');
+		$this->assertEquals('FOOBAR!', $ko->get('common.time_gap.foobar'));
+		$ko->set('common.foobar.baz', 'BAZ!');
+		$this->assertNotEquals('BAZ!', $ko->get('common.foobar.baz'));
+		
 		// Test fallback to English.
 		$en->only_in_english = 'Hello world';
 		$this->assertEquals('Hello world', $ko->only_in_english);

--- a/tests/unit/framework/LangTest.php
+++ b/tests/unit/framework/LangTest.php
@@ -4,30 +4,50 @@ class LangTest extends \Codeception\TestCase\Test
 {
 	public function testLang()
 	{
+		// Test separation of languages.
 		$ko = Rhymix\Framework\Lang::getInstance('ko');
 		$en = Rhymix\Framework\Lang::getInstance('en');
 		$this->assertTrue($ko instanceof Rhymix\Framework\Lang);
 		$this->assertTrue($en instanceof Rhymix\Framework\Lang);
 		$this->assertFalse($ko === $en);
 		
+		// Test backward compatible language code for Japanese.
 		$ja = Rhymix\Framework\Lang::getInstance('ja');
 		$jp = Rhymix\Framework\Lang::getInstance('jp');
 		$this->assertTrue($ja === $jp);
 		
-		$this->assertEquals('도움말', $ko->get('common.help'));
-		$this->assertEquals('Help', $en->get('common.help'));
-		$this->assertEquals('도움말', $ko->help);
-		$this->assertEquals('Help', $en->help);
-		
-		$this->assertEquals('common.nonexistent', $ko->get('common.nonexistent'));
-		$this->assertEquals('common.nonexistent', $ko->get('common.nonexistent', 'foo', 'bar'));
-		
-		$this->assertEquals('admin.help', $ko->get('admin.help'));
-		$this->assertEquals('admin.help', $en->get('admin.help'));
-		
+		// Test loading new plugins.
+		$this->assertNotEquals('ヘルプ', $ja->help);
 		$ja->loadPlugin('common');
 		$this->assertEquals('ヘルプ', $ja->help);
 		
+		// Test simple translations with namespacing.
+		$this->assertEquals('도움말', $ko->get('common.help'));
+		$this->assertEquals('Help', $en->get('common.help'));
+		
+		// Test simple translations without namespacing.
+		$this->assertEquals('도움말', $ko->help);
+		$this->assertEquals('Help', $en->help);
+		
+		// Test complex translations with multidimensional arrays.
+		$this->assertEquals('%d분 전', $ko->get('common.time_gap.min'));
+		$this->assertEquals('10분 전', $ko->get('common.time_gap.min', 10));
+		$this->assertTrue($ko->get('common.time_gap') instanceof \ArrayObject);
+		$this->assertEquals('%d분 전', $ko->get('common.time_gap')->min);
+		
+		// Test nonexistent keys.
+		$this->assertEquals('common.nonexistent', $ko->get('common.nonexistent'));
+		$this->assertEquals('common.nonexistent', $ko->get('common.nonexistent', 'foo', 'bar'));
+		$this->assertEquals('admin.help', $ko->get('admin.help'));
+		$this->assertEquals('admin.help', $en->get('admin.help'));
+		
+		// Test fallback to English.
+		$en->only_in_english = 'Hello world';
+		$this->assertEquals('Hello world', $ko->only_in_english);
+		$this->assertEquals('Hello world', $en->only_in_english);
+		$this->assertEquals('Hello world', $ja->only_in_english);
+		
+		// Test string interpolation.
 		$ko->foobartestlang = '%s님 안녕하세요?';
 		$this->assertEquals('Travis님 안녕하세요?', $ko->foobartestlang('Travis'));
 		$en->foobartestlang = 'Hello, %s!';


### PR DESCRIPTION
- 영어 이외의 언어를 로딩할 때 속도 30~40% 향상 (원하는 키가 없을 때만 체크하도록 변경)
- 배열 깊숙히 들어 있는 번역문도 `lang('document.search_target_list.readed_count');` 이런 문법으로 한 번에 불러올 수 있도록 개선 (플러그인 명칭을 포함해야 작동합니다)
- 함수 내부 구조 일부 정리
- 유닛 테스트 확대