### PR TITLE
알림센터에 각각의 페이지의 설정이 따로따로 저장되던 문제점 개선.

### DIFF
--- a/modules/ncenterlite/ncenterlite.admin.controller.php
+++ b/modules/ncenterlite/ncenterlite.admin.controller.php
@@ -34,18 +34,17 @@ class ncenterliteAdminController extends ncenterlite
 		}
 		foreach($config_vars as $val)
 		{
-
-			if($obj->disp_act == 'dispNcenterliteAdminConfig' && !$obj->mention_format)
-			{
-				$config->mention_format = array();
-			}
 			if($obj->{$val})
 			{
 				$config->{$val} = $obj->{$val};
 			}
-			if($obj->{$val} == null)
+			if($obj->disp_act == 'dispNcenterliteAdminConfig' && !$obj->anonymous_name)
 			{
-				$config->{$val} = null;
+				$config->anonymous_name = null;
+			}
+			if($obj->disp_act == 'dispNcenterliteAdminConfig' && !$obj->mention_format)
+			{
+				$config->mention_format = array();
 			}
 			if($obj->disp_act == 'dispNcenterliteAdminSeletedmid' && !$obj->hide_module_srls)
 			{
@@ -56,7 +55,6 @@ class ncenterliteAdminController extends ncenterlite
 				$config->admin_comment_module_srls = array();
 			}
 		}
-
 		$output = $oModuleController->updateModuleConfig('ncenterlite', $config);
 		if(!$output->toBool())
 		{


### PR DESCRIPTION
#417
빈값으로 들어온 정보가 있어서 전체적인 데이터에서 빈값으로 들어오는 데이터에 대해서 빈값으로 반환하도록 햇더니.. 각각의 페이지마다 저장값이 달라지던 문제점이 생겼음.

이를 고침.
