### PR TITLE
after 트리거에서 오류 반환시 롤백하는 기능 제거

### DIFF
--- a/modules/board/board.admin.view.php
+++ b/modules/board/board.admin.view.php
@@ -200,8 +200,8 @@ class boardAdminView extends board {
 
 		// get the addtional setup trigger
 		// the additional setup triggers can be used in many modules
-		$output = ModuleHandler::triggerCall('module.dispAdditionSetup', 'before', $content);
-		$output = ModuleHandler::triggerCall('module.dispAdditionSetup', 'after', $content);
+		ModuleHandler::triggerCall('module.dispAdditionSetup', 'before', $content);
+		ModuleHandler::triggerCall('module.dispAdditionSetup', 'after', $content);
 		Context::set('setup_content', $content);
 
 		// setup the template file

--- a/modules/comment/comment.controller.php
+++ b/modules/comment/comment.controller.php
@@ -179,12 +179,9 @@ class commentController extends comment
 		$obj->before_point = ($point < 0) ? $oComment->get('blamed_count') : $oComment->get('voted_count');
 		$obj->after_point = ($point < 0) ? $args->blamed_count : $args->voted_count;
 		$obj->cancel = 1;
-		$trigger_output = ModuleHandler::triggerCall('comment.updateVotedCountCancel', 'after', $obj);
-		if(!$trigger_output->toBool())
-		{
-			$oDB->rollback();
-			return $trigger_output;
-		}
+		
+		ModuleHandler::triggerCall('comment.updateVotedCountCancel', 'after', $obj);
+		$oDB->commit();
 		return $output;
 	}
 
@@ -578,15 +575,7 @@ class commentController extends comment
 		}
 
 		// call a trigger(after)
-		if($output->toBool())
-		{
-			$trigger_output = ModuleHandler::triggerCall('comment.insertComment', 'after', $obj);
-			if(!$trigger_output->toBool())
-			{
-				$oDB->rollback();
-				return $trigger_output;
-			}
-		}
+		ModuleHandler::triggerCall('comment.insertComment', 'after', $obj);
 
 		// commit
 		$oDB->commit();
@@ -905,15 +894,7 @@ class commentController extends comment
 		}
 
 		// call a trigger (after)
-		if($output->toBool())
-		{
-			$trigger_output = ModuleHandler::triggerCall('comment.updateComment', 'after', $obj);
-			if(!$trigger_output->toBool())
-			{
-				$oDB->rollback();
-				return $trigger_output;
-			}
-		}
+		ModuleHandler::triggerCall('comment.updateComment', 'after', $obj);
 
 		// commit
 		$oDB->commit();
@@ -1054,17 +1035,9 @@ class commentController extends comment
 		}
 
 		// call a trigger (after)
-		if($output->toBool())
-		{
-			$comment->isMoveToTrash = $isMoveToTrash;
-			$trigger_output = ModuleHandler::triggerCall('comment.deleteComment', 'after', $comment);
-			if(!$trigger_output->toBool())
-			{
-				$oDB->rollback();
-				return $trigger_output;
-			}
-			unset($comment->isMoveToTrash);
-		}
+		$comment->isMoveToTrash = $isMoveToTrash;
+		ModuleHandler::triggerCall('comment.deleteComment', 'after', $comment);
+		unset($comment->isMoveToTrash);
 
 		if(!$isMoveToTrash)
 		{
@@ -1144,11 +1117,7 @@ class commentController extends comment
 				}
 
 				// call a trigger (after)
-				$output = ModuleHandler::triggerCall('comment.deleteComment', 'after', $comment);
-				if(!$output->toBool())
-				{
-					continue;
-				}
+				ModuleHandler::triggerCall('comment.deleteComment', 'after', $comment);
 			}
 		}
 
@@ -1299,13 +1268,8 @@ class commentController extends comment
 		$obj->point = $point;
 		$obj->before_point = ($point < 0) ? $oComment->get('blamed_count') : $oComment->get('voted_count');
 		$obj->after_point = ($point < 0) ? $args->blamed_count : $args->voted_count;
-		$trigger_output = ModuleHandler::triggerCall('comment.updateVotedCount', 'after', $obj);
-		if(!$trigger_output->toBool())
-		{
-			$oDB->rollback();
-			return $trigger_output;
-		}
-
+		
+		ModuleHandler::triggerCall('comment.updateVotedCount', 'after', $obj);
 		$oDB->commit();
 
 		// Return the result
@@ -1437,12 +1401,7 @@ class commentController extends comment
 
 		// Call a trigger (after)
 		$trigger_obj->declared_count = $declared_count + 1;
-		$trigger_output = ModuleHandler::triggerCall('comment.declaredComment', 'after', $trigger_obj);
-		if(!$trigger_output->toBool())
-		{
-			$oDB->rollback();
-			return $trigger_output;
-		}
+		ModuleHandler::triggerCall('comment.declaredComment', 'after', $trigger_obj);
 
 		// commit
 		$oDB->commit();

--- a/modules/communication/communication.controller.php
+++ b/modules/communication/communication.controller.php
@@ -219,10 +219,10 @@ class communicationController extends communication
 		$trigger_obj->title = $title;
 		$trigger_obj->content = $content;
 		$trigger_obj->sender_log = $sender_log;
-		$triggerOutput = ModuleHandler::triggerCall('communication.sendMessage', 'before', $trigger_obj);
-		if(!$triggerOutput->toBool())
+		$trigger_output = ModuleHandler::triggerCall('communication.sendMessage', 'before', $trigger_obj);
+		if(!$trigger_output->toBool())
 		{
-			return $triggerOutput;
+			return $trigger_output;
 		}
 
 		$oDB = DB::getInstance();
@@ -248,12 +248,7 @@ class communicationController extends communication
 		}
 
 		// Call a trigger (after)
-		$trigger_output = ModuleHandler::triggerCall('communication.sendMessage', 'after', $trigger_obj);
-		if(!$trigger_output->toBool())
-		{
-			$oDB->rollback();
-			return $trigger_output;
-		}
+		ModuleHandler::triggerCall('communication.sendMessage', 'after', $trigger_obj);
 		
 		$oDB->commit();
 		

--- a/modules/document/document.admin.controller.php
+++ b/modules/document/document.admin.controller.php
@@ -209,13 +209,9 @@ class documentAdminController extends document
 			$oDB->rollback();
 			return $output;
 		}
-		// Call a trigger (before)
-		$output = ModuleHandler::triggerCall('document.moveDocumentModule', 'after', $triggerObj);
-		if(!$output->toBool())
-		{
-			$oDB->rollback();
-			return $output;
-		}
+		
+		// Call a trigger (after)
+		ModuleHandler::triggerCall('document.moveDocumentModule', 'after', $triggerObj);
 
 		$oDB->commit();
 		
@@ -433,12 +429,7 @@ class documentAdminController extends document
 
 		// Call a trigger (before)
 		$triggerObj->copied_srls = $copied_srls;
-		$output = ModuleHandler::triggerCall('document.copyDocumentModule', 'after', $triggerObj);
-		if(!$output->toBool())
-		{
-			$oDB->rollback();
-			return $output;
-		}
+		ModuleHandler::triggerCall('document.copyDocumentModule', 'after', $triggerObj);
 
 		$oDB->commit();
 
@@ -899,15 +890,7 @@ class documentAdminController extends document
 		}
 
 		// call a trigger (after)
-		if($output->toBool())
-		{
-			$trigger_output = ModuleHandler::triggerCall('document.restoreTrash', 'after', $originObject);
-			if(!$trigger_output->toBool())
-			{
-				$oDB->rollback();
-				return $trigger_output;
-			}
-		}
+		ModuleHandler::triggerCall('document.restoreTrash', 'after', $originObject);
 
 		// commit
 		$oDB->commit();

--- a/modules/document/document.controller.php
+++ b/modules/document/document.controller.php
@@ -176,13 +176,8 @@ class documentController extends document
 		$obj->after_point = ($point < 0) ? $args->blamed_count : $args->voted_count;
 		$obj->cancel = 1;
 
-		$trigger_output = ModuleHandler::triggerCall('document.updateVotedCountCancel', 'after', $obj);
-		if(!$trigger_output->toBool())
-		{
-			$oDB->rollback();
-			return $trigger_output;
-		}
-
+		ModuleHandler::triggerCall('document.updateVotedCountCancel', 'after', $obj);
+		$oDB->commit();
 		return $output;
 	}
 
@@ -467,29 +462,23 @@ class documentController extends document
 				$this->insertDocumentExtraVar($obj->module_srl, $obj->document_srl, $idx, $value, $extra_item->eid);
 			}
 		}
+		
 		// Update the category if the category_srl exists.
 		if($obj->category_srl) $this->updateCategoryCount($obj->module_srl, $obj->category_srl);
+		
 		// Call a trigger (after)
-		if($output->toBool())
+		if($obj->update_log_setting === 'Y')
 		{
-			if($obj->update_log_setting === 'Y')
-			{
-				$obj->extra_vars = serialize($extra_vars);
-				$update_output = $this->insertDocumentUpdateLog($obj);
+			$obj->extra_vars = serialize($extra_vars);
+			$update_output = $this->insertDocumentUpdateLog($obj);
 
-				if(!$update_output->toBool())
-				{
-					$oDB->rollback();
-					return $update_output;
-				}
-			}
-			$trigger_output = ModuleHandler::triggerCall('document.insertDocument', 'after', $obj);
-			if(!$trigger_output->toBool())
+			if(!$update_output->toBool())
 			{
 				$oDB->rollback();
-				return $trigger_output;
+				return $update_output;
 			}
 		}
+		ModuleHandler::triggerCall('document.insertDocument', 'after', $obj);
 
 		// commit
 		$oDB->commit();
@@ -738,36 +727,30 @@ class documentController extends document
 			if($extra_content->title) $this->insertDocumentExtraVar($obj->module_srl, $obj->document_srl, -1, $extra_content->title, 'title_'.Context::getLangType());
 			if($extra_content->content) $this->insertDocumentExtraVar($obj->module_srl, $obj->document_srl, -2, $extra_content->content, 'content_'.Context::getLangType());
 		}
+		
 		// Update the category if the category_srl exists.
 		if($source_obj->get('category_srl') != $obj->category_srl || $source_obj->get('module_srl') == $logged_info->member_srl)
 		{
 			if($source_obj->get('category_srl') != $obj->category_srl) $this->updateCategoryCount($obj->module_srl, $source_obj->get('category_srl'));
 			if($obj->category_srl) $this->updateCategoryCount($obj->module_srl, $obj->category_srl);
 		}
+		
 		// Call a trigger (after)
-		if($output->toBool())
+		if($obj->update_log_setting === 'Y')
 		{
-			if($obj->update_log_setting === 'Y')
+			$obj->extra_vars = serialize($extra_vars);
+			if($this->grant->manager)
 			{
-				$obj->extra_vars = serialize($extra_vars);
-				if($this->grant->manager)
-				{
-					$obj->is_admin = 'Y';
-				}
-				$update_output = $this->insertDocumentUpdateLog($obj, $source_obj);
-				if(!$update_output->toBool())
-				{
-					$oDB->rollback();
-					return $update_output;
-				}
+				$obj->is_admin = 'Y';
 			}
-			$trigger_output = ModuleHandler::triggerCall('document.updateDocument', 'after', $obj);
-			if(!$trigger_output->toBool())
+			$update_output = $this->insertDocumentUpdateLog($obj, $source_obj);
+			if(!$update_output->toBool())
 			{
 				$oDB->rollback();
-				return $trigger_output;
+				return $update_output;
 			}
 		}
+		ModuleHandler::triggerCall('document.updateDocument', 'after', $obj);
 
 		// commit
 		$oDB->commit();
@@ -888,18 +871,10 @@ class documentController extends document
 		// Delete extra variable
 		$this->deleteDocumentExtraVars($oDocument->get('module_srl'), $oDocument->document_srl);
 
-		//this
 		// Call a trigger (after)
-		if($output->toBool())
-		{
-			$trigger_obj = $oDocument->getObjectVars();
-			$trigger_output = ModuleHandler::triggerCall('document.deleteDocument', 'after', $trigger_obj);
-			if(!$trigger_output->toBool())
-			{
-				$oDB->rollback();
-				return $trigger_output;
-			}
-		}
+		$trigger_obj = $oDocument->getObjectVars();
+		ModuleHandler::triggerCall('document.deleteDocument', 'after', $trigger_obj);
+		
 		// declared document, log delete
 		$this->_deleteDeclaredDocuments($args);
 		$this->_deleteDocumentReadedLog($args);
@@ -1053,16 +1028,9 @@ class documentController extends document
 			$args->isvalid = 'N';
 			executeQuery('file.updateFileValid', $args);
 		}
+		
 		// Call a trigger (after)
-		if($output->toBool())
-		{
-			$trigger_output = ModuleHandler::triggerCall('document.moveDocumentToTrash', 'after', $obj);
-			if(!$trigger_output->toBool())
-			{
-				$oDB->rollback();
-				return $trigger_output;
-			}
-		}
+		ModuleHandler::triggerCall('document.moveDocumentToTrash', 'after', $obj);
 
 		// commit
 		$oDB->commit();
@@ -1135,12 +1103,7 @@ class documentController extends document
 		executeQuery('document.updateReadedCount', $args);
 
 		// Call a trigger when the read count is updated (after)
-		$trigger_output = ModuleHandler::triggerCall('document.updateReadedCount', 'after', $oDocument);
-		if(!$trigger_output->toBool())
-		{
-			$oDB->rollback();
-			return $trigger_output;
-		}
+		ModuleHandler::triggerCall('document.updateReadedCount', 'after', $oDocument);
 
 		$oDB->commit();
 
@@ -1396,12 +1359,8 @@ class documentController extends document
 		$obj->point = $point;
 		$obj->before_point = ($point < 0) ? $oDocument->get('blamed_count') : $oDocument->get('voted_count');
 		$obj->after_point = ($point < 0) ? $args->blamed_count : $args->voted_count;
-		$trigger_output = ModuleHandler::triggerCall('document.updateVotedCount', 'after', $obj);
-		if(!$trigger_output->toBool())
-		{
-			$oDB->rollback();
-			return $trigger_output;
-		}
+		
+		ModuleHandler::triggerCall('document.updateVotedCount', 'after', $obj);
 
 		$oDB->commit();
 
@@ -1539,12 +1498,7 @@ class documentController extends document
 
 		// Call a trigger (after)
 		$trigger_obj->declared_count = $declared_count + 1;
-		$trigger_output = ModuleHandler::triggerCall('document.declaredDocument', 'after', $trigger_obj);
-		if(!$trigger_output->toBool())
-		{
-			$oDB->rollback();
-			return $trigger_output;
-		}
+		ModuleHandler::triggerCall('document.declaredDocument', 'after', $trigger_obj);
 
 		// commit
 		$oDB->commit();

--- a/modules/file/file.controller.php
+++ b/modules/file/file.controller.php
@@ -282,7 +282,7 @@ class fileController extends file
 		executeQuery('file.updateFileDownloadCount', $args);
 
 		// Call a trigger (after)
-		$output = ModuleHandler::triggerCall('file.downloadFile', 'after', $file_obj);
+		ModuleHandler::triggerCall('file.downloadFile', 'after', $file_obj);
 
 		// Redirect to procFileOutput using file key
 		if(!isset($_SESSION['__XE_FILE_KEY__']) || !is_string($_SESSION['__XE_FILE_KEY__']) || strlen($_SESSION['__XE_FILE_KEY__']) != 32)
@@ -805,9 +805,9 @@ class fileController extends file
 
 		$output = executeQuery('file.insertFile', $args);
 		if(!$output->toBool()) return $output;
+		
 		// Call a trigger (after)
-		$trigger_output = ModuleHandler::triggerCall('file.insertFile', 'after', $args);
-		if(!$trigger_output->toBool()) return $trigger_output;
+		ModuleHandler::triggerCall('file.insertFile', 'after', $args);
 
 		$_SESSION['__XE_UPLOADING_FILES_INFO__'][$args->file_srl] = true;
 
@@ -895,8 +895,7 @@ class fileController extends file
 			if(!$output->toBool()) return $output;
 
 			// Call a trigger (after)
-			$trigger_output = ModuleHandler::triggerCall('file.deleteFile', 'after', $trigger_obj);
-			if(!$trigger_output->toBool()) return $trigger_output;
+			ModuleHandler::triggerCall('file.deleteFile', 'after', $trigger_obj);
 
 			// If successfully deleted, remove the file
 			FileHandler::removeFile($uploaded_filename);

--- a/modules/member/member.controller.php
+++ b/modules/member/member.controller.php
@@ -99,11 +99,12 @@ class memberController extends member
 		$logged_info = Context::get('logged_info');
 		$trigger_output = ModuleHandler::triggerCall('member.doLogout', 'before', $logged_info);
 		if(!$trigger_output->toBool()) return $trigger_output;
+		
 		// Destroy session information
 		$this->destroySessionInfo();
+		
 		// Call a trigger after log-out (after)
-		$trigger_output = ModuleHandler::triggerCall('member.doLogout', 'after', $logged_info);
-		if(!$trigger_output->toBool()) return $trigger_output;
+		ModuleHandler::triggerCall('member.doLogout', 'after', $logged_info);
 
 		$output = new Object();
 
@@ -426,9 +427,9 @@ class memberController extends member
 			return $this->setRedirectUrl(getUrl('', 'act', 'dispMemberLoginForm'), new Object(-12, $msg));
 		}
 		else $this->setMessage('success_registed');
+		
 		// Call a trigger (after)
-		$trigger_output = ModuleHandler::triggerCall('member.procMemberInsert', 'after', $config);
-		if(!$trigger_output->toBool()) return $trigger_output;
+		ModuleHandler::triggerCall('member.procMemberInsert', 'after', $config);
 
 		if($config->redirect_url)
 		{
@@ -616,12 +617,10 @@ class memberController extends member
 		// Get user_id information
 		$this->memberInfo = $oMemberModel->getMemberInfoByMemberSrl($args->member_srl);
 
-
-		// Call a trigger after successfully log-in (after)
-		$trigger_output = ModuleHandler::triggerCall('member.procMemberModifyInfo', 'after', $this->memberInfo);
-		if(!$trigger_output->toBool()) return $trigger_output;
-
+		// Call a trigger after successfully modified (after)
+		ModuleHandler::triggerCall('member.procMemberModifyInfo', 'after', $this->memberInfo);
 		$this->setSessionInfo();
+		
 		// Return result
 		$this->add('member_srl', $args->member_srl);
 		$this->setMessage('success_updated');
@@ -1543,7 +1542,7 @@ class memberController extends member
 
 		// Add
 		$output = executeQuery('member.addMemberToGroup',$args);
-		$output2 = ModuleHandler::triggerCall('member.addMemberToGroup', 'after', $args);
+		ModuleHandler::triggerCall('member.addMemberToGroup', 'after', $args);
 
 		$this->_clearMemberCache($member_srl, $site_srl);
 
@@ -1822,9 +1821,10 @@ class memberController extends member
 				}
 			}
 		}
+		
 		// Call a trigger after successfully log-in (after)
-		$trigger_output = ModuleHandler::triggerCall('member.doLogin', 'after', $this->memberInfo);
-		if(!$trigger_output->toBool()) return $trigger_output;
+		ModuleHandler::triggerCall('member.doLogin', 'after', $this->memberInfo);
+		
 		// When user checked to use auto-login
 		if($keep_signed)
 		{
@@ -2181,16 +2181,8 @@ class memberController extends member
 			}
 			$this->_sendAuthMail($auth_args, $args);
 		}
-		// Call a trigger (after)
-		if($output->toBool())
-		{
-			$trigger_output = ModuleHandler::triggerCall('member.insertMember', 'after', $args);
-			if(!$trigger_output->toBool())
-			{
-				$oDB->rollback();
-				return $trigger_output;
-			}
-		}
+		
+		ModuleHandler::triggerCall('member.insertMember', 'after', $args);
 
 		$oDB->commit(true);
 
@@ -2447,15 +2439,9 @@ class memberController extends member
 				$this->_updatePointByGroup($orgMemberInfo->member_srl, $group_srl_list);
 			}
 		}
+		
 		// Call a trigger (after)
-		if($output->toBool()) {
-			$trigger_output = ModuleHandler::triggerCall('member.updateMember', 'after', $args);
-			if(!$trigger_output->toBool())
-			{
-				$oDB->rollback();
-				return $trigger_output;
-			}
-		}
+		ModuleHandler::triggerCall('member.updateMember', 'after', $args);
 
 		$oDB->commit();
 
@@ -2564,15 +2550,7 @@ class memberController extends member
 			return $output;
 		}
 		// Call a trigger (after)
-		if($output->toBool())
-		{
-			$trigger_output = ModuleHandler::triggerCall('member.deleteMember', 'after', $trigger_obj);
-			if(!$trigger_output->toBool())
-			{
-				$oDB->rollback();
-				return $trigger_output;
-			}
-		}
+		ModuleHandler::triggerCall('member.deleteMember', 'after', $trigger_obj);
 
 		$oDB->commit();
 		// Name, image, image, mark, sign, delete

--- a/modules/menu/menu.admin.model.php
+++ b/modules/menu/menu.admin.model.php
@@ -413,8 +413,7 @@ class menuAdminModel extends menu
 		}
 
 		// after trigger
-		$output = ModuleHandler::triggerCall('menu.getModuleListInSitemap', 'after', $moduleList);
-		if(!$output->toBool()) return $output;
+		ModuleHandler::triggerCall('menu.getModuleListInSitemap', 'after', $moduleList);
 
 		$localModuleList = array_unique($moduleList);
 

--- a/modules/module/module.admin.controller.php
+++ b/modules/module/module.admin.controller.php
@@ -227,7 +227,7 @@ class moduleAdminController extends module
 			$triggerObj->moduleSrlList[] = $module_srl;
 		}
 
-		$output = ModuleHandler::triggerCall('module.procModuleAdminCopyModule', 'after', $triggerObj);
+		ModuleHandler::triggerCall('module.procModuleAdminCopyModule', 'after', $triggerObj);
 
 		$oDB->commit();
 

--- a/modules/module/module.admin.model.php
+++ b/modules/module/module.admin.model.php
@@ -115,8 +115,8 @@ class moduleAdminModel extends module
 		$content = '';
 		// Call a trigger for additional settings
 		// Considering uses in the other modules, trigger name cen be publicly used
-		$output = ModuleHandler::triggerCall('module.dispAdditionSetup', 'before', $content);
-		$output = ModuleHandler::triggerCall('module.dispAdditionSetup', 'after', $content);
+		ModuleHandler::triggerCall('module.dispAdditionSetup', 'before', $content);
+		ModuleHandler::triggerCall('module.dispAdditionSetup', 'after', $content);
 		Context::set('setup_content', $content);
 
 		if(count($tabChoice) == 0)

--- a/modules/module/module.admin.view.php
+++ b/modules/module/module.admin.view.php
@@ -206,8 +206,8 @@ class moduleAdminView extends module
 		$content = '';
 		// Call a trigger for additional settings
 		// Considering uses in the other modules, trigger name cen be publicly used
-		$output = ModuleHandler::triggerCall('module.dispAdditionSetup', 'before', $content);
-		$output = ModuleHandler::triggerCall('module.dispAdditionSetup', 'after', $content);
+		ModuleHandler::triggerCall('module.dispAdditionSetup', 'before', $content);
+		ModuleHandler::triggerCall('module.dispAdditionSetup', 'after', $content);
 		Context::set('setup_content', $content);
 		// Set the layout to be pop-up
 		$this->setLayoutPath('./common/tpl');

--- a/modules/module/module.controller.php
+++ b/modules/module/module.controller.php
@@ -726,15 +726,7 @@ class moduleController extends module
 		// Remove the module manager
 		$this->deleteAdminId($module_srl);
 		// Call a trigger (after)
-		if($output->toBool())
-		{
-			$trigger_output = ModuleHandler::triggerCall('module.deleteModule', 'after', $trigger_obj);
-			if(!$trigger_output->toBool())
-			{
-				$oDB->rollback();
-				return $trigger_output;
-			}
-		}
+		ModuleHandler::triggerCall('module.deleteModule', 'after', $trigger_obj);
 
 		// commit
 		$oDB->commit();

--- a/modules/point/point.controller.php
+++ b/modules/point/point.controller.php
@@ -672,12 +672,7 @@ class pointController extends point
 		$trigger_obj->new_group_list = $new_group_list;
 		$trigger_obj->del_group_list = $del_group_list;
 		$trigger_obj->new_level = $level;
-		$trigger_output = ModuleHandler::triggerCall('point.setPoint', 'after', $trigger_obj);
-		if(!$trigger_output->toBool())
-		{
-			$oDB->rollback();
-			return $trigger_output;
-		}
+		ModuleHandler::triggerCall('point.setPoint', 'after', $trigger_obj);
 
 		$oDB->commit();
 


### PR DESCRIPTION
문서 작성, 문서 수정, 댓글 작성, 댓글 수정, 투표, 가입, 회원정보 수정 등 다양한 작업 도중 `after` 트리거가 오류를 반환할 경우 트랜잭션을 롤백하고 컨트롤러 실행을 중단하는 기능이 있습니다.

그러나 대부분의 웹호스팅 환경에서는 MyISAM 저장엔진을 사용하므로 롤백이 작동하지 않습니다. 오히려 작업을 하다 말고 중단되어 DB가 이상한 상태로 남아버릴 가능성이 있습니다.

서드파티 자료 개발자들도 `after` 트리거에서 오류를 반환하면 작업이 제대로 취소된다는 보장이 없으므로 일관성있는 효과를 기대할 수 없는 상황입니다. 작업을 취소하려면 `before` 트리거가 더 효과적이기 때문에, 실제로도 오류는 `before` 트리거에서 반환하는 일이 훨씬 흔하고요. `after`는 이미 완료된 작업에 대해 사후보고를 받는 의미에 가깝습니다.

이렇게 DB 종류에 따라 일관성없는 결과가 나오는 것을 막기 위해, `after` 트리거에서 반환하는 오류는 대부분 무시하도록 변경했습니다. 기존 사용자들도 대부분 롤백이 작동하지 않는 MyISAM을 사용하므로, 눈에 띄는 차이는 없을 것으로 예상됩니다.

- 앞으로 `after` 트리거에서는 트랜잭션 진행에 영향을 미칠 수 없습니다.
- 단, 트랜잭션과 무관하고 중요한 기능을 수행할 가능성이 있는 아래의 트리거는 그대로 두었습니다.
  -  `moduleHandler.init` `after`
  -  `moduleHandler.proc` `after`
  -  `moduleObject.proc` `after`
- 트리거 실행 결과를 변수에 저장하기만 하고 실제로는 사용하지 않는 경우도 모두 정리했습니다.
- 댓글 추천 취소시 트랜잭션을 시작하기만 하고 커밋하지 않는 문제를 수정했습니다. @bjrambo 