### PR TITLE
본문 삽입시 URL을 상대경로로 변경

### DIFF
--- a/common/js/plugins/jquery.fileupload/js/main.js
+++ b/common/js/plugins/jquery.fileupload/js/main.js
@@ -103,7 +103,7 @@
 
 					if(result.error == 0) {
 						if(/\.(jpe?g|png|gif)$/i.test(result.source_filename)) {
-							temp_code += '<img src="' + window.request_uri + result.download_url + '" alt="' + result.source_filename + '" editor_component="image_link" data-file-srl="' + result.file_srl + '" />';
+							temp_code += '<img src="' + result.download_url + '" alt="' + result.source_filename + '" editor_component="image_link" data-file-srl="' + result.file_srl + '" />';
 							temp_code += "\r\n<p><br></p>\r\n";
 						}
 
@@ -244,10 +244,10 @@
 				if(!fileinfo) return;
 
 				if(/\.(jpe?g|png|gif)$/i.test(fileinfo.source_filename)) {
-					temp_code += '<img src="' + window.request_uri + fileinfo.download_url + '" alt="' + fileinfo.source_filename + '" editor_component="image_link" data-file-srl="' + fileinfo.file_srl + '" />';
+					temp_code += '<img src="' + fileinfo.download_url + '" alt="' + fileinfo.source_filename + '" editor_component="image_link" data-file-srl="' + fileinfo.file_srl + '" />';
 					temp_code += "\r\n<p><br></p>\r\n";
 				} else {
-					temp_code += '<a href="' + window.request_uri + fileinfo.download_url + '" data-file-srl="' + fileinfo.file_srl + '">' + fileinfo.source_filename + "</a>\n";
+					temp_code += '<a href="' + fileinfo.download_url + '" data-file-srl="' + fileinfo.file_srl + '">' + fileinfo.source_filename + "</a>\n";
 				}
 
 			});
@@ -379,6 +379,3 @@
 		return u;
 	};
 })(jQuery);
-
-
-

--- a/modules/editor/skins/ckeditor/js/xe_interface.js
+++ b/modules/editor/skins/ckeditor/js/xe_interface.js
@@ -19,8 +19,6 @@ function editorGetContent(editor_sequence) {
 
 //Replace html content to editor
 function editorReplaceHTML(iframe_obj, content) {
-	content = editorReplacePath(content);
-
 	var editor_sequence = parseInt(iframe_obj.id.replace(/^.*_/, ''), 10);
 
 	_getCkeInstance(editor_sequence).insertHtml(content, "unfiltered_html");
@@ -28,17 +26,4 @@ function editorReplaceHTML(iframe_obj, content) {
 
 function editorGetIFrame(editor_sequence) {
 	return jQuery('#ckeditor_instance_' + editor_sequence).get(0);
-}
-
-
-function editorReplacePath(content) {
-	// 태그 내 src, href, url의 XE 상대경로를 http로 시작하는 full path로 변경
-	content = content.replace(/\<([^\>\<]*)(src=|href=|url\()("|\')*([^"\'\)]+)("|\'|\))*(\s|>)*/ig, function(m0,m1,m2,m3,m4,m5,m6) {
-		if(m2=="url(") { m3=''; m5=')'; } else { if(typeof(m3)=='undefined') m3 = '"'; if(typeof(m5)=='undefined') m5 = '"'; if(typeof(m6)=='undefined') m6 = ''; }
-		var val = jQuery.trim(m4).replace(/^\.\//,'');
-		if(/^(http\:|https\:|ftp\:|telnet\:|mms\:|mailto\:|\/|\.\.|\#)/i.test(val)) return m0;
-		return '<'+m1+m2+m3+request_uri+val+m5+m6;
-	});
-
-	return content;
 }

--- a/modules/editor/skins/xpresseditor/js/xe_interface.js
+++ b/modules/editor/skins/xpresseditor/js/xe_interface.js
@@ -41,9 +41,6 @@ function editorStart_xe(editor_sequence, primary_key, content_key, editor_height
 	var content = form[content_key].value;
 	if(xFF && !content) content = '<br />';
 
-	// src, href, url의 XE 상대경로를 http로 시작하는 full path로 변경
-	content = editorReplacePath(content);
-
 	form[content_key].value = content;
 	jQuery("#xpress-editor-"+editor_sequence).val(content);
 
@@ -203,22 +200,8 @@ function editorGetIframe(srl) {
 }
 
 function editorReplaceHTML(iframe_obj, content) {
-	// src, href, url의 XE 상대경로를 http로 시작하는 full path로 변경
-	content = editorReplacePath(content);
-
 	var srl = parseInt(iframe_obj.id.replace(/^.*_/,''),10);
 	editorRelKeys[srl]["pasteHTML"](content);
-}
-
-function editorReplacePath(content) {
-	// 태그 내 src, href, url의 XE 상대경로를 http로 시작하는 full path로 변경
-	content = content.replace(/\<([^\>\<]*)(src=|href=|url\()("|\')*([^"\'\)]+)("|\'|\))*(\s|>)*/ig, function(m0,m1,m2,m3,m4,m5,m6) {
-		if(m2=="url(") { m3=''; m5=')'; } else { if(typeof(m3)=='undefined') m3 = '"'; if(typeof(m5)=='undefined') m5 = '"'; if(typeof(m6)=='undefined') m6 = ''; }
-		var val = jQuery.trim(m4).replace(/^\.\//,'');
-		if(/^(http\:|https\:|ftp\:|telnet\:|mms\:|mailto\:|\/|\.\.|\#)/i.test(val)) return m0;
-		return '<'+m1+m2+m3+request_uri+val+m5+m6;
-	});
-	return content;
 }
 
 function editorGetAutoSavedDoc(form) {

--- a/modules/editor/skins/xpresseditor/js/xpresseditor.js
+++ b/modules/editor/skins/xpresseditor/js/xpresseditor.js
@@ -5868,9 +5868,6 @@ function editorStart_xe(editor_sequence, primary_key, content_key, editor_height
 	var content = form[content_key].value;
 	if(xFF && !content) content = '<br />';
 
-	// src, href, url의 XE 상대경로를 http로 시작하는 full path로 변경
-	content = editorReplacePath(content);
-
 	form[content_key].value = content;
 	jQuery("#xpress-editor-"+editor_sequence).val(content);
 
@@ -6030,22 +6027,8 @@ function editorGetIframe(srl) {
 }
 
 function editorReplaceHTML(iframe_obj, content) {
-	// src, href, url의 XE 상대경로를 http로 시작하는 full path로 변경
-	content = editorReplacePath(content);
-
 	var srl = parseInt(iframe_obj.id.replace(/^.*_/,''),10);
 	editorRelKeys[srl]["pasteHTML"](content);
-}
-
-function editorReplacePath(content) {
-	// 태그 내 src, href, url의 XE 상대경로를 http로 시작하는 full path로 변경
-	content = content.replace(/\<([^\>\<]*)(src=|href=|url\()("|\')*([^"\'\)]+)("|\'|\))*(\s|>)*/ig, function(m0,m1,m2,m3,m4,m5,m6) {
-		if(m2=="url(") { m3=''; m5=')'; } else { if(typeof(m3)=='undefined') m3 = '"'; if(typeof(m5)=='undefined') m5 = '"'; if(typeof(m6)=='undefined') m6 = ''; }
-		var val = jQuery.trim(m4).replace(/^\.\//,'');
-		if(/^(http\:|https\:|ftp\:|telnet\:|mms\:|mailto\:|\/|\.\.|\#)/i.test(val)) return m0;
-		return '<'+m1+m2+m3+request_uri+val+m5+m6;
-	});
-	return content;
 }
 
 function editorGetAutoSavedDoc(form) {

--- a/modules/file/file.controller.php
+++ b/modules/file/file.controller.php
@@ -45,13 +45,15 @@ class fileController extends file
 		if(!$upload_target_srl) $_SESSION['upload_info'][$editor_sequence]->upload_target_srl = $upload_target_srl = getNextSequence();
 
 		$output = $this->insertFile($file_info, $module_srl, $upload_target_srl);
+		
 		Context::setResponseMethod('JSON');
 		$this->add('file_srl', $output->get('file_srl'));
 		$this->add('file_size', $output->get('file_size'));
 		$this->add('direct_download', $output->get('direct_download'));
 		$this->add('source_filename', $output->get('source_filename'));
-		$this->add('download_url', $output->get('uploaded_filename'));
 		$this->add('upload_target_srl', $output->get('upload_target_srl'));
+		$this->add('download_url', $oFileModel->getDirectFileUrl($output->get('uploaded_filename')));
+		
 		if($output->error != '0') $this->stop($output->message);
 	}
 

--- a/modules/file/file.controller.php
+++ b/modules/file/file.controller.php
@@ -46,12 +46,12 @@ class fileController extends file
 
 		$output = $this->insertFile($file_info, $module_srl, $upload_target_srl);
 		Context::setResponseMethod('JSON');
-		$this->add('file_srl',$output->get('file_srl'));
-		$this->add('file_size',$output->get('file_size'));
-		$this->add('direct_download',$output->get('direct_download'));
-		$this->add('source_filename',$output->get('source_filename'));
-		$this->add('download_url',$output->get('uploaded_filename'));
-		$this->add('upload_target_srl',$output->get('upload_target_srl'));
+		$this->add('file_srl', $output->get('file_srl'));
+		$this->add('file_size', $output->get('file_size'));
+		$this->add('direct_download', $output->get('direct_download'));
+		$this->add('source_filename', $output->get('source_filename'));
+		$this->add('download_url', $output->get('uploaded_filename'));
+		$this->add('upload_target_srl', $output->get('upload_target_srl'));
 		if($output->error != '0') $this->stop($output->message);
 	}
 

--- a/modules/file/file.model.php
+++ b/modules/file/file.model.php
@@ -47,8 +47,14 @@ class fileModel extends file
 				$obj->source_filename = $file_info->source_filename;
 				$obj->file_size = $file_info->file_size;
 				$obj->disp_file_size = FileHandler::filesize($file_info->file_size);
-				if($file_info->direct_download=='N') $obj->download_url = $this->getDownloadUrl($file_info->file_srl, $file_info->sid, $file_info->module_srl);
-				else $obj->download_url = $file_info->uploaded_filename;
+				if($file_info->direct_download == 'N')
+				{
+					$obj->download_url = $this->getDownloadUrl($file_info->file_srl, $file_info->sid, $file_info->module_srl);
+				}
+				else
+				{
+					$obj->download_url = $this->getDirectFileUrl($file_info->uploaded_filename);
+				}
 				$obj->direct_download = $file_info->direct_download;
 				$obj->cover_image = ($file_info->cover_image === 'Y') ? true : false;
 				$files[] = $obj;
@@ -109,7 +115,23 @@ class fileModel extends file
 	{
 		return sprintf('?module=%s&amp;act=%s&amp;file_srl=%s&amp;sid=%s&amp;module_srl=%s', 'file', 'procFileDownload', $file_srl, $sid, $module_srl);
 	}
+	
+	/**
+	 * Return direct download file url
+	 *
+	 * @param string $path
+	 * @return string
+	 */
+	function getDirectFileUrl($path)
+	{
+		if(dirname($_SERVER['SCRIPT_NAME']) == '/' || dirname($_SERVER['SCRIPT_NAME']) == '\\')
+		{
+			return '/' . substr($path, 2);
+		}
 
+		return dirname($_SERVER['SCRIPT_NAME']) . '/' . substr($path, 2);
+	}
+	
 	/**
 	 * Get file configurations
 	 *

--- a/modules/file/file.model.php
+++ b/modules/file/file.model.php
@@ -48,7 +48,7 @@ class fileModel extends file
 				$obj->file_size = $file_info->file_size;
 				$obj->disp_file_size = FileHandler::filesize($file_info->file_size);
 				if($file_info->direct_download=='N') $obj->download_url = $this->getDownloadUrl($file_info->file_srl, $file_info->sid, $file_info->module_srl);
-				else $obj->download_url = str_replace('./', '', $file_info->uploaded_filename);
+				else $obj->download_url = $file_info->uploaded_filename;
 				$obj->direct_download = $file_info->direct_download;
 				$obj->cover_image = ($file_info->cover_image === 'Y') ? true : false;
 				$files[] = $obj;

--- a/modules/widget/tpl/js/widget.js
+++ b/modules/widget/tpl/js/widget.js
@@ -200,7 +200,6 @@ function doSyncPageContent() {
 			if(!fo_obj.document_srl || fo_obj.document_srl.value == '0') {
 				try {
 					var content = Base64.decode(xInnerHtml(obj));
-					content = editorReplacePath(content);
 					get_by_id("content_fo").content.value = content;
 					xe.Editors["1"].exec("SET_IR", [content]);
 				}


### PR DESCRIPTION
첨부파일 업로드후 이미지를 본문 삽입할 경우 아래와 같이 전체 URL(도메인 포함)이 지정되어 삽입됩니다.

![1](https://cloud.githubusercontent.com/assets/8565457/13876769/d5e69738-ed49-11e5-8c09-852ca0df45f0.png)

이렇게 되면 사이트 도메인을 변경할 경우 (기존 도메인은 해지) 이전 게시물의 본문삽입 이미지는 무조건 엑박뜬다는 문제가 있습니다.

따라서 해당 문제의 해결을 위해 본문삽입 URL을 다시 상대 경로로 변경합니다.

    <img alt="a.png" editor_component="image_link" src="/files/attach/images/195/750/002/205e5e8821dbf86f5058dfbc3df3e546.png" />