### PR TITLE
ModuleHandler에서 return하는 경우 디버그 정보가 남지 않는 문제 수정

### DIFF
--- a/classes/context/Context.class.php
+++ b/classes/context/Context.class.php
@@ -448,6 +448,12 @@ class Context
 	 */
 	public static function close()
 	{
+		// Save debugging information.
+		if (!DisplayHandler::$debug_printed)
+		{
+			DisplayHandler::getDebugInfo();
+		}
+		
 		// Check session status and close it if open.
 		if (self::checkSessionStatus())
 		{

--- a/classes/display/DisplayHandler.class.php
+++ b/classes/display/DisplayHandler.class.php
@@ -12,6 +12,7 @@
 class DisplayHandler extends Handler
 {
 	public static $response_size = 0;
+	public static $debug_printed = 0;
 	var $content_size = 0; // /< The size of displaying contents
 	var $gz_enabled = FALSE; // / <a flog variable whether to call contents after compressing by gzip
 	var $handler = NULL;
@@ -136,16 +137,34 @@ class DisplayHandler extends Handler
 	 * 
 	 * @return string
 	 */
-	public function getDebugInfo(&$output)
+	public function getDebugInfo(&$output = null)
 	{
+		// Check if debugging information has already been printed.
+		
+		if (self::$debug_printed)
+		{
+			return;
+		}
+		else
+		{
+			self::$debug_printed = 1;
+		}
+		
 		// Check if debugging is enabled for this request.
 		if (!config('debug.enabled') || !Rhymix\Framework\Debug::isEnabledForCurrentUser())
 		{
 			return;
 		}
 		
+		// Do not display debugging information if there is no output.
+		$display_type = config('debug.display_type');
+		if ($output === null && $display_type !== 'file')
+		{
+			return;
+		}
+		
 		// Print debug information.
-		switch ($display_type = config('debug.display_type'))
+		switch ($display_type)
 		{
 			case 'panel':
 				$data = Rhymix\Framework\Debug::getDebugData();


### PR DESCRIPTION
ModuleHandler 실행 도중 return해버리는 경우 DisplayHandler가 실행되지 않아서 디버그 정보가 기록되지 않는 문제를 수정합니다.

마지막으로 실행되는 `Context::close()`에서 디버그 정보 출력 여부를 다시 확인하도록 변경했습니다.