### PR TITLE
아이프레임, 오브젝트 태그 src에서 http 가 없으면 무조건 필터 되는 문제 수정

### DIFF
--- a/common/framework/filters/mediafilter.php
+++ b/common/framework/filters/mediafilter.php
@@ -79,7 +79,7 @@ class MediaFilter
 	 */
 	public static function formatPrefix($prefix)
 	{
-		$prefix = preg_match('@^https?://(.*)$@i', $prefix, $matches) ? $matches[1] : $prefix;
+		$prefix = preg_match('@^(https?:)?//(.*)$@i', $prefix, $matches) ? $matches[2] : $prefix;
 		if (strpos($prefix, '/') === false)
 		{
 			$prefix .= '/';
@@ -117,7 +117,7 @@ class MediaFilter
 		{
 			$result[] = str_replace('\*\.', '[a-z0-9-]+\.', preg_quote($domain, '%'));
 		}
-		return '%^https?://(' . implode('|', $result) . ')%';
+		return '%^(https?:)?//(' . implode('|', $result) . ')%';
 	}
 	
 	/**
@@ -150,7 +150,7 @@ class MediaFilter
 		{
 			$result[] = str_replace('\*\.', '[a-z0-9-]+\.', preg_quote($domain, '%'));
 		}
-		return '%^https?://(' . implode('|', $result) . ')%';
+		return '%^(https?:)?//(' . implode('|', $result) . ')%';
 	}
 	
 	/**


### PR DESCRIPTION
https://www.xetown.com/qna/248526

`//www.youtube.com/embed/HR_NEwTxxQ8` 와 같이 `http:`가 없으면 무조건 필터되는 문제를 수정합니다.