### PR TITLE
자동 링크 애드온 개선 (#462)

### DIFF
--- a/addons/autolink/autolink.js
+++ b/addons/autolink/autolink.js
@@ -5,13 +5,13 @@
  */
 (function($){
 	var protocol_re = '(https?|ftp|news|telnet|irc|mms)://';
-	var domain_re   = '(?:[\\w\\-]+\\.)+(?:[a-z]+)';
+	var domain_re   = '(?:[^./]+\\.)+[^./]+';
 	var max_255_re  = '(?:1[0-9]{2}|2[0-4][0-9]|25[0-5]|[1-9]?[0-9])';
 	var ip_re       = '(?:'+max_255_re+'\\.){3}'+max_255_re;
 	var port_re     = '(?::([0-9]+))?';
-	var user_re     = '(?:/~[\\w-]+)?';
-	var path_re     = '((?:/[\\w!"$-/:-@]+)*)';
-	var hash_re     = '(?:#([\\w!-@]+))?';
+	var user_re     = '(?:/~\\w+)?';
+	var path_re     = '(?:/[\\w!@$%&!?="/.,:;-]+)*';
+	var hash_re     = '(?:#[\\w!@$%&!?="/.,:;-]*)?';
 
 	var url_regex = new RegExp('('+protocol_re+'('+domain_re+'|'+ip_re+'|localhost'+')'+port_re+user_re+path_re+hash_re+')', 'ig');
 
@@ -36,7 +36,7 @@
 			var content  = textNode.nodeValue;
 			var dummy    = $('<span>');
 
-			content = content.replace(/</g, '&lt;').replace(/>/g, '&gt;');
+			//content = content.replace(/</g, '&lt;').replace(/>/g, '&gt;');
 			content = content.replace(url_regex, '<a href="$1" target="_blank">$1</a>');
 
 			$(textNode).before(dummy);
@@ -52,9 +52,7 @@
 				return;
 			}
 
-			$(obj)
-			.contents()
-			.each(function(){
+			$(obj).contents().each(function(){
 				var node_name = this.nodeName.toLowerCase();
 				if($.inArray(node_name, ['a', 'pre', 'xml', 'textarea', 'input', 'select', 'option', 'code', 'script', 'style', 'iframe', 'button', 'img', 'embed', 'object', 'ins']) != -1) return;
 


### PR DESCRIPTION
#462 

- URL 뒤의 괄호가 주소에 포함되는 것으로 잘못 인식하는 문제를 수정합니다.
  - 정규식의 `[ ]` 문법 중간에 `-`가 들어가서 앞뒤 문자를 범위로 해석하고 있었습니다. 공교롭게도 그 범위에 괄호가 포함되었네요.
  - 문제를 일으키는 `-`를 맨 뒤로 옮기고, 그 밖에 정상적인 URL에 포함될 수 있는 `&`, `=`, `?` 등의 특수문자들을 추가했습니다.
- 한글 도메인도 정상적인 URL로 인식하도록 변경합니다.