### PR TITLE
캐시 파일을 쓸 수 없을때 화면 출력이 되지않는 문제 수정

### DIFF
--- a/classes/template/TemplateHandler.class.php
+++ b/classes/template/TemplateHandler.class.php
@@ -142,7 +142,11 @@ class TemplateHandler
 			if(Rhymix\Framework\Storage::write($this->compiled_file, $buff) === false)
 			{
 				$tmpfilename = tempnam(sys_get_temp_dir(), 'rx-compiled');
-				Rhymix\Framework\Storage::write($tmpfilename, $buff);
+				if($tmpfilename === false || Rhymix\Framework\Storage::write($tmpfilename, $buff) === false)
+				{
+					return 'Fatal Error : Cannot create temporary file. Please check permissions.';
+				}
+				
 				$this->compiled_file = $tmpfilename;
 			}
 		}


### PR DESCRIPTION
라이믹스 초기 설치시, 라이믹스 디렉토리에 쓰기권한(777)이 주어지지않으면 빈 화면이(500에러 아님) 나타나는 문제를 수정합니다.

이것은 PHP에러가 아니라 황당하게도 템플릿 엔진에서 캐시파일을 쓰지못하면서 발생한 문제였습니다.