### PR TITLE
파비콘 URL에 상대경로를 사용하고 mtime을 추가하도록 변경

### DIFF
--- a/modules/admin/admin.admin.model.php
+++ b/modules/admin/admin.admin.model.php
@@ -943,24 +943,30 @@ class adminAdminModel extends admin
 
 	function iconUrlCheck($iconname, $default_icon_name, $default)
 	{
+		if ($default)
+		{
+			return \RX_BASEURL . 'modules/admin/tpl/img/' . $default_icon_name;
+		}
+		
 		$site_info = Context::get('site_module_info');
-		$virtual_site = '';
-		if($site_info->site_srl) 
+		if ($site_info->site_srl) 
 		{
 			$virtual_site = $site_info->site_srl . '/';
 		}
-
-		$file_exsit = FileHandler::readFile(_XE_PATH_ . 'files/attach/xeicon/' . $virtual_site . $iconname);
-		if(!$file_exsit && $default === true)
-        {
-            $icon_url = './modules/admin/tpl/img/' . $default_icon_name;
-        }
-        elseif($file_exsit)
+		else
 		{
-			$default_url = Context::getDefaultUrl();
-			$icon_url = $default_url . 'files/attach/xeicon/' . $virtual_site . $iconname;
+			$virtual_site = '';
 		}
-		return $icon_url;
+		
+		$filename = 'files/attach/xeicon/' . $virtual_site . $iconname;
+		if (Rhymix\Framework\Storage::exists(\RX_BASEDIR . $filename))
+		{
+			return \RX_BASEURL . $filename . '?' . date('YmdHis', filemtime(\RX_BASEDIR . $filename));
+		}
+		else
+		{
+			return false;
+		}
 	}
 
 }


### PR DESCRIPTION
참고 링크: https://www.xetown.com/qna/251490

파비콘과 모바일 아이콘 URL이 항상 "기본 URL"을 포함한 절대경로로 생성되어서 SSL 선택적 사용시 문제가 발생하고, mtime이 지정되지 않아서 아이콘을 변경하더라도 캐시 갱신이 되지 않는 문제를 수정합니다.