### PR TITLE
Redis 캐시 사용시 DB 번호를 선택할 수 있도록 함

### DIFF
--- a/common/framework/drivers/cache/redis.php
+++ b/common/framework/drivers/cache/redis.php
@@ -29,12 +29,13 @@ class Redis implements \Rhymix\Framework\Drivers\CacheInterface
 	{
 		try
 		{
-			$this->_conn = new \Redis;
+			$this->_conn = null;
 			foreach ($config as $url)
 			{
 				$info = parse_url($url);
 				if (isset($info['host']) && isset($info['port']))
 				{
+					$this->_conn = new \Redis;
 					$this->_conn->connect($info['host'], $info['port'], 0.15);
 					if(isset($info['user']) || isset($info['pass']))
 					{
@@ -47,7 +48,6 @@ class Redis implements \Rhymix\Framework\Drivers\CacheInterface
 					break;
 				}
 			}
-			$this->_conn = null;
 		}
 		catch (\RedisException $e)
 		{

--- a/modules/admin/admin.admin.controller.php
+++ b/modules/admin/admin.admin.controller.php
@@ -675,6 +675,10 @@ class adminAdminController extends admin
 			if ($vars->object_cache_type === 'memcached' || $vars->object_cache_type === 'redis')
 			{
 				$cache_servers = array($vars->object_cache_type . '://' . $vars->object_cache_host . ':' . intval($vars->object_cache_port));
+				if ($vars->object_cache_type === 'redis')
+				{
+					$cache_servers[0] .= '/' . intval($vars->object_cache_dbnum);
+				}
 			}
 			else
 			{

--- a/modules/admin/admin.admin.view.php
+++ b/modules/admin/admin.admin.view.php
@@ -515,11 +515,14 @@ class adminAdminView extends admin
 		{
 			Context::set('object_cache_host', parse_url(array_first($cache_servers), PHP_URL_HOST) ?: null);
 			Context::set('object_cache_port', parse_url(array_first($cache_servers), PHP_URL_PORT) ?: null);
+			$cache_dbnum = preg_replace('/[^\d]/', '', parse_url(array_first($cache_servers), PHP_URL_PATH));
+			Context::set('object_cache_dbnum', $cache_dbnum === '' ? 1 : intval($cache_dbnum));
 		}
 		else
 		{
 			Context::set('object_cache_host', null);
 			Context::set('object_cache_port', null);
+			Context::set('object_cache_dbnum', 1);
 		}
 		
 		// Thumbnail settings

--- a/modules/admin/lang/en.php
+++ b/modules/admin/lang/en.php
@@ -106,6 +106,7 @@ $lang->use_object_cache = 'Use Cache';
 $lang->cache_default_ttl = 'Cache default TTL';
 $lang->cache_host = 'Host';
 $lang->cache_port = 'Port';
+$lang->cache_dbnum = 'DB Number';
 $lang->msg_cache_handler_not_supported = 'Your server does not support the selected cache method, or Rhymix is unable to use the cache with the given settings.';
 $lang->msg_invalid_default_url = 'The default URL is invalid.';
 $lang->msg_default_url_ssl_inconsistent = 'In order to use SSL always, the default URL must also begin with https://';

--- a/modules/admin/lang/ja.php
+++ b/modules/admin/lang/ja.php
@@ -96,6 +96,7 @@ $lang->about_delay_session = 'Varnishなどのプロキシキャッシュサー�
 $lang->use_object_cache = 'キャッシュ使用';
 $lang->cache_host = 'ホスト';
 $lang->cache_port = 'ポート';
+$lang->cache_dbnum = 'DB番号';
 $lang->msg_cache_handler_not_supported = '選択したキャッシュ方式をサーバーでサポートされていないか、与えられた情報でキャッシュにアクセスすることができません。';
 $lang->msg_invalid_default_url = '基本URLが正しくありません。';
 $lang->msg_default_url_ssl_inconsistent = 'SSLを常に使用する場合、基本URLもhttps：//で始まる必要があります。';

--- a/modules/admin/lang/ko.php
+++ b/modules/admin/lang/ko.php
@@ -106,6 +106,7 @@ $lang->use_object_cache = '캐시 사용';
 $lang->cache_default_ttl = '캐시 기본 TTL';
 $lang->cache_host = '호스트';
 $lang->cache_port = '포트';
+$lang->cache_dbnum = 'DB번호';
 $lang->msg_cache_handler_not_supported = '선택하신 캐시 방식을 서버에서 지원하지 않거나, 주어진 정보로 캐시에 접속할 수 없습니다.';
 $lang->msg_invalid_default_url = '기본 URL이 올바르지 않습니다.';
 $lang->msg_default_url_ssl_inconsistent = 'SSL을 항상 사용하실 경우 기본 URL도 https://로 시작해야 합니다.';

--- a/modules/admin/tpl/config_advanced.html
+++ b/modules/admin/tpl/config_advanced.html
@@ -80,6 +80,7 @@
 				<div id="object_cache_additional_config" class="x_inline" style="display:none;margin-left:16px">
 					<label for="object_cache_host" class="x_inline">{$lang->cache_host}: <input type="text" name="object_cache_host" id="object_cache_host" value="{$object_cache_host}" /></label>
 					<label for="object_cache_port" class="x_inline">{$lang->cache_port}: <input type="number" name="object_cache_port" id="object_cache_port" size="5" style="min-width:70px" value="{$object_cache_port}" /></label>
+					<label for="object_cache_dbnum" class="x_inline">{$lang->cache_dbnum}: <input type="number" name="object_cache_dbnum" id="object_cache_dbnum" size="3" style="min-width:70px" value="{$object_cache_dbnum}" /></label>
 				</div>
 			</div>
 		</div>

--- a/modules/admin/tpl/js/config.js
+++ b/modules/admin/tpl/js/config.js
@@ -12,11 +12,17 @@ jQuery(function($){
 				if (!$("#object_cache_port").val()) {
 					$("#object_cache_port").val($(this).val().match(/memcache/) ? '11211' : '6379');
 				}
-				if ($(this).val().match(/memcache/) && $("#object_cache_port").val() == '6379') {
-					$("#object_cache_port").val('11211');
+				if ($(this).val().match(/memcache/)) {
+					if ($("#object_cache_port").val() == '6379') {
+						$("#object_cache_port").val('11211');
+					}
+					$("#object_cache_dbnum").parents("label").hide();
 				}
-				if ($(this).val().match(/redis/) && $("#object_cache_port").val() == '11211') {
-					$("#object_cache_port").val('6379');
+				if ($(this).val().match(/redis/)) {
+					if ($("#object_cache_port").val() == '11211') {
+						$("#object_cache_port").val('6379');
+					}
+					$("#object_cache_dbnum").parents("label").show();
 				}
 			} else {
 				$("#object_cache_additional_config").hide();


### PR DESCRIPTION
Redis는 푸쉬알림 등의 용도로 많이 사용하는데, 캐시로 겸용할 경우 캐시 데이터와 다른 용도의 데이터가 섞여 버려서 캐시만 모두 비우거나 다른 데이터를 관리하기가 힘들어집니다.

다행히 Redis는 임의의 DB 번호를 선택하여 데이터를 구분하는 기능을 지원하므로, 캐시 설정시 DB 번호를 선택하여 다른 데이터와 섞이지 않도록 하는 기능을 추가합니다.

대부분의 사용자들은 0번 DB를 사용하므로, 안전을 위해 캐시 데이터는 1번 DB를 사용하는 것을 기본값으로 하였습니다.