### PR TITLE
알림센터의 닉네임 표시를 익명게시판 설정에 따르도록 개선

### DIFF
--- a/modules/ncenterlite/ncenterlite.admin.controller.php
+++ b/modules/ncenterlite/ncenterlite.admin.controller.php
@@ -41,10 +41,6 @@ class ncenterliteAdminController extends ncenterlite
 			{
 				$config->use = array();
 			}
-			if (!$config->anonymous_name)
-			{
-				$config->anonymous_name = null;
-			}
 			if (!$config->mention_suffixes)
 			{
 				$config->mention_suffixes = array();

--- a/modules/ncenterlite/ncenterlite.controller.php
+++ b/modules/ncenterlite/ncenterlite.controller.php
@@ -985,7 +985,7 @@ class ncenterliteController extends ncenterlite
 			$args->target_email_address = $args->target_nick_name;
 		}
 		// 로그인을 했을경우 logged_info 정보를 가져와 검사한다.
-		else if(Context::get('logged_info'))
+		else if(Context::get('is_logged'))
 		{
 			$logged_info = Context::get('logged_info');
 			$args->target_member_srl = $logged_info->member_srl;

--- a/modules/ncenterlite/ncenterlite.controller.php
+++ b/modules/ncenterlite/ncenterlite.controller.php
@@ -970,36 +970,24 @@ class ncenterliteController extends ncenterlite
 
 	function _insertNotify($args, $anonymous = FALSE)
 	{
-		$oNcenterliteModel = getModel('ncenterlite');
-		$config = $oNcenterliteModel->getConfig();
 		// 비회원 노티 제거
 		if($args->member_srl <= 0)
 		{
 			return new Object();
 		}
 
-		$logged_info = Context::get('logged_info');
+
 
 		if($anonymous == TRUE)
 		{
-			// 설정에서 익명 이름이 설정되어 있으면 익명 이름을 설정함. 없을 경우 Anonymous 를 사용한다.
-			if(!$config->anonymous_name)
-			{
-				$anonymous_name = 'Anonymous';
-			}
-			else
-			{
-				$anonymous_name = $config->anonymous_name;
-			}
-			// 익명 노티 시 회원정보 제거
 			$args->target_member_srl = 0;
-			$args->target_nick_name = $anonymous_name;
-			$args->target_user_id = $anonymous_name;
-			$args->target_email_address = $anonymous_name;
+			$args->target_user_id = $args->target_nick_name;
+			$args->target_email_address = $args->target_nick_name;
 		}
-		else if($logged_info)
+		// 로그인을 했을경우 logged_info 정보를 가져와 검사한다.
+		else if(Context::get('logged_info'))
 		{
-			// 익명 노티가 아닐 때 로그인 세션의 회원정보 넣기
+			$logged_info = Context::get('logged_info');
 			$args->target_member_srl = $logged_info->member_srl;
 			$args->target_nick_name = $logged_info->nick_name;
 			$args->target_user_id = $logged_info->user_id;

--- a/modules/ncenterlite/ncenterlite.model.php
+++ b/modules/ncenterlite/ncenterlite.model.php
@@ -34,7 +34,6 @@ class ncenterliteModel extends ncenterlite
 			if(!$config->skin) $config->skin = 'default';
 			if(!$config->colorset) $config->colorset = 'black';
 			if(!$config->zindex) $config->zindex = '9999';
-			if(!$config->anonymous_name) $config->anonymous_name = 'Anonymous';
 
 			self::$config = $config;
 		}

--- a/modules/ncenterlite/tpl/advancedconfig.html
+++ b/modules/ncenterlite/tpl/advancedconfig.html
@@ -39,14 +39,6 @@
 				<p class="x_help-block">{$lang->about_mention_suffix_always_cut}</p>
 			</div>
 		</div>
-
-		<div class="x_control-group">
-			<label class="x_control-label">{$lang->anonymous_nick_name_setting}</label>
-			<div class="x_controls">
-				<input type="text" name="anonymous_name" value="{escape($config->anonymous_name, false)}" />
-				<p class="x_help-block">{$lang->about_anonymous_nick_name}</p>
-			</div>
-		</div>
 	</section>
 	<div class="x_clearfix btnArea">
 		<div class="x_pull-right">


### PR DESCRIPTION
게시판 익명 설정이 463이슈에서 강화됨에 따라 알림센터에서 더이상 익명 네임을 설정하지 않더라도, `nick_name` 게시판의 닉네임정보를 가져오도록 할 필요성이 있음.

그래서 각 설정한 익명 닉네임을 그대로 넘겨오도록 개선 함.

