### PR TITLE
ckeditor 서식에 인용구 스타일 추가

### DIFF
--- a/modules/editor/styles/ckeditor_light/editor.css
+++ b/modules/editor/styles/ckeditor_light/editor.css
@@ -7,7 +7,7 @@
 .xe_content.editable blockquote.q4,
 .xe_content.editable blockquote.q5,
 .xe_content.editable blockquote.q6,
-.xe_content.editable blockquote.q7{padding:10px;margin:0 15px}
+.xe_content.editable blockquote.q7{padding:10px;margin:0 15px;border:0;}
 .xe_content.editable blockquote.q1{padding:0 10px;border-left:2px solid #ccc}
 .xe_content.editable blockquote.q2{padding:0 10px;background:url(./img/bg_qmark.gif) no-repeat left top}
 .xe_content.editable blockquote.q3{border:1px solid #d9d9d9}

--- a/modules/editor/styles/ckeditor_light/editor.css
+++ b/modules/editor/styles/ckeditor_light/editor.css
@@ -1,6 +1,5 @@
 @charset "utf-8";
 /* NAVER (developers@xpressengine.com) */
-.xe_content.editable { }
 .xe_content.editable img{border:0;max-width:100%;}
 .xe_content.editable blockquote.q1,
 .xe_content.editable blockquote.q2,
@@ -17,3 +16,27 @@
 .xe_content.editable blockquote.q6{border:1px dashed #707070}
 .xe_content.editable blockquote.q7{border:1px dashed #707070;background:#fbfbfb}
 .xe_content.editable table .xe_selected_cell{background-color:#d6e9ff}
+
+.xe_content.editable blockquote
+{
+	font-style: italic;
+	padding: 2px 0;
+	font-family: '돋움', dotum, Georgia, Times, "Times New Roman", serif;
+	border-style: solid;
+	border-color: #ccc;
+	border-width: 0;
+}
+
+.xe_content.editable.cke_contents_ltr blockquote
+{
+	padding-left: 20px;
+	padding-right: 8px;
+	border-left-width: 5px;
+}
+
+.xe_content.editable.cke_contents_rtl blockquote
+{
+	padding-left: 8px;
+	padding-right: 20px;
+	border-right-width: 5px;
+}

--- a/modules/editor/styles/ckeditor_light/editor.css
+++ b/modules/editor/styles/ckeditor_light/editor.css
@@ -19,9 +19,7 @@
 
 .xe_content.editable blockquote
 {
-	font-style: italic;
 	padding: 2px 0;
-	font-family: '돋움', dotum, Georgia, Times, "Times New Roman", serif;
 	border-style: solid;
 	border-color: #ccc;
 	border-width: 0;

--- a/modules/editor/styles/ckeditor_light/style.css
+++ b/modules/editor/styles/ckeditor_light/style.css
@@ -6,7 +6,7 @@
 .xe_content blockquote.q4,
 .xe_content blockquote.q5,
 .xe_content blockquote.q6,
-.xe_content blockquote.q7{padding:10px;margin:0 15px}
+.xe_content blockquote.q7{padding:10px;margin:0 15px;border:0;}
 .xe_content blockquote.q1{padding:0 10px;border-left:2px solid #ccc}
 .xe_content blockquote.q2{padding:0 10px;background:url(./img/bg_qmark.gif) no-repeat left top}
 .xe_content blockquote.q3{border:1px solid #d9d9d9}

--- a/modules/editor/styles/ckeditor_light/style.css
+++ b/modules/editor/styles/ckeditor_light/style.css
@@ -18,9 +18,7 @@
 
 .xe_content blockquote
 {
-	font-style: italic;
 	padding: 2px 0;
-	font-family: '돋움', dotum, Georgia, Times, "Times New Roman", serif;
 	border-style: solid;
 	border-color: #ccc;
 	border-width: 0;

--- a/modules/editor/styles/ckeditor_light/style.css
+++ b/modules/editor/styles/ckeditor_light/style.css
@@ -1,6 +1,5 @@
 @charset "utf-8";
 /* NAVER (developers@xpressengine.com) */
-.xe_content {color:#000;font-size:13px;font-family:sans-serif;line-height:1.5}
 .xe_content blockquote.q1,
 .xe_content blockquote.q2,
 .xe_content blockquote.q3,
@@ -16,3 +15,16 @@
 .xe_content blockquote.q6{border:1px dashed #707070}
 .xe_content blockquote.q7{border:1px dashed #707070;background:#fbfbfb}
 .xe_content p{margin:0}
+
+.xe_content blockquote
+{
+	font-style: italic;
+	padding: 2px 0;
+	font-family: '돋움', dotum, Georgia, Times, "Times New Roman", serif;
+	border-style: solid;
+	border-color: #ccc;
+	border-width: 0;
+	padding-left: 20px;
+	padding-right: 8px;
+	border-left-width: 5px;
+}

--- a/modules/editor/styles/ckeditor_light/style.ini
+++ b/modules/editor/styles/ckeditor_light/style.ini
@@ -1,1 +1,1 @@
-
+style.css


### PR DESCRIPTION
보니까 CK 에디터에서 인용구 `<blockquote>` 사용시 표시되는 스타일이 없더라구요. 

ckeditor 정식버전에는 있는 데 말이죠.

그래서 현재 인용구는 그냥 들여쓰기 취급..;;

![2](https://cloud.githubusercontent.com/assets/8565457/15984147/75cbaee8-2ffb-11e6-9c6c-b36b6462c52e.png)
[ 추가한 인용구 스타일 ]

ps. 기존에는 style.css 파일이 불필요하다고 로딩되지않도록 했더라구요.. 그치만 이런 스타일을 추가하다보니.. 필요한 파일이 였음.