### PR TITLE
AJAX 요청 도중 치명적인 오류가 발생할 경우의 처리 방식 개선

### DIFF
--- a/classes/context/Context.class.php
+++ b/classes/context/Context.class.php
@@ -1529,7 +1529,7 @@ class Context
 		
 		if (in_array(Context::getRequestMethod(), array('XMLRPC', 'JSON', 'JS_CALLBACK')))
 		{
-			$oMessageObject->setMessage($title . ': ' . $message);
+			$oMessageObject->setMessage(trim($title . "\n\n" . $message));
 		}
 		else
 		{

--- a/classes/context/Context.class.php
+++ b/classes/context/Context.class.php
@@ -1521,9 +1521,21 @@ class Context
 		// Set the message.
 		$oMessageObject = getView('message');
 		$oMessageObject->setError(-1);
-		$oMessageObject->setHttpStatusCode($status);
-		$oMessageObject->setMessage($title);
-		$oMessageObject->dispMessage($message);
+		if ($status != 200)
+		{
+			$oMessageObject->setHttpStatusCode($status);
+			ModuleHandler::_setHttpStatusMessage($status);
+		}
+		
+		if (in_array(Context::getRequestMethod(), array('XMLRPC', 'JSON', 'JS_CALLBACK')))
+		{
+			$oMessageObject->setMessage($title . ': ' . $message);
+		}
+		else
+		{
+			$oMessageObject->setMessage($title);
+			$oMessageObject->dispMessage($message);
+		}
 		
 		// Display the message.
 		$oModuleHandler = new ModuleHandler;

--- a/classes/display/DisplayHandler.class.php
+++ b/classes/display/DisplayHandler.class.php
@@ -83,7 +83,7 @@ class DisplayHandler extends Handler
 
 		// header output
 		$httpStatusCode = $oModule->getHttpStatusCode();
-		if($httpStatusCode && $httpStatusCode != 200)
+		if($httpStatusCode && $httpStatusCode != 200 && !in_array(Context::getRequestMethod(), array('XMLRPC', 'JSON', 'JS_CALLBACK')))
 		{
 			self::_printHttpStatusCode($httpStatusCode);
 		}

--- a/common/framework/debug.php
+++ b/common/framework/debug.php
@@ -417,7 +417,8 @@ class Debug
 		}
 		
 		// Localize the error message.
-		$message = ini_get('display_errors') ? $message : lang('msg_server_error_see_log');
+		$display_error_message = ini_get('display_errors') || (\Context::get('logged_info') && toBool(\Context::get('logged_info')->is_admin));
+		$message = $display_error_message ? $message : lang('msg_server_error_see_log');
 		if ($message === 'msg_server_error_see_log')
 		{
 			$message = 'Your server is configured to hide error messages. Please see your server\'s error log for details.';


### PR DESCRIPTION
치명적인 오류 발생시 HTTP 상태 코드가 `500 Internal Server Error`로 지정되는데, AJAX 요청에서는 `200 OK`를 제외한 모든 상태 코드를 오류로 취급하여 JSON 반환값을 무시하게 됩니다. 그래서 AJAX 요청 도중 치명적인 오류가 발생하면 단순한 통신 에러로만 표시됩니다.

이 문제를 해결하기 위해

- AJAX 요청인 경우 오류가 발생하더라도 HTTP 상태 코드를 `200 OK`로 지정합니다.

또한 사이트 관리자의 디버깅을 돕기 위해

- 서버의 `display_errors` 설정이 꺼져 있더라도 관리자에게는 항상 에러 메시지를 노출시킵니다.