### PR TITLE
시스템 에러 메세지를 출력할 경우 403 HTTP 코드로 설정

### DIFF
--- a/classes/context/Context.class.php
+++ b/classes/context/Context.class.php
@@ -1524,7 +1524,6 @@ class Context
 		if ($status != 200)
 		{
 			$oMessageObject->setHttpStatusCode($status);
-			ModuleHandler::_setHttpStatusMessage($status);
 		}
 		
 		if (in_array(Context::getRequestMethod(), array('XMLRPC', 'JSON', 'JS_CALLBACK')))

--- a/classes/display/DisplayHandler.class.php
+++ b/classes/display/DisplayHandler.class.php
@@ -83,7 +83,7 @@ class DisplayHandler extends Handler
 
 		// header output
 		$httpStatusCode = $oModule->getHttpStatusCode();
-		if($httpStatusCode && $httpStatusCode != 200 && !in_array(Context::getRequestMethod(), array('XMLRPC', 'JSON', 'JS_CALLBACK')))
+		if($httpStatusCode !== 200 && !in_array(Context::getRequestMethod(), array('XMLRPC', 'JSON', 'JS_CALLBACK')))
 		{
 			self::_printHttpStatusCode($httpStatusCode);
 		}

--- a/classes/module/ModuleHandler.class.php
+++ b/classes/module/ModuleHandler.class.php
@@ -213,9 +213,12 @@ class ModuleHandler extends Handler
 				{
 					$oDocumentModel = getModel('document');
 					$oDocument = $oDocumentModel->getDocument($this->document_srl);
-					if($oDocument->isSecret() && !$oDocument->isGranted())
+					if($oDocument->isSecret() || $oDocument->get('status') === $oDocumentModel->getConfigStatus('temp'))
 					{
-						$this->httpStatusCode = '403';
+						if(!$oDocument->isGranted() && !$oDocument->isAccessible())
+						{
+							$this->httpStatusCode = '403';
+						}
 					}
 				}
 			}

--- a/classes/module/ModuleHandler.class.php
+++ b/classes/module/ModuleHandler.class.php
@@ -914,10 +914,10 @@ class ModuleHandler extends Handler
 				$oMessageObject->setMessage($this->error);
 				$oMessageObject->dispMessage();
 
-				if($oMessageObject->getHttpStatusCode() && $oMessageObject->getHttpStatusCode() !== '200')
+				if($oMessageObject->getHttpStatusCode() && $oMessageObject->getHttpStatusCode() != '200')
 				{
 					self::_setHttpStatusMessage($oMessageObject->getHttpStatusCode());
-					if($oMessageObject->getHttpStatusCode() !== '403')
+					if($oMessageObject->getHttpStatusCode() != '403')
 					{
 						$oMessageObject->setTemplateFile('http_status_code');
 					}

--- a/classes/module/ModuleHandler.class.php
+++ b/classes/module/ModuleHandler.class.php
@@ -897,7 +897,6 @@ class ModuleHandler extends Handler
 		$methodList = array('XMLRPC' => 1, 'JSON' => 1, 'JS_CALLBACK' => 1);
 		if(!isset($methodList[Context::getRequestMethod()]))
 		{
-
 			if($_SESSION['XE_VALIDATOR_RETURN_URL'])
 			{
 				header('location: ' . $_SESSION['XE_VALIDATOR_RETURN_URL']);
@@ -914,15 +913,14 @@ class ModuleHandler extends Handler
 				$oMessageObject->setMessage($this->error);
 				$oMessageObject->dispMessage();
 
-				if($oMessageObject->getHttpStatusCode() && $oMessageObject->getHttpStatusCode() != '200')
+				// display Error Page
+				if($oMessageObject->getHttpStatusCode() && !in_array($oMessageObject->getHttpStatusCode(), array('200', '403')))
 				{
-					self::_setHttpStatusMessage($oMessageObject->getHttpStatusCode());
-					if($oMessageObject->getHttpStatusCode() != '403')
-					{
-						$oMessageObject->setTemplateFile('http_status_code');
-					}
+					$oMessageObject->setTemplateFile('http_status_code');
 				}
-
+				
+				self::_setHttpStatusMessage($oMessageObject->getHttpStatusCode());
+				
 				// If module was called normally, change the templates of the module into ones of the message view module
 				if($oModule)
 				{

--- a/classes/module/ModuleHandler.class.php
+++ b/classes/module/ModuleHandler.class.php
@@ -207,6 +207,17 @@ class ModuleHandler extends Handler
 				{
 					unset($module_info);
 				}
+				
+				// if the secret document permission does not have, specify HTTP 403
+				if(Context::getRequestMethod() == 'GET')
+				{
+					$oDocumentModel = getModel('document');
+					$oDocument = $oDocumentModel->getDocument($this->document_srl);
+					if($oDocument->isSecret() && !$oDocument->isGranted())
+					{
+						$this->httpStatusCode = '403';
+					}
+				}
 			}
 		}
 
@@ -1048,6 +1059,12 @@ class ModuleHandler extends Handler
 					$oModule->setLayoutFile('default_layout');
 				}
 			}
+		}
+		
+		// Set http status code
+		if($this->httpStatusCode && (!$oModule->getHttpStatusCode() || $oModule->getHttpStatusCode() == '200'))
+		{
+			$oModule->setHttpStatusCode($this->httpStatusCode);
 		}
 		
 		// Set http status message

--- a/classes/module/ModuleHandler.class.php
+++ b/classes/module/ModuleHandler.class.php
@@ -925,7 +925,7 @@ class ModuleHandler extends Handler
 				$oMessageObject->dispMessage();
 
 				// display Error Page
-				if($oMessageObject->getHttpStatusCode() && !in_array($oMessageObject->getHttpStatusCode(), array('200', '403')))
+				if(!in_array($oMessageObject->getHttpStatusCode(), array(200, 403)))
 				{
 					$oMessageObject->setTemplateFile('http_status_code');
 				}
@@ -1062,7 +1062,7 @@ class ModuleHandler extends Handler
 		}
 		
 		// Set http status code
-		if($this->httpStatusCode && (!$oModule->getHttpStatusCode() || $oModule->getHttpStatusCode() == '200'))
+		if($this->httpStatusCode && $oModule->getHttpStatusCode() === 200)
 		{
 			$oModule->setHttpStatusCode($this->httpStatusCode);
 		}

--- a/classes/module/ModuleHandler.class.php
+++ b/classes/module/ModuleHandler.class.php
@@ -919,8 +919,6 @@ class ModuleHandler extends Handler
 					$oMessageObject->setTemplateFile('http_status_code');
 				}
 				
-				self::_setHttpStatusMessage($oMessageObject->getHttpStatusCode());
-				
 				// If module was called normally, change the templates of the module into ones of the message view module
 				if($oModule)
 				{
@@ -933,7 +931,7 @@ class ModuleHandler extends Handler
 				{
 					$oModule = $oMessageObject;
 				}
-
+				
 				self::_clearErrorSession();
 			}
 
@@ -1051,7 +1049,10 @@ class ModuleHandler extends Handler
 				}
 			}
 		}
-
+		
+		// Set http status message
+		self::_setHttpStatusMessage($oModule->getHttpStatusCode());
+		
 		// Display contents
 		$oDisplayHandler = new DisplayHandler();
 		$oDisplayHandler->printContent($oModule);

--- a/classes/module/ModuleHandler.class.php
+++ b/classes/module/ModuleHandler.class.php
@@ -632,7 +632,7 @@ class ModuleHandler extends Handler
 					{
 						self::_setInputErrorToContext();
 
-						$this->error = 'msg_is_not_administrator';
+						$this->error = 'admin.msg_is_not_administrator';
 						$oMessageObject = self::getModuleInstance('message', $display_mode);
 						$oMessageObject->setError(-1);
 						$oMessageObject->setMessage($this->error);
@@ -646,7 +646,7 @@ class ModuleHandler extends Handler
 					if(!$grant->manager)
 					{
 						self::_setInputErrorToContext();
-						$this->error = 'msg_is_not_administrator';
+						$this->error = 'admin.msg_is_not_administrator';
 						$oMessageObject = self::getModuleInstance('message', $display_mode);
 						$oMessageObject->setError(-1);
 						$oMessageObject->setMessage($this->error);
@@ -658,7 +658,7 @@ class ModuleHandler extends Handler
 						if(!$grant->is_admin && $this->module != $this->orig_module->module && $xml_info->permission->{$this->act} != 'manager')
 						{
 							self::_setInputErrorToContext();
-							$this->error = 'msg_is_not_administrator';
+							$this->error = 'admin.msg_is_not_administrator';
 							$oMessageObject = self::getModuleInstance('message', $display_mode);
 							$oMessageObject->setError(-1);
 							$oMessageObject->setMessage($this->error);
@@ -914,10 +914,13 @@ class ModuleHandler extends Handler
 				$oMessageObject->setMessage($this->error);
 				$oMessageObject->dispMessage();
 
-				if($oMessageObject->getHttpStatusCode() && $oMessageObject->getHttpStatusCode() != '200')
+				if($oMessageObject->getHttpStatusCode() && $oMessageObject->getHttpStatusCode() !== '200')
 				{
 					self::_setHttpStatusMessage($oMessageObject->getHttpStatusCode());
-					$oMessageObject->setTemplateFile('http_status_code');
+					if($oMessageObject->getHttpStatusCode() !== '403')
+					{
+						$oMessageObject->setTemplateFile('http_status_code');
+					}
 				}
 
 				// If module was called normally, change the templates of the module into ones of the message view module
@@ -925,6 +928,7 @@ class ModuleHandler extends Handler
 				{
 					$oModule->setTemplatePath($oMessageObject->getTemplatePath());
 					$oModule->setTemplateFile($oMessageObject->getTemplateFile());
+					$oModule->setHttpStatusCode($oMessageObject->getHttpStatusCode());
 					// Otherwise, set message instance as the target module
 				}
 				else

--- a/classes/module/ModuleObject.class.php
+++ b/classes/module/ModuleObject.class.php
@@ -236,6 +236,8 @@ class ModuleObject extends Object
 
 		$this->setTemplatePath($oMessageObject->getTemplatePath());
 		$this->setTemplateFile($oMessageObject->getTemplateFile());
+		$this->setHttpStatusCode($oMessageObject->getHttpStatusCode());
+		ModuleHandler::_setHttpStatusMessage($oMessageObject->getHttpStatusCode());
 
 		return $this;
 	}

--- a/classes/module/ModuleObject.class.php
+++ b/classes/module/ModuleObject.class.php
@@ -237,8 +237,7 @@ class ModuleObject extends Object
 		$this->setTemplatePath($oMessageObject->getTemplatePath());
 		$this->setTemplateFile($oMessageObject->getTemplateFile());
 		$this->setHttpStatusCode($oMessageObject->getHttpStatusCode());
-		ModuleHandler::_setHttpStatusMessage($oMessageObject->getHttpStatusCode());
-
+		
 		return $this;
 	}
 

--- a/classes/module/ModuleObject.class.php
+++ b/classes/module/ModuleObject.class.php
@@ -191,7 +191,7 @@ class ModuleObject extends Object
 			{
 				case 'root' :
 				case 'manager' :
-					$this->stop('msg_is_not_administrator');
+					$this->stop('admin.msg_is_not_administrator');
 					return;
 				case 'member' :
 					if(!$is_logged)

--- a/classes/object/Object.class.php
+++ b/classes/object/Object.class.php
@@ -31,7 +31,7 @@ class Object
 	 * http status code.
 	 * @var int
 	 */
-	var $httpStatusCode = NULL;
+	var $httpStatusCode = 200;
 
 	/**
 	 * Constructor
@@ -73,9 +73,9 @@ class Object
 	 * @param int $code HTTP status code. Default value is `200` that means successful
 	 * @return void
 	 */
-	function setHttpStatusCode($code = '200')
+	function setHttpStatusCode($code = 200)
 	{
-		$this->httpStatusCode = $code;
+		$this->httpStatusCode = (int) $code;
 	}
 
 	/**

--- a/common/js/xml_handler.js
+++ b/common/js/xml_handler.js
@@ -203,7 +203,7 @@
 			
 			// If the response contains an error, display the error message.
 			if(data.error != "0" && data.error > -1000) {
-				if(data.error == -1 && data.message == "msg_is_not_administrator") {
+				if(data.error == -1 && data.message == "admin.msg_is_not_administrator") {
 					alert("You are not logged in as an administrator.");
 					if ($.isFunction(callback_error)) {
 						callback_error(data);

--- a/modules/admin/admin.admin.controller.php
+++ b/modules/admin/admin.admin.controller.php
@@ -22,7 +22,7 @@ class adminAdminController extends admin
 		$logged_info = $oMemberModel->getLoggedInfo();
 		if($logged_info->is_admin != 'Y')
 		{
-			return $this->stop("msg_is_not_administrator");
+			return $this->stop("admin.msg_is_not_administrator");
 		}
 	}
 

--- a/modules/admin/admin.admin.view.php
+++ b/modules/admin/admin.admin.view.php
@@ -40,7 +40,7 @@ class adminAdminView extends admin
 		$logged_info = $oMemberModel->getLoggedInfo();
 		if($logged_info->is_admin != 'Y')
 		{
-			return $this->stop("msg_is_not_administrator");
+			return $this->stop("admin.msg_is_not_administrator");
 		}
 
 		// change into administration layout

--- a/modules/adminlogging/adminlogging.controller.php
+++ b/modules/adminlogging/adminlogging.controller.php
@@ -23,7 +23,7 @@ class adminloggingController extends adminlogging
 		$logged_info = $oMemberModel->getLoggedInfo();
 		if($logged_info->is_admin != 'Y')
 		{
-			return $this->stop("msg_is_not_administrator");
+			return $this->stop("admin.msg_is_not_administrator");
 		}
 	}
 

--- a/modules/board/board.view.php
+++ b/modules/board/board.view.php
@@ -1136,9 +1136,9 @@ class boardView extends board
 	 **/
 	function dispBoardMessage($msg_code)
 	{
-		$msg = lang($msg_code);
-		if(!$msg) $msg = $msg_code;
-		Context::set('message', $msg);
+		Context::set('message', lang($msg_code));
+		
+		$this->setHttpStatusCode('403');
 		$this->setTemplateFile('message');
 	}
 

--- a/modules/board/board.view.php
+++ b/modules/board/board.view.php
@@ -1189,7 +1189,9 @@ class boardView extends board
 	function alertMessage($message)
 	{
 		$script =  sprintf('<script> jQuery(function(){ alert("%s"); } );</script>', lang($message));
-		Context::addHtmlFooter( $script );
+		Context::addHtmlFooter($script);
+		
+		$this->setHttpStatusCode('403');
 	}
 
 }

--- a/modules/board/board.view.php
+++ b/modules/board/board.view.php
@@ -1138,7 +1138,7 @@ class boardView extends board
 	{
 		Context::set('message', lang($msg_code));
 		
-		$this->setHttpStatusCode('403');
+		$this->setHttpStatusCode(403);
 		$this->setTemplateFile('message');
 	}
 
@@ -1191,7 +1191,7 @@ class boardView extends board
 		$script =  sprintf('<script> jQuery(function(){ alert("%s"); } );</script>', lang($message));
 		Context::addHtmlFooter($script);
 		
-		$this->setHttpStatusCode('403');
+		$this->setHttpStatusCode(403);
 	}
 
 }

--- a/modules/message/message.mobile.php
+++ b/modules/message/message.mobile.php
@@ -20,12 +20,15 @@ class messageMobile extends messageView
 		$config = $oModuleModel->getModuleConfig('message');
 		if(!is_object($config)) $config = new stdClass;
 		if(!$config->mskin) $config->mskin = 'default';
+		
 		// Set the template path
 		$template_path = sprintf('%sm.skins/%s', $this->module_path, $config->mskin);
+		
 		// Get the member configuration
 		$oModuleModel = getModel('module');
 		$member_config = $oModuleModel->getModuleConfig('member');
 		Context::set('member_config', $member_config);
+		
 		// Set a flag to check if the https connection is made when using SSL and create https url 
 		$ssl_mode = false;
 		if($member_config->enable_ssl == 'Y')
@@ -41,6 +44,12 @@ class messageMobile extends messageView
 
 		$this->setTemplatePath($template_path);
 		$this->setTemplateFile('system_message');
+		
+		// Default 403 Error
+		if(!$this->getHttpStatusCode() || $this->getHttpStatusCode() === '200')
+		{
+			$this->setHttpStatusCode('403');
+		}
 	}
 }
 /* End of file message.mobile.php */

--- a/modules/message/message.mobile.php
+++ b/modules/message/message.mobile.php
@@ -46,9 +46,9 @@ class messageMobile extends messageView
 		$this->setTemplateFile('system_message');
 		
 		// Default 403 Error
-		if(!$this->getHttpStatusCode() || $this->getHttpStatusCode() == '200')
+		if($this->getHttpStatusCode() === 200)
 		{
-			$this->setHttpStatusCode('403');
+			$this->setHttpStatusCode(403);
 		}
 	}
 }

--- a/modules/message/message.mobile.php
+++ b/modules/message/message.mobile.php
@@ -46,7 +46,7 @@ class messageMobile extends messageView
 		$this->setTemplateFile('system_message');
 		
 		// Default 403 Error
-		if(!$this->getHttpStatusCode() || $this->getHttpStatusCode() === '200')
+		if(!$this->getHttpStatusCode() || $this->getHttpStatusCode() == '200')
 		{
 			$this->setHttpStatusCode('403');
 		}

--- a/modules/message/message.view.php
+++ b/modules/message/message.view.php
@@ -31,27 +31,16 @@ class messageView extends message
 		if(!$config->skin)
 		{
 			$config->skin = 'xedition';
-			$template_path = sprintf('%sskins/%s', $this->module_path, $config->skin);
 		}
-		else
-		{
-			//check theme
-			$config_parse = explode('|@|', $config->skin);
-			if (count($config_parse) > 1)
-			{
-				$template_path = sprintf('./themes/%s/modules/message/', $config_parse[0]);
-			}
-			else
-			{
-				$template_path = sprintf('%sskins/%s', $this->module_path, $config->skin);
-			}
-		}
+		$template_path = sprintf('%sskins/%s', $this->module_path, $config->skin);
+		
 		// Template path
 		$this->setTemplatePath($template_path);
 
 		// Get the member configuration
 		$member_config = $oModuleModel->getModuleConfig('member');
 		Context::set('member_config', $member_config);
+		
 		// Set a flag to check if the https connection is made when using SSL and create https url
 		$ssl_mode = false;
 		if($member_config->enable_ssl == 'Y')
@@ -64,6 +53,12 @@ class messageView extends message
 		Context::set('system_message_detail', nl2br($detail));
 
 		$this->setTemplateFile('system_message');
+		
+		// Default 403 Error
+		if(!$this->getHttpStatusCode() || $this->getHttpStatusCode() === '200')
+		{
+			$this->setHttpStatusCode('403');
+		}
 	}
 }
 /* End of file message.view.php */

--- a/modules/message/message.view.php
+++ b/modules/message/message.view.php
@@ -55,7 +55,7 @@ class messageView extends message
 		$this->setTemplateFile('system_message');
 		
 		// Default 403 Error
-		if(!$this->getHttpStatusCode() || $this->getHttpStatusCode() === '200')
+		if(!$this->getHttpStatusCode() || $this->getHttpStatusCode() == '200')
 		{
 			$this->setHttpStatusCode('403');
 		}

--- a/modules/message/message.view.php
+++ b/modules/message/message.view.php
@@ -55,9 +55,9 @@ class messageView extends message
 		$this->setTemplateFile('system_message');
 		
 		// Default 403 Error
-		if(!$this->getHttpStatusCode() || $this->getHttpStatusCode() == '200')
+		if($this->getHttpStatusCode() === 200)
 		{
-			$this->setHttpStatusCode('403');
+			$this->setHttpStatusCode(403);
 		}
 	}
 }

--- a/modules/message/skins/default/http_status_code.html
+++ b/modules/message/skins/default/http_status_code.html
@@ -11,7 +11,7 @@ section{margin-top:20px}
 </style>
 <section>
 	<div>
-		<h1>404 Not Found</h1>
+		<h1>{$http_status_code} {$http_status_message}</h1>
 		<p>{$lang->msg_module_is_not_exists}</p>
 	</div>
 </section>

--- a/modules/message/skins/xedition/http_status_code.html
+++ b/modules/message/skins/xedition/http_status_code.html
@@ -30,7 +30,7 @@
 
 <!--// BODY -->
 <section class="xedition-error">
-	<h1>404</h1>
-	<p>Oops, Sorry.<br>Page is not found!</p>
+	<h1>{$http_status_code}</h1>
+	<p>Oops, Sorry.<br>Page is {$http_status_message}!</p>
 	<img src="./img/error.png" width="340" height="400" />
 </section>


### PR DESCRIPTION
보통 시스템 에러 메세지는 권한 문제에 관한 것입니다. 권한문제가 아니더라도 접근할 수 없다는 건 분명합니다.

따라서 시스템 메세지 출력페이지를  403 HTTP 코드로 설정함으로 접근권한이 없다는 것을 분명히 알립니다. 로봇에게...