### PR TITLE
FrontEndFileHandler 나머지 정리 및 HTTP/2 server push 지원 초안

### DIFF
--- a/classes/context/Context.class.php
+++ b/classes/context/Context.class.php
@@ -2270,11 +2270,12 @@ class Context
 	 * Returns the list of javascripts that matches the given type.
 	 *
 	 * @param string $type Added position. (head:<head>..</head>, body:<body>..</body>)
+	 * @param bool $finalize (optional)
 	 * @return array Returns javascript file list. Array contains file, targetie.
 	 */
-	public static function getJsFile($type = 'head')
+	public static function getJsFile($type = 'head', $finalize = false)
 	{
-		return self::$_instance->oFrontEndFileHandler->getJsFileList($type);
+		return self::$_instance->oFrontEndFileHandler->getJsFileList($type, $finalize);
 	}
 
 	/**
@@ -2322,11 +2323,12 @@ class Context
 	/**
 	 * Return a list of css files
 	 *
+	 * @param bool $finalize (optional)
 	 * @return array Returns css file list. Array contains file, media, targetie.
 	 */
-	public static function getCSSFile()
+	public static function getCSSFile($finalize = false)
 	{
-		return self::$_instance->oFrontEndFileHandler->getCssFileList();
+		return self::$_instance->oFrontEndFileHandler->getCssFileList($finalize);
 	}
 
 	/**

--- a/classes/frontendfile/FrontEndFileHandler.class.php
+++ b/classes/frontendfile/FrontEndFileHandler.class.php
@@ -441,7 +441,7 @@ class FrontEndFileHandler extends Handler
 			}
 		}
 		
-		// Enable HTTP/2 server push for JS resources.
+		// Enable HTTP/2 server push for CSS resources.
 		if ($finalize && config('view.server_push') && strncmp($_SERVER['SERVER_PROTOCOL'], 'HTTP/2', 6) === 0)
 		{
 			foreach ($result as $resource)
@@ -546,7 +546,7 @@ class FrontEndFileHandler extends Handler
 		}
 		
 		// Enable HTTP/2 server push for JS resources.
-		if ($finalize && config('view.server_push') && strncmp($_SERVER['SERVER_PROTOCOL'], 'HTTP/2', 6) === 0)
+		if ($type === 'head' && $finalize && config('view.server_push') && strncmp($_SERVER['SERVER_PROTOCOL'], 'HTTP/2', 6) === 0)
 		{
 			foreach ($result as $resource)
 			{

--- a/classes/frontendfile/FrontEndFileHandler.class.php
+++ b/classes/frontendfile/FrontEndFileHandler.class.php
@@ -359,9 +359,10 @@ class FrontEndFileHandler extends Handler
 	/**
 	 * Get css file list
 	 *
+	 * @param bool $finalize (optional)
 	 * @return array Returns css file list. Array contains file, media, targetie.
 	 */
-	public function getCssFileList()
+	public function getCssFileList($finalize = false)
 	{
 		$map = &$this->cssMap;
 		$mapIndex = &$this->cssMapIndex;
@@ -370,25 +371,28 @@ class FrontEndFileHandler extends Handler
 		$this->_sortMap($map, $mapIndex);
 		
 		// Minify all scripts, and compile LESS/SCSS into CSS.
-		foreach ($map as $indexedMap)
+		if ($finalize)
 		{
-			foreach ($indexedMap as $file)
+			foreach ($map as $indexedMap)
 			{
-				$minify_this_file = !$file->isMinified && !$file->isExternalURL && !$file->isCachedScript && (($file->isCommon && $minify !== 'none') || $minify === 'all');
-				if ($file->fileExtension === 'css')
+				foreach ($indexedMap as $file)
 				{
-					$this->proc_CSS_JS($file, $minify_this_file);
-				}
-				else
-				{
-					$this->proc_LESS_SCSS($file, $minify_this_file);
+					$minify_this_file = !$file->isMinified && !$file->isExternalURL && !$file->isCachedScript && (($file->isCommon && $minify !== 'none') || $minify === 'all');
+					if ($file->fileExtension === 'css')
+					{
+						$this->proc_CSS_JS($file, $minify_this_file);
+					}
+					else
+					{
+						$this->proc_LESS_SCSS($file, $minify_this_file);
+					}
 				}
 			}
 		}
 		
 		// Add all files to the final result.
 		$result = array();
-		if ($concat && count($concat_list = $this->_concatMap($map)))
+		if ($concat && $finalize && count($concat_list = $this->_concatMap($map)))
 		{
 			foreach ($concat_list as $concat_fileset)
 			{
@@ -443,9 +447,10 @@ class FrontEndFileHandler extends Handler
 	 * Get javascript file list
 	 *
 	 * @param string $type Type of javascript. head, body
+	 * @param bool $finalize (optional)
 	 * @return array Returns javascript file list. Array contains file, targetie.
 	 */
-	public function getJsFileList($type = 'head')
+	public function getJsFileList($type = 'head', $finalize = false)
 	{
 		if($type == 'head')
 		{
@@ -463,20 +468,23 @@ class FrontEndFileHandler extends Handler
 		$this->_sortMap($map, $mapIndex);
 		
 		// Minify all scripts.
-		foreach ($map as $indexedMap)
+		if ($finalize)
 		{
-			foreach ($indexedMap as $file)
+			foreach ($map as $indexedMap)
 			{
-				if (!$file->isMinified && !$file->isExternalURL && !$file->isCachedScript && (($file->isCommon && $minify !== 'none') || $minify === 'all'))
+				foreach ($indexedMap as $file)
 				{
-					$this->proc_CSS_JS($file, true);
+					if (!$file->isMinified && !$file->isExternalURL && !$file->isCachedScript && (($file->isCommon && $minify !== 'none') || $minify === 'all'))
+					{
+						$this->proc_CSS_JS($file, true);
+					}
 				}
 			}
 		}
 		
 		// Add all files to the final result.
 		$result = array();
-		if ($concat && $type === 'head' && count($concat_list = $this->_concatMap($map)))
+		if ($concat && $finalize && $type === 'head' && count($concat_list = $this->_concatMap($map)))
 		{
 			foreach ($concat_list as $concat_fileset)
 			{

--- a/classes/frontendfile/FrontEndFileHandler.class.php
+++ b/classes/frontendfile/FrontEndFileHandler.class.php
@@ -440,6 +440,18 @@ class FrontEndFileHandler extends Handler
 				}
 			}
 		}
+		
+		// Enable HTTP/2 server push for JS resources.
+		if ($finalize && config('view.server_push') && strncmp($_SERVER['SERVER_PROTOCOL'], 'HTTP/2', 6) === 0)
+		{
+			foreach ($result as $resource)
+			{
+				if ($resource['file'][0] === '/' && $resource['file'][1] !== '/')
+				{
+					header(sprintf('Link: <%s>; rel=preload; as=style', $resource['file']), false);
+				}
+			}
+		}
 		return $result;
 	}
 
@@ -529,6 +541,18 @@ class FrontEndFileHandler extends Handler
 						$url .= '?' . date('YmdHis', filemtime($file->fileFullPath));
 					}
 					$result[] = array('file' => $url, 'targetie' => $file->targetIe);
+				}
+			}
+		}
+		
+		// Enable HTTP/2 server push for JS resources.
+		if ($finalize && config('view.server_push') && strncmp($_SERVER['SERVER_PROTOCOL'], 'HTTP/2', 6) === 0)
+		{
+			foreach ($result as $resource)
+			{
+				if ($resource['file'][0] === '/' && $resource['file'][1] !== '/')
+				{
+					header(sprintf('Link: <%s>; rel=preload; as=script', $resource['file']), false);
 				}
 			}
 		}

--- a/common/defaults/config.php
+++ b/common/defaults/config.php
@@ -74,6 +74,7 @@ return array(
 	'view' => array(
 		'minify_scripts' => 'common',
 		'concat_scripts' => 'none',
+		'server_push' => false,
 		'use_gzip' => false,
 	),
 	'admin' => array(

--- a/common/tpl/common_layout.html
+++ b/common/tpl/common_layout.html
@@ -15,14 +15,14 @@
 <title>{Context::getBrowserTitle()}</title>
 
 <!-- CSS -->
-<block loop="Context::getCssFile() => $key, $css_file">
+<block loop="Context::getCssFile(true) => $key, $css_file">
 <block cond="$css_file['targetie']"><!--[if {$css_file['targetie']}]><block cond="stripos($css_file['targetie'], 'gt') === 0"><!--></block></block>
 <link rel="stylesheet" href="{$css_file['file']}" media="{$css_file['media']}"|cond="$css_file['media'] != 'all'" />
 <block cond="$css_file['targetie']"><block cond="stripos($css_file['targetie'], 'gt') === 0"><!--</block><![endif]-->{"\n"}</block>
 </block>
 
 <!-- JS -->
-<block loop="Context::getJsFile() => $key, $js_file">
+<block loop="Context::getJsFile('head', true) => $key, $js_file">
 <block cond="$js_file['targetie']"><!--[if {$js_file['targetie']}]><block cond="stripos($js_file['targetie'], 'gt') === 0"><!--></block></block>
 <script src="{$js_file['file']}"></script>
 <block cond="$js_file['targetie']"><block cond="stripos($js_file['targetie'], 'gt') === 0"><!--</block><![endif]-->{"\n"}</block>
@@ -70,7 +70,7 @@
 <div id="rhymix_debug_button"></div>
 
 <!-- BODY JS -->
-<block loop="Context::getJsFile('body') => $key, $js_file">
+<block loop="Context::getJsFile('body', true) => $key, $js_file">
 <block cond="$js_file['targetie']"><!--[if {$js_file['targetie']}]></block>
 <script src="{$js_file['file']}"></script>
 <block cond="$js_file['targetie']"><![endif]-->{"\n"}</block>

--- a/modules/admin/admin.admin.controller.php
+++ b/modules/admin/admin.admin.controller.php
@@ -700,6 +700,7 @@ class adminAdminController extends admin
 		Rhymix\Framework\Config::set('session.use_db', $vars->use_db_session === 'Y');
 		Rhymix\Framework\Config::set('view.minify_scripts', $vars->minify_scripts ?: 'common');
 		Rhymix\Framework\Config::set('view.concat_scripts', $vars->concat_scripts ?: 'none');
+		Rhymix\Framework\Config::set('view.server_push', $vars->use_server_push === 'Y');
 		Rhymix\Framework\Config::set('view.gzip', $vars->use_gzip === 'Y');
 		
 		// Save

--- a/modules/admin/admin.admin.view.php
+++ b/modules/admin/admin.admin.view.php
@@ -531,6 +531,7 @@ class adminAdminView extends admin
 		Context::set('use_db_session', Rhymix\Framework\Config::get('session.use_db'));
 		Context::set('minify_scripts', Rhymix\Framework\Config::get('view.minify_scripts'));
 		Context::set('concat_scripts', Rhymix\Framework\Config::get('view.concat_scripts'));
+		Context::set('use_server_push', Rhymix\Framework\Config::get('view.server_push'));
 		Context::set('use_gzip', Rhymix\Framework\Config::get('view.gzip'));
 		
 		$this->setTemplateFile('config_advanced');

--- a/modules/admin/lang/en.php
+++ b/modules/admin/lang/en.php
@@ -92,6 +92,7 @@ $lang->cmd_concat_css_only = 'Combine all CSS';
 $lang->cmd_concat_js_only = 'Combine all JS';
 $lang->cmd_concat_css_js = 'Combine both CSS and JS';
 $lang->about_concat_scripts = 'Automatically combine CSS and JS scripts into as few files as possible. External scripts are not combined.';
+$lang->use_server_push = 'Use HTTP/2 Server Push';
 $lang->use_gzip = 'gzip Compression';
 $lang->delay_session = 'Delay session start';
 $lang->about_delay_session = 'To improve performance when using a caching proxy server such as Varnish, do not issue sessions to visitors until they log in.<br>Selecting this option may cause view counts and visitor counts to become inaccurate.';

--- a/modules/admin/lang/ja.php
+++ b/modules/admin/lang/ja.php
@@ -89,6 +89,7 @@ $lang->cmd_concat_css_only = 'CSSのみ結合';
 $lang->cmd_concat_js_only = 'JSのみ結合';
 $lang->cmd_concat_css_js = 'CSSやJSの両方を結合';
 $lang->about_concat_scripts = 'CSS、JSファイルを一つにまとめて送信されます。外部からロードするスクリプトは、合わせてされません.';
+$lang->use_server_push = 'HTTP/2 Server Push使用';
 $lang->use_gzip = 'gzip 圧縮';
 $lang->delay_session = 'セッションの開始を遅延';
 $lang->about_delay_session = 'Varnishなどのプロキシキャッシュサーバ使用時のパフォーマンスを向上させるために、ログインしていないユーザーには、認証セッションを付与しません。<br>このオプションを選択した場合、訪問者数とヒット集計が正確でない場合があります。';

--- a/modules/admin/lang/ko.php
+++ b/modules/admin/lang/ko.php
@@ -92,6 +92,7 @@ $lang->cmd_concat_css_only = 'CSS만 합침';
 $lang->cmd_concat_js_only = 'JS만 합침';
 $lang->cmd_concat_css_js = 'CSS와 JS를 모두 합침';
 $lang->about_concat_scripts = 'CSS, JS 파일들을 하나로 합쳐서 전송합니다. 외부에서 로딩하는 스크립트는 합쳐지지 않습니다.';
+$lang->use_server_push = 'Server Push 사용';
 $lang->use_gzip = 'gzip 압축';
 $lang->delay_session = '세션 시작 지연';
 $lang->about_delay_session = 'Varnish 등의 프록시 캐싱 서버 사용시 성능 개선을 위해, 로그인하지 않은 사용자에게는 인증 세션을 부여하지 않습니다.<br>이 옵션을 선택할 경우 방문자 수 및 조회수 집계가 정확하게 이루어지지 않을 수 있습니다.';

--- a/modules/admin/tpl/config_advanced.html
+++ b/modules/admin/tpl/config_advanced.html
@@ -98,6 +98,13 @@
 			</div>
 		</div>
 		<div class="x_control-group">
+			<label class="x_control-label">{$lang->use_server_push}</label>
+			<div class="x_controls">
+				<label for="use_server_push_y" class="x_inline"><input type="radio" name="use_server_push" id="use_server_push_y" value="Y" checked="checked"|cond="$use_server_push" /> {$lang->cmd_yes}</label>
+				<label for="use_server_push_n" class="x_inline"><input type="radio" name="use_server_push" id="use_server_push_n" value="N" checked="checked"|cond="!$use_server_push" /> {$lang->cmd_no}</label>
+			</div>
+		</div>
+		<div class="x_control-group">
 			<label class="x_control-label">{$lang->use_gzip}</label>
 			<div class="x_controls">
 				<label for="use_gzip_y" class="x_inline"><input type="radio" name="use_gzip" id="use_gzip_y" value="Y" checked="checked"|cond="$use_gzip" /> {$lang->cmd_yes}</label>

--- a/tests/unit/classes/FrontEndFileHandlerTest.php
+++ b/tests/unit/classes/FrontEndFileHandlerTest.php
@@ -39,7 +39,7 @@ class FrontEndFileHandlerTest extends \Codeception\TestCase\Test
 			$handler = new FrontEndFileHandler();
 			$handler->loadFile(array('./common/css/rhymix.scss'));
 			$handler->loadFile(array('./common/css/mobile.css'));
-			$result = $handler->getCssFileList();
+			$result = $handler->getCssFileList(true);
 			$this->assertRegexp('/\.rhymix\.scss\.css\?\d+$/', $result[0]['file']);
 			$this->assertEquals('all', $result[0]['media']);
 			$this->assertEmpty($result[0]['targetie']);
@@ -155,7 +155,7 @@ class FrontEndFileHandlerTest extends \Codeception\TestCase\Test
 			$handler = new FrontEndFileHandler();
 			$handler->loadFile(array('./common/css/rhymix.scss'));
 			$handler->loadFile(array('./common/css/mobile.css'));
-			$result = $handler->getCssFileList();
+			$result = $handler->getCssFileList(true);
 			$this->assertRegexp('/\.rhymix\.scss\.min\.css\b/', $result[0]['file']);
 			$this->assertEquals('all', $result[0]['media']);
 			$this->assertEmpty($result[0]['targetie']);
@@ -167,7 +167,7 @@ class FrontEndFileHandlerTest extends \Codeception\TestCase\Test
 		$this->specify("minify (js)", function() {
 			$handler = new FrontEndFileHandler();
 			$handler->loadFile(array('./common/js/common.js', 'head'));
-			$result = $handler->getJsFileList();
+			$result = $handler->getJsFileList('head', true);
 			$this->assertRegexp('/minified\/common\.js\.common\.min\.js\?\d+$/', $result[0]['file']);
 			$this->assertEmpty($result[0]['targetie']);
 		});
@@ -186,7 +186,7 @@ class FrontEndFileHandlerTest extends \Codeception\TestCase\Test
 			$handler->loadFile(array('./tests/_data/formatter/concat.source2.css'));
 			$handler->loadFile(array('./tests/_data/formatter/concat.target1.css'));
 			$handler->loadFile(array('./tests/_data/formatter/concat.target2.css'));
-			$result = $handler->getCssFileList();
+			$result = $handler->getCssFileList(true);
 			$this->assertEquals(4, count($result));
 			$this->assertRegexp('/combined\/[0-9a-f]+\.css\?\d+$/', $result[0]['file']);
 			$this->assertEquals('http://external.host/style.css', $result[1]['file']);
@@ -207,7 +207,7 @@ class FrontEndFileHandlerTest extends \Codeception\TestCase\Test
 			$handler->loadFile(array('./tests/_data/formatter/concat.source2.js', 'head', 'gt IE 7'));
 			$handler->loadFile(array('./tests/_data/formatter/concat.target1.js'));
 			$handler->loadFile(array('./tests/_data/formatter/concat.target2.js'));
-			$result = $handler->getJsFileList();
+			$result = $handler->getJsFileList('head', true);
 			$this->assertEquals(3, count($result));
 			$this->assertRegexp('/combined\/[0-9a-f]+\.js\?\d+$/', $result[0]['file']);
 			$this->assertEquals('//external.host/js/script.js', $result[1]['file']);


### PR DESCRIPTION
- #483 적용 후 서드파티 애드온 등에서 `Context::getCssFile()`, `Context::getJsFile()` 등을 호출하면 압축 및 합치기 후의 결과를 반환하는 문제를 해결
  - 기존 방식으로 호출하면 압축 및 합치기하기 전의 원본 목록을 반환하도록 수정
  - `common_layout.html`에서는 파라미터 하나를 추가로 전달하여 압축 및 합치기하도록 함
  - 최종 1회 외에는 원본 목록을 반환하므로 서드파티 자료에서 처리하기 쉽고, 처리 후의 내용도 최종 1회 압축 및 합치기할 때 함께 처리할 수 있음
- FrontEndFileHandler를 통해 로딩하는 CSS 및 JS 리소스에 대하여 HTTP/2 server push를 사용할 수 있도록 옵션 추가 (시스템 설정 → 고급 설정 화면에서 변경 가능)
  - 시험적인 기능이므로 기본값은 꺼둠
