### PR TITLE
사용자가 작성한 HTML 콘텐츠 중 일부 id 속성을 허용

### DIFF
--- a/common/framework/filters/htmlfilter.php
+++ b/common/framework/filters/htmlfilter.php
@@ -106,7 +106,8 @@ class HTMLFilter
 			// Customize the default configuration.
 			$config->set('Attr.AllowedFrameTargets', array('_blank'));
 			$config->set('Attr.DefaultImageAlt', '');
-			$config->set('Attr.EnableID', false);
+			$config->set('Attr.EnableID', true);
+			$config->set('Attr.IDPrefix', 'user_content_');
 			$config->set('AutoFormat.AutoParagraph', false);
 			$config->set('AutoFormat.DisplayLinkURI', false);
 			$config->set('AutoFormat.Linkify', false);

--- a/tests/unit/framework/filters/HTMLFilterTest.php
+++ b/tests/unit/framework/filters/HTMLFilterTest.php
@@ -105,7 +105,7 @@ class HTMLFilterTest extends \Codeception\TestCase\Test
 		$target = '<iframe title="Video Test" width="640" height="360" frameborder="0" scrolling="no"></iframe>';
 		$this->assertEquals($target, Rhymix\Framework\Filters\HTMLFilter::clean($source));
 		
-		$source = '<object type="application/x-shockwave-flash" id="DaumVodPlayer_s474b7BR2zzREo0g7OT7EKo" width="640px" height="360px" align="middle" classid="clsid:d27cdb6e-ae6d-11cf-96b8-444553540000" codebase="http://fpdownload.macromedia.com/pub/shockwave/cabs/flash/swflash.cab#version=10,3,0,0">' .
+		$source = '<object type="application/x-shockwave-flash" width="640px" height="360px" align="middle" classid="clsid:d27cdb6e-ae6d-11cf-96b8-444553540000" codebase="http://fpdownload.macromedia.com/pub/shockwave/cabs/flash/swflash.cab#version=10,3,0,0">' .
 			'<param name="movie" value="http://videofarm.daum.net/controller/player/VodPlayer.swf" />' .
 			'<param name="allowScriptAccess" value="always" />' .
 			'<param name="allowFullScreen" value="true" />' .
@@ -153,11 +153,22 @@ class HTMLFilterTest extends \Codeception\TestCase\Test
 		$this->assertEquals($target, Rhymix\Framework\Filters\HTMLFilter::clean($source));
 		
 		$source = '<div somekey="somevalue" otherkey="othervalue" onload="alert(\'xss\');" id="foo" class="bar" editor_component="component_name"></div>';
-		$target = '<div somekey="somevalue" otherkey="othervalue" class="bar" editor_component="component_name"></div>';
+		$target = '<div somekey="somevalue" otherkey="othervalue" id="user_content_foo" class="bar" editor_component="component_name"></div>';
 		$this->assertEquals($target, Rhymix\Framework\Filters\HTMLFilter::clean($source));
 		
 		$source = '<div editor_component="component_name" style="width:400px;height:300px;" draggable dropzone contextmenu="whatever"></div>';
 		$target = '<div editor_component="component_name" style="width:400px;height:300px;"></div>';
+		$this->assertEquals($target, Rhymix\Framework\Filters\HTMLFilter::clean($source));
+	}
+	
+	public function testHTMLFilterUserContentID()
+	{
+		$source = '<p id="foobar">Hello World!</p>';
+		$target = '<p id="user_content_foobar">Hello World!</p>';
+		$this->assertEquals($target, Rhymix\Framework\Filters\HTMLFilter::clean($source));
+		
+		$source = '<p id="user_content_foobar">Hello World!</p>';
+		$target = '<p id="user_content_foobar">Hello World!</p>';
 		$this->assertEquals($target, Rhymix\Framework\Filters\HTMLFilter::clean($source));
 	}
 }


### PR DESCRIPTION
HTMLPurifier는 기본적으로 id 속성을 모두 제거합니다. 페이지상의 다른 요소와 같은 id를 사용할 경우 이상하게 동작하거나 보안취약점이 발생할 수도 있기 때문인데요, 문서 내에서 서로 참조하는 데도 사용할 수 없는 [이런 불편](https://www.xetown.com/square/289861)이 일어나기도 합니다.

그래서 `user_content_`으로 시작하는 id 속성은 허용하도록 변경합니다. `user_content_`으로 시작하지 않는 id는 자동으로 앞에 `user_content_`가 붙습니다. 위에 링크한 것과 같은 고급 기능을 개발하는 데 도움이 될 것으로 생각됩니다.