### PR TITLE
외부 요청시 프록시 설정 방식 개선

### DIFF
--- a/classes/file/FileHandler.class.php
+++ b/classes/file/FileHandler.class.php
@@ -377,14 +377,17 @@ class FileHandler
 				$request_headers['Content-Type'] = $content_type;
 			}
 			
-			$proxy = parse_url(__PROXY_SERVER__);
-			if($proxy["host"])
+			if(defined('__PROXY_SERVER__'))
 			{
-				$request_options['proxy'] = array($proxy['host'] . ($proxy['port'] ? (':' . $proxy['port']) : ''));
-				if($proxy['user'] && $proxy['pass'])
+				$proxy = parse_url(__PROXY_SERVER__);
+				if($proxy["host"])
 				{
-					$request_options['proxy'][] = $proxy['user'];
-					$request_options['proxy'][] = $proxy['pass'];
+					$request_options['proxy'] = array($proxy['host'] . ($proxy['port'] ? (':' . $proxy['port']) : ''));
+					if($proxy['user'] && $proxy['pass'])
+					{
+						$request_options['proxy'][] = $proxy['user'];
+						$request_options['proxy'][] = $proxy['pass'];
+					}
 				}
 			}
 			

--- a/common/constants.php
+++ b/common/constants.php
@@ -133,7 +133,6 @@ define('_XE_PACKAGE_', 'XE');
 define('_XE_LOCATION_', 'en');
 define('_XE_LOCATION_SITE_', 'https://www.xpressengine.com/');
 define('_XE_DOWNLOAD_SERVER_', 'https://download.xpressengine.com/');
-define('__PROXY_SERVER__', null);
 define('__DEBUG__', 0);
 
 /**


### PR DESCRIPTION
지난번에 `FileHandler::getRemoteResource()` 메소드에서 `rmccue/requests` 라이브러리를 사용하도록 변경하면서 기존의 `__PROXY_SERVER__` 상수는 그냥 `null`로 해두었습니다. 이 상태로는 프록시를 사용하기 위해 코어 수정이 필요한 문제가 있어서, 상수를 기본으로 선언하지 않도록 변경합니다.

사용자가 `config.user.inc.php` 파일에서 `__PROXY_SERVER__` 상수를 선언하면 정상적으로 사용합니다. 클라우드플레어를 사용하면서 서버 IP 노출을 막기 위해 꼭 필요한 기능이지요.