### PR TITLE
RSS 통합 피드가 작동하지 않는 버그 수정

### DIFF
--- a/modules/rss/rss.view.php
+++ b/modules/rss/rss.view.php
@@ -34,7 +34,7 @@ class rssView extends rss
 		{
 			$site_module_info = Context::get('site_module_info');
 			$site_srl = $site_module_info->site_srl;
-			$mid = Context::get('mid'); // The target module id, if absent, then all
+			$mid = isset($_REQUEST['mid']) ? Context::get('mid') : null;
 			$start_date = (int)Context::get('start_date');
 			$end_date = (int)Context::get('end_date');
 
@@ -42,6 +42,7 @@ class rssView extends rss
 			$rss_config = array();
 			$total_config = '';
 			$total_config = $oModuleModel->getModuleConfig('rss');
+			
 			// If one is specified, extract only for this mid
 			if($mid)
 			{
@@ -52,8 +53,8 @@ class rssView extends rss
 					$module_srls[] = $module_srl; 
 					$open_rss_config[$module_srl] = $config->open_rss;
 				}
-				// If mid is not selected, then get all
 			}
+			// If mid is not selected, then get all
 			else
 			{
 				if($total_config->use_total_feed != 'N')
@@ -73,7 +74,10 @@ class rssView extends rss
 				}
 			}
 
-			if(!count($module_srls) && !$add_description) return $this->dispError();
+			if (!count($module_srls) && !$add_description)
+			{
+				return $this->dispError();
+			}
 
 			$info = new stdClass;
 			$args = new stdClass;


### PR DESCRIPTION
각 모듈의 RSS 피드는 잘 작동하지만, 통합 피드는 항상 잠겨 있다고 나오는 버그를 수정합니다. `mid`가 비어 있으면 통합 피드, 그렇지 않으면 모듈별 피드로 판단하는데, 언젠가부터 `mid`가 빈 경우 모듈핸들러에서 기본 `mid`를 자동으로 채워주도록 변경된 것 같습니다.

참고 링크: https://www.xetown.com/qna/251634
참고 이슈: xpressengine/xe-core#1886