### PR TITLE
관리자가 글을 수정할 때 HTML 필터링이 적용되는 문제 수정

### DIFF
--- a/modules/comment/comment.controller.php
+++ b/modules/comment/comment.controller.php
@@ -829,9 +829,9 @@ class commentController extends comment
 		}
 
 		// set modifier's information if logged-in and posting author and modifier are matched.
+		$logged_info = Context::get('logged_info');
 		if(Context::get('is_logged'))
 		{
-			$logged_info = Context::get('logged_info');
 			if($source_obj->member_srl == $logged_info->member_srl)
 			{
 				$obj->member_srl = $logged_info->member_srl;

--- a/modules/document/document.controller.php
+++ b/modules/document/document.controller.php
@@ -610,9 +610,9 @@ class documentController extends document
 		}
 
 		// If an author is identical to the modifier or history is used, use the logged-in user's information.
+		$logged_info = Context::get('logged_info');
 		if(Context::get('is_logged') && !$manual_updated && $module_info->use_anonymous != 'Y')
 		{
-			$logged_info = Context::get('logged_info');
 			if($source_obj->get('member_srl')==$logged_info->member_srl)
 			{
 				$obj->member_srl = $logged_info->member_srl;


### PR DESCRIPTION
XE 1.8.18에서 제보된 문제를 일으켰던 패치가 라이믹스에도 적용되어 있기에 수정합니다.

- xpressengine/xe-core#1876
- xpressengine/xe-core#1882
- https://www.xpressengine.com/qna/23134182
- https://www.xetown.com/qna/235368