### PR TITLE
.htaccess 및 nginx rewrite 규칙 개선

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,21 +1,17 @@
 RewriteEngine On
 
-# reserve Rhymix Layout Template Source File (*.html)
-RewriteRule ^(common|layouts|m.layouts)/(.+)\.html$ - [L,F]
-# reserve Rhymix Template Source Files (*.html)
-RewriteCond %{REQUEST_URI} !/modules/editor/
-RewriteRule /(skins|m.skins)/(.+)\.html$ - [L,F]
-
-# conf, query, schema
-RewriteRule ^(modules|addons|widgets)/(.+)/(conf|queries|schemas)/(.+)\.xml$ ./index.php [L]
+# block direct access to templates, XML schema files, config files, dotfiles, environment, etc.
+RewriteCond %{REQUEST_URI} !/modules/editor/(skins|styles)/
+RewriteRule ^(addons|common|files/ruleset|(m\.)?layouts|modules|plugins|themes|widgets|widgetstyles)/.+\.(html|xml)$ -  [L,F]
+RewriteRule ^files/(attach|config|cache/store)/.+\.php$ - [L,F]
+RewriteRule ^files/env/ - [L,F]
+RewriteRule ^(\.|codeception\.|composer\.|Gruntfile\.js|package\.json|CONTRIBUTING|COPYRIGHT|LICENSE|README) - [L,F]
 
 # static files
 RewriteCond %{SCRIPT_FILENAME} !-f
-RewriteRule ^(.+)/files/(member_extra_info|attach|cache|faceOff)/(.*) ./files/$2/$3 [L]
-RewriteCond %{SCRIPT_FILENAME} !-f
-RewriteRule ^(.+)/(files|modules|widgets|widgetstyles|layouts|m.layouts|addons)/(.*) ./$2/$3 [L]
+RewriteRule ^(.+)/(addons|files|layouts|m\.layouts|modules|widgets|widgetstyles)/(.*) ./$2/$3 [L]
 
-# rss , blogAPI
+# rss, blogAPI
 RewriteRule ^(rss|atom)$ ./index.php?module=rss&act=$1 [L]
 RewriteRule ^([a-zA-Z0-9_]+)/(rss|atom|api)$ ./index.php?mid=$1&act=$2 [L]
 RewriteRule ^([a-zA-Z0-9_]+)/([a-zA-Z0-9_]+)/(rss|atom|api)$ ./index.php?vid=$1&mid=$2&act=$3 [L]

--- a/common/manual/server_config/rhymix-nginx.conf
+++ b/common/manual/server_config/rhymix-nginx.conf
@@ -1,12 +1,22 @@
-# conf, query, schema, skins, layouts, m.layouts
-rewrite ^/(modules|addons|widgets|(m\.)?layouts)/(.+)\.(html|xml)$ /index.php last;
+# block direct access to templates, XML schemas, config files, dotfiles, environment info, etc.
+location ~ ^/modules/editor/(skins|styles)/.+\.html$ {
+	# pass
+}
+location ~ ^/(addons|common|files/ruleset|(m\.)?layouts|modules|plugins|themes|widgets|widgetstyles)/.+\.(html|xml)$ {
+	return 403;
+}
+location ~ ^/files/(attach|config|cache/store)/.+\.php$ {
+	return 403;
+}
+location ~ ^/files/env/ {
+	return 403;
+}
+location ~ ^/(\.|codeception\.|composer\.|Gruntfile\.js|package\.json|CONTRIBUTING|COPYRIGHT|LICENSE|README) {
+	return 403;
+}
 
-# reserve setting files
-rewrite ^/files/config/(.+)\.php$ /index.php last;
-
-# static files
-rewrite ^/(.+)/files/(member_extra_info|attach|cache|faceOff)/(.*) /files/$2/$3 last;
-rewrite ^/(.+)/(files|modules|widgets|widgetstyles|layouts|m.layouts|addons)/(.*) /$2/$3 last;
+# fix incorrect relative URLs (for legacy support)
+rewrite ^/(.+)/(addons|files|layouts|m\.layouts|modules|widgets|widgetstyles)/(.*) /$2/$3 last;
 
 # rss, blogAPI
 rewrite ^/(rss|atom)$ /index.php?module=rss&act=$1 last;


### PR DESCRIPTION
- 모든 모듈, 애드온, 위젯, 플러그인, 테마, 공통 폴더의 HTML 템플릿과 XML 스키마/쿼리 파일에 직접 접근할 수 없도록 변경 (fc8c625 패치를 더욱 강화)
- `files/env` 폴더 내의 환경 정보에 직접 접근할 수 없도록 변경 (마지막으로 업데이트한 시기 등 보안상 민감한 정보가 노출될 수 있음)
- `.git` 등 개발자들이 사용하는 리소스에 직접 접근할 수 없도록 변경
- `files/cache/store` 폴더 내의 PHP 스크립트에 직접 접근할 수 없도록 변경
- `files/attach` 폴더 내에서 PHP가 실행되지 않도록 변경 (웹쉘에 대한 방어를 더욱 강화)
- 아파치와 nginx rewrite 규칙을 일관성있게 변경
- 불필요하게 중복되는 rewrite 규칙 제거

다양한 서버 환경에서 정상 작동하는지 테스트가 필요합니다.

- 모든 모듈, 애드온 등의 HTML 템플릿과 XML 스키마/쿼리 파일에 접근할 수 없는지 확인
- 단, `modules/menu/skins`, `modules/menu/styles` 아래의 HTML 파일에는 접근할 수 있는지 확인
- `files/env`, `files/cache/store/*.php`, `files/config/*.php` 등에 직접 접근할 수 없는지 확인
- `files/attach` 폴더 내에 PHP 파일을 넣더라도 실행되지 않는지 확인
- `.git`, `composer.json` 등 개발자 리소스에 직접 접근할 수 없는지 확인
- 기존에 정상 작동하던 짧은 주소 및 첨부파일 주소 등에는 영향이 없는지 확인
- 라이믹스를 서브폴더에 설치했을 때도 정상 작동하는지 확인