### PR TITLE
Item 클래스에도 autoload 적용

### DIFF
--- a/common/autoload.php
+++ b/common/autoload.php
@@ -58,7 +58,6 @@ $GLOBALS['RX_AUTOLOAD_FILE_MAP'] = array_change_key_case(array(
 	'ConditionWithArgument' => 'classes/db/queryparts/condition/ConditionWithArgument.class.php',
 	'ConditionWithoutArgument' => 'classes/db/queryparts/condition/ConditionWithoutArgument.class.php',
 	'ClickCountExpression' => 'classes/db/queryparts/expression/ClickCountExpression.class.php',
-	'documentItem' => 'modules/document/document.item.php',
 	'DeleteExpression' => 'classes/db/queryparts/expression/DeleteExpression.class.php',
 	'Expression' => 'classes/db/queryparts/expression/Expression.class.php',
 	'InsertExpression' => 'classes/db/queryparts/expression/InsertExpression.class.php',
@@ -169,7 +168,7 @@ spl_autoload_register(function($class_name)
 			{
 				$filename = RX_BASEDIR . $GLOBALS['RX_AUTOLOAD_FILE_MAP'][$lc_class_name];
 			}
-			elseif (preg_match('/^([a-zA-Z0-9_]+?)(Admin)?(View|Controller|Model|Api|Wap|Mobile)?$/', $class_name, $matches))
+			elseif (preg_match('/^([a-zA-Z0-9_]+?)(Admin)?(View|Controller|Model|Item|Api|Wap|Mobile)?$/', $class_name, $matches))
 			{
 				$filename = RX_BASEDIR . 'modules/' . strtolower($matches[1] . '/' . $matches[1]);
 				if (isset($matches[2]) && $matches[2]) $filename .= '.admin';

--- a/modules/comment/comment.class.php
+++ b/modules/comment/comment.class.php
@@ -1,8 +1,6 @@
 <?php
 /* Copyright (C) NAVER <http://www.navercorp.com> */
 
-require_once(_XE_PATH_ . 'modules/comment/comment.item.php');
-
 /**
  * comment
  * comment module's high class

--- a/modules/document/document.class.php
+++ b/modules/document/document.class.php
@@ -1,6 +1,5 @@
 <?php
 /* Copyright (C) NAVER <http://www.navercorp.com> */
-require_once(_XE_PATH_.'modules/document/document.item.php');
 
 /**
  * document class


### PR DESCRIPTION
`document.item.php`, `comment.item.php` 등이 컨트롤러, 모델 등과 함께 오토로딩되지 않고 별도 설정 또는 직접 인클루드하고 있는 것을 고쳐서, 언제 어디서 호출하더라도 오토로딩되도록 합니다.