### PR TITLE
XE의 SEO 모듈을 가져와서 라이믹스에 맞게 고침

### DIFF
--- a/modules/seo/LICENSE
+++ b/modules/seo/LICENSE
@@ -1,0 +1,8 @@
+The MIT License (MIT)
+Copyright (c) 2016 Gyeong-Won Hong <bnufactory@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/modules/seo/README.md
+++ b/modules/seo/README.md
@@ -1,0 +1,2 @@
+XpressEngine SEO
+================

--- a/modules/seo/conf/info.xml
+++ b/modules/seo/conf/info.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module version="0.2">
+	<title xml:lang="ko">SEO</title>
+	<description xml:lang="ko">검색엔진 최적화</description>
+	<version>1.8.19</version>
+	<date>2016-04-15</date>
+	<license>MIT</license>
+	<author email_address="bnufactory@gmail.com">
+		<name xml:lang="ko">BNU</name>
+		<name xml:lang="vi">BNU</name>
+		<name xml:lang="zh-CN">BNU</name>
+		<name xml:lang="jp">BNU</name>
+		<name xml:lang="en">BNU</name>
+		<name xml:lang="es">BNU</name>
+		<name xml:lang="ru">BNU</name>
+		<name xml:lang="zh-TW">BNU</name>
+		<name xml:lang="tr">BNU</name>
+	</author>
+	<author email_address="developers@xpressengine.com" link="https://www.xpressengine.com/">
+		<name xml:lang="ko">NAVER</name>
+		<name xml:lang="vi">NAVER</name>
+		<name xml:lang="zh-CN">NAVER</name>
+		<name xml:lang="jp">NAVER</name>
+		<name xml:lang="en">NAVER</name>
+		<name xml:lang="es">NAVER</name>
+		<name xml:lang="ru">NAVER</name>
+		<name xml:lang="zh-TW">NAVER</name>
+		<name xml:lang="tr">NAVER</name>
+	</author>
+</module>

--- a/modules/seo/conf/module.xml
+++ b/modules/seo/conf/module.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<module>
+	<grants />
+	<permissions />
+	<actions>
+		<action name="dispSeoAdminSetting" type="view" menu_name="setting" menu_index="true" admin_index="true" />
+		<action name="procSeoAdminEnviromentGatheringAgreement" type="controller" />
+
+		<action name="procSeoAdminSaveSetting" type="controller" />
+	</actions>
+	<menus>
+		<menu name="setting" type="all">
+			<title xml:lang="ko">XE SEO</title>
+		</menu>
+	</menus>
+</module>

--- a/modules/seo/package.json
+++ b/modules/seo/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "XE-SEO",
+  "version": "1.8.0",
+  "author": "BNU",
+  "contributors": [
+    {
+      "name" : "BNU",
+      "email" : "bnufactory@gmail.com"
+    }
+  ],
+  "keywords": ["SEO","search engine optimization", "XpressEngine", "XE"],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/xpressengine/xe-module-seo.git"
+  },
+  "bugs": {
+    "url" : "https://github.com/xpressengine/xe-module-seo/issues"
+  },
+  "devDependencies": {
+    "grunt": ">0.4.0",
+    "grunt-phplint": "0.0.5"
+  },
+  "main": "Gruntfile.js",
+  "scripts": {
+    "test": "grunt"
+  }
+}

--- a/modules/seo/ruleset/saveSetting.xml
+++ b/modules/seo/ruleset/saveSetting.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ruleset version="1.5.0">
+	<fields>
+		<field name="site_name" required="true">
+			<if test="$use_optimize_title == 'Y'" attr="required" value="true" />
+		</field>
+	</fields>
+</ruleset>

--- a/modules/seo/seo.admin.controller.php
+++ b/modules/seo/seo.admin.controller.php
@@ -1,0 +1,78 @@
+<?php
+class seoAdminController extends seo
+{
+	function procSeoAdminSaveSetting()
+	{
+		$oModuleController = getController('module');
+
+		$vars = Context::getRequestVars();
+		$config = $this->getConfig();
+
+		if ($vars->setting_section == 'general')
+		{
+			// 기본 설정
+			$config->enable = ($vars->enable === 'Y') ? 'Y' : 'N';
+			$config->use_optimize_title = $vars->use_optimize_title;
+			$config->site_name = $vars->site_name;
+			$config->site_slogan = $vars->site_slogan;
+			$config->site_description = $vars->site_description;
+			$config->site_keywords = $vars->site_keywords;
+
+			if ($vars->site_image)
+			{
+				$path = _XE_PATH_ . 'files/attach/site_image/';
+				$ext = strtolower(array_pop(explode('.', $vars->site_image['name'])));
+				$timestamp = time();
+				$filename = "site_image.{$timestamp}.{$ext}";
+				FileHandler::copyFile($vars->site_image['tmp_name'], $path . $filename);
+				$config->site_image = $filename;
+				
+				list($width, $height) = @getimagesize($path . $filename);
+				$site_image_dimension = array('width' => $width, 'height' => $height);
+				Rhymix\Framework\Cache::set('seo:site_image', $site_image_dimension, 0, true);
+			}
+		}
+		elseif ($vars->setting_section == 'analytics')
+		{
+			// analytics
+
+			// Google
+			$config->ga_id = trim($vars->ga_id);
+			$config->ga_except_admin = $vars->ga_except_admin;
+
+			// Naver
+			$config->na_id = trim($vars->na_id);
+			$config->na_except_admin = $vars->na_except_admin;
+		}
+		elseif ($vars->setting_section == 'miscellaneous')
+		{
+			// miscellaneous
+
+			// Facebook
+			$config->fb_app_id = trim($vars->fb_app_id);
+			$config->fb_admins = trim($vars->fb_admins);
+		}
+
+		$config->site_image_url = NULL;
+
+		$oModuleController->updateModuleConfig('seo', $config);
+
+		if($config->enable === 'Y')
+		{
+			$this->moduleUpdate();
+		}
+		else
+		{
+			// Delete Triggers
+			$oModuleController = getController('module');
+			$oModuleController->deleteModuleTriggers('seo');
+		}
+
+		$this->setMessage('success_updated');
+		if (Context::get('success_return_url'))
+		{
+			$this->setRedirectUrl(Context::get('success_return_url'));
+		}
+	}
+}
+/* !End of file */

--- a/modules/seo/seo.admin.view.php
+++ b/modules/seo/seo.admin.view.php
@@ -1,0 +1,33 @@
+<?php
+class seoAdminView extends seo
+{
+	function init()
+	{
+		$this->setTemplatePath($this->module_path . 'tpl');
+		$this->setTemplateFile(str_replace('dispSeo', '', $this->act));
+	}
+
+	function dispSeoAdminDashboard()
+	{
+		$oModuleModel = getModel('module');
+	}
+
+	function dispSeoAdminSetting()
+	{
+		$vars = Context::getRequestVars();
+		if (!$vars->setting_section)
+		{
+			Context::set('setting_section', 'general');
+		}
+
+		$config = $this->getConfig();
+
+		$db_info = Context::getDBInfo();
+		$hostname = parse_url($db_info->default_url);
+		$hostname = $hostname['host'];
+
+		Context::set('config', $config);
+		Context::set('hostname', $hostname);
+	}
+}
+/* !End of file */

--- a/modules/seo/seo.class.php
+++ b/modules/seo/seo.class.php
@@ -1,0 +1,169 @@
+<?php
+class seo extends ModuleObject
+{
+	public $SEO = array(
+		'link' => array(),
+		'meta' => array()
+	);
+
+	protected $canonical_url;
+
+	private $triggers = array(
+		array('display', 'seo', 'controller', 'triggerBeforeDisplay', 'before'),
+		array('file.deleteFile', 'seo', 'controller', 'triggerAfterFileDeleteFile', 'after'),
+		array('document.updateDocument', 'seo', 'controller', 'triggerAfterDocumentUpdateDocument', 'after'),
+		array('document.deleteDocument', 'seo', 'controller', 'triggerAfterDocumentDeleteDocument', 'after')
+	);
+
+	public function getConfig()
+	{
+		$oModuleModel = getModel('module');
+		$config = $oModuleModel->getModuleConfig('seo');
+
+		if (!$config) $config = new stdClass;
+		if (!$config->enable) $config->enable = 'Y';
+		if (!$config->use_optimize_title) $config->use_optimize_title = 'N';
+		if (!$config->ga_except_admin) $config->ga_except_admin = 'N';
+		if (!$config->ga_track_subdomain) $config->ga_track_subdomain = 'N';
+		if ($config->site_image)
+		{
+			$request_uri = Rhymix\Framework\URL::encodeIdna(Context::getRequestUri());
+			$config->site_image_url = $request_uri . 'files/attach/site_image/' . $config->site_image;
+
+			$site_image = Rhymix\Framework\Cache::get('seo:site_image');
+			if (!$site_image)
+			{
+				$path = _XE_PATH_ . 'files/attach/site_image/';
+				list($width, $height) = @getimagesize($path . $config->site_image);
+				$site_image_dimension = array('width' => $width, 'height' => $height);
+				Rhymix\Framework\Cache::set('seo:site_image', $site_image_dimension, 0, true);
+			}
+		}
+
+		return $config;
+	}
+
+	public function addMeta($property, $content, $attr_name = 'property')
+	{
+		if (!$content) return;
+
+		$oModuleController = getController('module');
+		$oModuleController->replaceDefinedLangCode($content);
+		if (!in_array($property, array('og:url'))) {
+			$content = htmlspecialchars($content);
+			$content = preg_replace("/(\s+)/", ' ', $content);
+		}
+
+		$this->SEO['meta'][] = array('property' => $property, 'content' => $content, 'attr_name' => $attr_name);
+	}
+
+	public function addLink($rel, $href)
+	{
+		if (!$href) return;
+
+		$this->SEO['link'][] = array('rel' => $rel, 'href' => $href);
+	}
+
+	protected function applySEO()
+	{
+		$config = $this->getConfig();
+		$logged_info = Context::get('logged_info');
+
+		foreach ($this->SEO as $type => $list) {
+			if (!$list || !count($list)) continue;
+
+			foreach ($list as $val) {
+				if ($type == 'meta') {
+					$attr_name = $val['attr_name'];
+					Context::addHtmlHeader('<meta ' . $attr_name . '="' . $val['property'] . '" content="' . $val['content'] . '" />');
+				} elseif ($type == 'link') {
+					Context::addHtmlHeader('<link rel="' . $val['rel'] . '" href="' . $val['href'] . '" />');
+				}
+			}
+		}
+
+		// Google Analytics
+		if ($config->ga_id && !($config->ga_except_admin == 'Y' && $logged_info->is_admin == 'Y')) {
+			$gaq_push = array();
+			// $gaq_push[] = '_gaq.push([\'_setAccount\', \'' . $config->ga_id . '\']);';
+			$gaq_push[] = "ga('create', '{$config->ga_id}', 'auto');";
+			$canonical_url = str_replace(Context::get('request_uri'), '/', $this->canonical_url);
+			$gaq_push[] = "ga('send', 'pageview', '{$canonical_url}');";
+			$gaq_push = implode(PHP_EOL, $gaq_push);
+
+			$ga_script = <<< GASCRIPT
+<!-- Google Analytics -->
+<script>
+(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+{$gaq_push}
+</script>
+GASCRIPT;
+
+			Context::addHtmlHeader($ga_script . PHP_EOL);
+		}
+
+		// Naver Analytics
+		if ($config->na_id && !($config->na_except_admin == 'Y' && $logged_info->is_admin == 'Y')) {
+			$na_script = <<< NASCRIPT
+<!-- NAVER Analytics -->
+<script src="//wcs.naver.net/wcslog.js"></script>
+<script>if(!wcs_add){var wcs_add={wa:'{$config->na_id}'};}if(typeof wcs_do!="undefined"){wcs_do();}</script>
+NASCRIPT;
+			Context::addHtmlFooter($na_script . PHP_EOL);
+		}
+	}
+
+	function moduleInstall()
+	{
+		return new Object();
+	}
+
+	function checkUpdate()
+	{
+		$oModuleModel = getModel('module');
+
+		$seo_config = $this->getConfig();
+
+		if($seo_config->enable === 'Y') {
+			foreach ($this->triggers as $trigger) {
+				if (!$oModuleModel->getTrigger($trigger[0], $trigger[1], $trigger[2], $trigger[3], $trigger[4])) return TRUE;
+			}
+		}
+
+		return FALSE;
+	}
+
+	function moduleUpdate()
+	{
+		$oModuleModel = getModel('module');
+		$oModuleController = getController('module');
+
+		$seo_config = $this->getConfig();
+
+		if($seo_config->enable === 'Y') {
+			foreach ($this->triggers as $trigger) {
+				if (!$oModuleModel->getTrigger($trigger[0], $trigger[1], $trigger[2], $trigger[3], $trigger[4])) {
+					$oModuleController->insertTrigger($trigger[0], $trigger[1], $trigger[2], $trigger[3], $trigger[4]);
+				}
+			}
+		}
+
+		return new Object(0, 'success_updated');
+	}
+
+	function moduleUninstall()
+	{
+		$oModuleController = getController('module');
+
+		foreach ($this->triggers as $trigger) {
+			$oModuleController->deleteTrigger($trigger[0], $trigger[1], $trigger[2], $trigger[3], $trigger[4]);
+		}
+
+		return new Object();
+	}
+}
+/* !End of file */

--- a/modules/seo/seo.controller.php
+++ b/modules/seo/seo.controller.php
@@ -1,0 +1,270 @@
+<?php
+class seoController extends seo
+{
+	function getBrowserTitle($document_title = null)
+	{
+		$site_module_info = Context::get('site_module_info');
+		if ($site_module_info->site_srl != 0) return Context::getBrowserTitle();
+
+		$config = $this->getConfig();
+		if ($config->use_optimize_title != 'Y') return Context::getBrowserTitle();
+
+		$current_module_info = Context::get('current_module_info');
+		$is_index = ($current_module_info->module_srl == $site_module_info->module_srl) ? true : false;
+
+		$piece = array();
+		$piece['[:site_name:]'] = $config->site_name;
+		$piece['[:site_slogan:]'] = $config->site_slogan;
+		$piece['[:module_title:]'] = $current_module_info->browser_title;
+		if ($document_title) $piece['[:document_title:]'] = $document_title;
+
+		if ($config->use_optimize_title == 'Y') {
+			$title = array();
+			if ($piece['[:document_title:]']) {
+				$title[] = $piece['[:document_title:]'];
+				$title[] = $piece['[:module_title:]'];
+				$title[] = $piece['[:site_name:]'];
+			} else {
+				if ($is_index) {
+					$title[] = $piece['[:site_name:]'];
+					if ($piece['[:site_slogan:]']) $title[] = $piece['[:site_slogan:]'];
+				} else {
+					$title[] = $piece['[:module_title:]'];
+					$title[] = $piece['[:site_name:]'];
+				}
+			}
+			$title = implode(' - ', $title);
+		}
+
+		return $title;
+	}
+
+	function triggerBeforeDisplay(&$output_content)
+	{
+		if (Context::getResponseMethod() != 'HTML') return;
+		if (Context::get('module') == 'admin') return;
+
+		$locales = array(
+			'de' => 'de_DE',
+			'en' => 'en_US',
+			'es' => 'es_ES',
+			'fr' => 'fr_FR',
+			'ja' => 'ja_JP',
+			'jp' => 'ja_JP',
+			'ko' => 'ko_KR',
+			'mn' => 'mn_MN',
+			'ru' => 'ru_RU',
+			'tr' => 'tr_TR',
+			'vi' => 'vi_VN',
+			'zh-CN' => 'zh_CN',
+			'zh-TW' => 'zh_TW',
+		);
+
+		$oModuleModel = getModel('module');
+		$config = $this->getConfig();
+		$request_uri = Rhymix\Framework\URL::encodeIdna(Context::getRequestUri());
+
+		$logged_info = Context::get('logged_info');
+		$current_module_info = Context::get('current_module_info');
+		$site_module_info = Context::get('site_module_info');
+		$document_srl = Context::get('document_srl');
+		$is_article = false;
+		$single_image = false;
+		$is_index = ($current_module_info->module_srl == $site_module_info->module_srl) ? true : false;
+
+		$piece = new stdClass;
+		$piece->document_title = null;
+		$piece->type = 'website';
+		$piece->url = getFullUrl('');
+		$piece->title = Context::getBrowserTitle();
+		$piece->description = $config->site_description;
+		$piece->keywords = $config->site_keywords;
+		$piece->tags = array();
+		$piece->image = array();
+		$piece->author = null;
+
+		if(stristr($_SERVER['HTTP_USER_AGENT'], 'facebookexternalhit') != FALSE) {
+			$single_image = true;
+		}
+
+		if ($document_srl) {
+			$oDocument = Context::get('oDocument');
+			if (!is_a($oDocument, 'documentItem')) {
+				$oDocumentModel = getModel('document');
+				$oDocument = $oDocumentModel->getDocument($document_srl);
+			}
+
+			if (is_a($oDocument, 'documentItem') && $document_srl == $oDocument->document_srl) {
+				$is_article = true;
+			}
+		}
+
+		// 문서 데이터 수집
+		if ($is_article)
+		{
+			if (!$oDocument->isSecret())
+			{
+				$piece->document_title = $oDocument->getTitleText();
+				$piece->url = getFullUrl('', 'mid', $current_module_info->mid, 'document_srl',$document_srl);
+				$piece->type = 'article';
+				$piece->description = trim(str_replace('&nbsp;', ' ', $oDocument->getContentText(400)));
+				$piece->author = $oDocument->getNickName();
+				$tags = $oDocument->get('tag_list');
+				if (count($tags))
+				{
+					$piece->tags = $tags;
+				}
+
+				$document_images = Rhymix\Framework\Cache::get('seo:document_images:' . $document_srl);
+				if ($document_images === null && $oDocument->hasUploadedFiles())
+				{
+					$image_ext = array('bmp', 'gif', 'jpg', 'jpeg', 'png');
+					$document_images = array();
+
+					foreach ($oDocument->getUploadedFiles() as $file)
+					{
+						if ($file->isvalid != 'Y')
+						{
+							continue;
+						}
+
+						$ext = array_pop(explode('.', $file->uploaded_filename));
+						if (!in_array(strtolower($ext), $image_ext))
+						{
+							continue;
+						}
+						
+						list($width, $height) = @getimagesize($file->uploaded_filename);
+						if ($width < 100 && $height < 100)
+						{
+							continue;
+						}
+
+						$image = array(
+							'filepath' => $file->uploaded_filename,
+							'width' => $width,
+							'height' => $height
+						);
+
+						if ($file->cover_image === 'Y')
+						{
+							array_unshift($document_images, $image);
+						}
+						else
+						{
+							$document_images[] = $image;
+						}
+					}
+					
+					Rhymix\Framework\Cache::set('seo:document_images:' . $document_srl, $document_images);
+				}
+				
+				if ($document_images)
+				{
+					$piece->image = $document_images;
+				}
+			}
+			else
+			{
+				$piece->url = getFullUrl('', 'mid', $current_module_info->mid);
+			}
+		}
+		else
+		{
+			if (!$is_index)
+			{
+				$page = (Context::get('page') > 1) ? Context::get('page') : null;
+				$piece->url = getNotEncodedFullUrl('mid', $current_module_info->mid, 'page',$page);
+			}
+		}
+
+		$piece->title = $this->getBrowserTitle($piece->document_title);
+		
+		$site_image = Rhymix\Framework\Cache::get('seo:site_image');
+		if ($site_image)
+		{
+			$site_image['url'] = $config->site_image_url;
+		}
+		$piece->image[] = $site_image;
+		
+		$this->addLink('canonical', $piece->url);
+		$this->addMeta('keywords', $piece->keywords, 'name');
+		$this->addMeta('description', $piece->description, 'name');
+
+		// Open Graph
+		$this->addMeta('og:locale', $locales[Context::getLangType()]);
+		$this->addMeta('og:type', $piece->type);
+		$this->addMeta('og:url', $piece->url);
+		$this->addMeta('og:site_name', $config->site_name);
+		$this->addMeta('og:title', $piece->title);
+		$this->addMeta('og:description', $piece->description);
+		if ($is_article)
+		{
+			if (Context::getLangType() !== $oDocument->getLangCode())
+			{
+				$this->addMeta('og:locale:alternate', $locales[$oDocument->getLangCode()]);
+			}
+			$this->addMeta('article:published_time', $oDocument->getRegdate('c'));
+			$this->addMeta('article:modified_time', $oDocument->getUpdate('c'));
+			foreach ($piece->tags as $tag)
+			{
+				$this->addMeta('article:tag', $tag);
+			}
+		}
+
+		foreach ($piece->image as $img)
+		{
+			if (!$img['url'])
+			{
+				if (!$img['filepath'])
+				{
+					continue;
+				}
+				$img['url'] = $request_uri . $img['filepath'];
+			}
+
+			$this->addMeta('og:image', $img['url']);
+			$this->addMeta('og:image:width', $img['width']);
+			$this->addMeta('og:image:height', $img['height']);
+			if ($single_image)
+			{
+				break;
+			}
+		}
+
+		$this->canonical_url = $piece->url;
+
+		$this->applySEO();
+
+		if ($config->use_optimize_title == 'Y')
+		{
+			Context::setBrowserTitle($piece->title);
+		}
+	}
+
+	function triggerAfterFileDeleteFile($data)
+	{
+		$document_srl = $data->upload_target_srl;
+		if(!$document_srl) return new Object();
+
+		$this->deleteCacheDocumentImages($document_srl);
+	}
+
+	function triggerAfterDocumentUpdateDocument($data)
+	{
+		$document_srl = $data->document_srl;
+		$this->deleteCacheDocumentImages($document_srl);
+	}
+
+	function triggerAfterDocumentDeleteDocument($data)
+	{
+		$document_srl = $data->document_srl;
+		$this->deleteCacheDocumentImages($document_srl);
+	}
+
+	private function deleteCacheDocumentImages($document_srl)
+	{
+		Rhymix\Framework\Cache::delete('seo:document_images:' . $document_srl);
+	}
+}
+/* !End of file */

--- a/modules/seo/tpl/AdminDashboard.html
+++ b/modules/seo/tpl/AdminDashboard.html
@@ -1,0 +1,1 @@
+<include target="_AdminHeader.html" />

--- a/modules/seo/tpl/AdminSetting.html
+++ b/modules/seo/tpl/AdminSetting.html
@@ -1,0 +1,159 @@
+<include target="_AdminHeader.html" />
+
+<form action="./" class="x_form-horizontal" ruleset="saveSetting" method="post" enctype="multipart/form-data">
+	<input type="hidden" name="module" value="seo" />
+	<input type="hidden" name="act" value="procSeoAdminSaveSetting" />
+	<input type="hidden" name="setting_section" value="{$setting_section}" />
+	<input type="hidden" name="success_return_url" value="{getUrl('act', $act)}" />
+
+	<!--// general -->
+	<block cond="$setting_section == 'general'">
+		{@ $use_multilang = true}
+		<section class="section default">
+			<h1>기본 설정</h1>
+			<div class="x_control-group default">
+				<label for="enable" class="x_control-label">기능 활성화</label>
+				<div class="x_controls">
+					<label><input type="checkbox" name="enable" id="enable" value="Y" checked="checked"|cond="$config->enable == 'Y'" /> 검색엔진 최적화 기능 사용</label>
+				</div>
+			</div>
+			<div class="x_control-group">
+				<label class="x_control-label" for="site_image">사이트 대표 이미지</label>
+				<div class="x_controls">
+					<input type="file" name="site_image" id="site_image" />
+					<p class="x_help-block">페이스북 공유 시 문서에 이미지가 없으면 기본 이미지로 사용됩니다. (추천 : 1200x600, 600x315, 200x200)</p>
+					<div class="x_thumbnail" cond="$config->site_image_url">
+						<img src="{$config->site_image_url}" alt="지정된 사이트 대표 이미지" />
+					</div>
+				</div>
+			</div>
+		</section>
+
+		<section class="section">
+			<h1>문서 제목 최적화</h1>
+			<p class="x_well x_well-small">
+				<em class="x_label x_label-success">사용 권장</em> 사이트 이름 및 문서의 제목을 효과적으로 표시할 수 있습니다.
+				<br>
+				<br>
+				<span class="x_label x_label-info">예시 - 메인 페이지</span> '사이트 이름 - 사이트 부제'
+				<br>
+				<span class="x_label x_label-info">예시 - 모듈 페이지</span> '페이지 제목 - 사이트 이름'
+				<br>
+				<span class="x_label x_label-info">예시 - 글(게시물)</span> '글 제목 - 사이트 이름'
+			</p>
+			<div class="x_control-group">
+				<label for="use_optimize_title" class="x_control-label">문서 제목 최적화</label>
+				<div class="x_controls">
+					<label><input type="checkbox" name="use_optimize_title" id="use_optimize_title" value="Y" checked="checked"|cond="$config->use_optimize_title == 'Y'" /> 문서 제목 최적화 기능 사용</label>
+				</div>
+			</div>
+			<div class="x_control-group">
+				<label class="x_control-label" for="lang_site_name">사이트 이름</label>
+				<div class="x_controls">
+					<input type="text" name="site_name" id="site_name" value="<!--@if(strpos($config->site_name, '$user_lang->') === false)-->{$config->site_name}<!--@else-->{htmlspecialchars($config->site_name)}<!--@end-->" class="lang_code" />
+					<p class="x_help-block">모든 페이지의 제목으로 사용되며 '모듈 브라우저 타이틀 - 사이트 이름' 또는 '글 제목 - 사이트 이름'과 같이 표시됩니다.</p>
+				</div>
+			</div>
+			<div class="x_control-group">
+				<label class="x_control-label" for="lang_site_slogan">사이트 부제</label>
+				<div class="x_controls">
+					<input type="text" name="site_slogan" id="site_slogan" value="<!--@if(strpos($config->site_slogan, '$user_lang->') === false)-->{$config->site_slogan}<!--@else-->{htmlspecialchars($config->site_slogan)}<!--@end-->" class="lang_code" />
+					<p class="x_help-block">사이트의 부제, 슬로건, 캐치프레이즈. 시작 페이지에서만 표시되며 '사이트 이름 - 사이트 부제'와 같이 표시됩니다.</p>
+				</div>
+			</div>
+		</section>
+
+		<section class="section">
+			<h1>기본 메타태그</h1>
+			<p class="x_well x_well-small">사이트 전역에 사용 될 <code>&lt;meta&gt;</code> 태그 설정.</p>
+			<div class="x_control-group">
+				<label class="x_control-label" for="lang_site_keywords">사이트 키워드 (keywords)</label>
+				<div class="x_controls">
+					<input type="text" name="site_keywords" id="site_keywords" value="<!--@if(strpos($config->site_keywords, '$user_lang->') === false)-->{$config->site_keywords}<!--@else-->{htmlspecialchars($config->site_keywords)}<!--@end-->" class="lang_code x_input-xxlarge" />
+					<p class="x_help-block">여러 키워드는 콤마(,)로 구분하여 입력하세요.</p>
+				</div>
+			</div>
+			<div class="x_control-group">
+				<label class="x_control-label" for="lang_site_description">사이트 설명 (description)</label>
+				<div class="x_controls">
+					<input type="text" name="site_description" id="site_description" value="<!--@if(strpos($config->site_description, '$user_lang->') === false)-->{$config->site_description}<!--@else-->{htmlspecialchars($config->site_description)}<!--@end-->" class="lang_code x_input-xxlarge" />
+					<p class="x_help-block">사이트의 주제에 관한 설명. 200자 미만으로 너무 길지 않고 의도적으로 너무 많은 키워드를 반복하는 것은 좋지 않습니다.</p>
+				</div>
+			</div>
+		</section>
+	</block>
+
+	<!--// analytics -->
+	<block cond="$setting_section == 'analytics'">
+		<section class="section">
+			<h1>Google</h1>
+			<p class="x_well">
+				Google Analytics 추적 코드를 자동으로 삽입하고, 최적화 된 URL을 추적하도록 돕습니다.<br>
+				<span class="x_label x_label-important">Important</span> 이미 추적 코드를 사용 중이면 삽입한 추적 코드를 제거하거나 이 설정을 입력하지 마세요.
+			</p>
+			<div class="x_control-group">
+				<label class="x_control-label" for="ga_id">속성 ID</label>
+				<div class="x_controls">
+					<input type="text" name="ga_id" id="ga_id" value="{$config->ga_id}" placeholder="UA-XXXXXXXX-X" />
+				</div>
+			</div>
+			<div class="x_control-group">
+				<label class="x_control-label" for="ga_except_admin">관리자 제외</label>
+				<div class="x_controls">
+					<label><input type="checkbox" name="ga_except_admin" id="ga_except_admin" value="Y" checked="checked"|cond="$config->ga_except_admin == 'Y'" /> 관리자 접속 시 추적 코드를 사용하지 않음</label>
+				</div>
+			</div>
+		</section>
+
+		<section class="section">
+			<h1>NAVER</h1>
+			<p class="x_well">
+				Naver Analytics 추적 코드를 자동으로 삽입합니다.<br>
+				<span class="x_label x_label-important">Important</span> 이미 추적 코드를 사용 중이면 삽입한 추적 코드를 제거하거나 이 설정을 입력하지 마세요.
+			</p>
+			<div class="x_control-group">
+				<label class="x_control-label" for="na_id">발급 ID</label>
+				<div class="x_controls">
+					<input type="text" name="na_id" id="na_id" value="{$config->na_id}" />
+				</div>
+			</div>
+			<div class="x_control-group">
+				<label class="x_control-label" for="na_except_admin">관리자 제외</label>
+				<div class="x_controls">
+					<label><input type="checkbox" name="na_except_admin" id="na_except_admin" value="Y" checked="checked"|cond="$config->na_except_admin == 'Y'" /> 관리자 접속 시 추적 코드를 사용하지 않음</label>
+				</div>
+			</div>
+		</section>
+	</block>
+
+	<!--// analytics -->
+	<block cond="$setting_section == 'miscellaneous'">
+		<section class="section <!--@if(false && !$config->fb_app_id && !$config->fb_admins)-->collapsed<!--@endif-->">
+			<h1>Facebook</h1>
+			<p class="x_well x_well-small">페이스북 앱 연동 설정이 필요한 때 활용할 수 있습니다.</p>
+			<div class="x_control-group">
+				<label class="x_control-label" for="fb_app_id">Facebook App ID</label>
+				<div class="x_controls">
+					<input type="text" name="fb_app_id" id="fb_app_id" value="{$config->fb_app_id}" />
+					<p class="x_help-inline">페이스북 앱의 app_id</p>
+				</div>
+			</div>
+			<div class="x_control-group">
+				<label class="x_control-label" for="fb_admins">Facebook Admin</label>
+				<div class="x_controls">
+					<input type="text" name="fb_admins" id="fb_admins" value="{$config->fb_admins}" />
+					<p class="x_help-block">페이스북 앱의 관리자. 이메일이나 페이스북의 개인 주소가 아닌 숫자로 된 고유ID를 입력해야 합니다. 여러명을 지정 시 콤마(,)로 구분.</p>
+				</div>
+			</div>
+		</section>
+	</block>
+
+	<div class="x_clearfix btnArea">
+		<div class="x_pull-right">
+			<button class="x_btn x_btn-primary" type="submit">{$lang->cmd_save}</button>
+		</div>
+	</div>
+</form>
+
+<include target="../../module/tpl/include.multilang.html" />
+<include target="../../module/tpl/include.multilang.textarea.html" />

--- a/modules/seo/tpl/_AdminHeader.html
+++ b/modules/seo/tpl/_AdminHeader.html
@@ -1,0 +1,15 @@
+<div class="x_page-header">
+	<h1>SEO</h1>
+</div>
+
+<div cond="$XE_VALIDATOR_MESSAGE" class="message {$XE_VALIDATOR_MESSAGE_TYPE}">
+	<p>{$XE_VALIDATOR_MESSAGE}</p>
+</div>
+
+<div>
+	<ul class="x_nav x_nav-tabs">
+		<li class="x_active"|cond="$act == 'dispSeoAdminSetting' && $setting_section == 'general'"><a href="{getUrl('act','dispSeoAdminSetting', 'setting_section','general')}">기본 설정</a></li>
+		<li class="x_active"|cond="$act == 'dispSeoAdminSetting' && $setting_section == 'analytics'"><a href="{getUrl('act','dispSeoAdminSetting', 'setting_section','analytics')}">Analytics</a></li>
+		<li class="x_active"|cond="$act == 'dispSeoAdminSetting' && $setting_section == 'miscellaneous'"><a href="{getUrl('act','dispSeoAdminSetting', 'setting_section','miscellaneous')}">기타</a></li>
+	</ul>
+</div>


### PR DESCRIPTION
XE 1.8.19에 포함된 SEO 모듈이 라이믹스에서 더이상 사용하지 않는 `idna_convert` 라이브러리에 의존하기 때문에, XE 1.8.19에서 라이믹스로 업그레이드하면 오류가 발생합니다. 이 문제를 해결하고 라이믹스와의 호환성을 높이기 위해, 일부 수정한 SEO 모듈을 라이믹스로 들여왔습니다.

수정 내역:

- `idna_convert` 라이브러리 의존성 제거
- 캐시 처리 부분을 라이믹스 방식으로 변경하여 효율 향상