### PR TITLE
캐시파일 등을 덮어쓸 때의 안정성 향상

### DIFF
--- a/classes/validator/Validator.class.php
+++ b/classes/validator/Validator.class.php
@@ -682,7 +682,7 @@ class Validator
 			return FALSE;
 		}
 
-		@file_put_contents($filepath, $content, LOCK_EX);
+		Rhymix\Framework\Storage::write($filepath, $content);
 
 		return $filepath;
 	}

--- a/common/framework/storage.php
+++ b/common/framework/storage.php
@@ -8,6 +8,11 @@ namespace Rhymix\Framework;
 class Storage
 {
 	/**
+	 * Use atomic rename to overwrite files.
+	 */
+	public static $safe_overwrite = true;
+	
+	/**
 	 * Check if a path really exists.
 	 * 
 	 * @param string $path
@@ -217,10 +222,16 @@ class Storage
 		if (!self::exists($destination_dir))
 		{
 			$mkdir_success = self::createDirectory($destination_dir);
-			if (!$mkdir_success)
+			if (!$mkdir_success && !self::exists($destination_dir))
 			{
 				return false;
 			}
+		}
+		
+		if (self::$safe_overwrite && strncasecmp($mode, 'a', 1))
+		{
+			$original_filename = $filename;
+			$filename = $filename . '.tmp.' . microtime(true);
 		}
 		
 		if ($fp = fopen($filename, $mode))
@@ -241,6 +252,23 @@ class Storage
 		else
 		{
 			return false;
+		}
+		
+		if (self::$safe_overwrite && strncasecmp($mode, 'a', 1))
+		{
+			$rename_success = @rename($filename, $original_filename);
+			if (!$rename_success)
+			{
+				@unlink($original_filename);
+				$rename_success = @rename($filename, $original_filename);
+				if (!$rename_success)
+				{
+					@unlink($filename);
+					throw new Exception('foo');
+					return false;
+				}
+			}
+			$filename = $original_filename;
 		}
 		
 		@chmod($filename, ($perms === null ? (0666 & ~umask()) : $perms));
@@ -301,10 +329,33 @@ class Storage
 			$destination = $destination . '/' . basename($source);
 		}
 		
+		if (self::$safe_overwrite)
+		{
+			$original_destination = $destination;
+			$destination = $destination . '.tmp.' . microtime(true);
+		}
+		
 		$copy_success = @copy($source, $destination);
 		if (!$copy_success)
 		{
 			return false;
+		}
+		
+		if (self::$safe_overwrite)
+		{
+			$rename_success = @rename($destination, $original_destination);
+			if (!$rename_success)
+			{
+				@unlink($original_destination);
+				$rename_success = @rename($destination, $original_destination);
+				if (!$rename_success)
+				{
+					@unlink($destination);
+					throw new Exception('foo');
+					return false;
+				}
+			}
+			$destination = $original_destination;
 		}
 		
 		if ($destination_perms === null)

--- a/common/framework/storage.php
+++ b/common/framework/storage.php
@@ -276,6 +276,8 @@ class Storage
 		{
 			@opcache_invalidate($filename, true);
 		}
+		
+		clearstatcache(true, $filename);
 		return $result;
 	}
 	
@@ -373,6 +375,8 @@ class Storage
 		{
 			@chmod($destination, $destination_perms);
 		}
+		
+		clearstatcache(true, $destination);
 		return true;
 	}
 	
@@ -409,6 +413,8 @@ class Storage
 		{
 			@opcache_invalidate($source, true);
 		}
+		
+		clearstatcache(true, $destination);
 		return $result;
 	}
 	

--- a/modules/module/module.admin.controller.php
+++ b/modules/module/module.admin.controller.php
@@ -904,7 +904,7 @@ class moduleAdminController extends module
 			{
 				$buff[] = sprintf('$lang[\'%s\'] = \'%s\';', $code, addcslashes($value, "'"));
 			}
-			if (!@file_put_contents(sprintf('%s/%d.%s.php', $cache_path, $args->site_srl, $langCode), join(PHP_EOL, $buff), LOCK_EX))
+			if (!Rhymix\Framework\Storage::write(sprintf('%s/%d.%s.php', $cache_path, $args->site_srl, $langCode), join(PHP_EOL, $buff)))
 			{
 				return;
 			}

--- a/modules/point/point.admin.controller.php
+++ b/modules/point/point.admin.controller.php
@@ -328,7 +328,7 @@ class pointAdminController extends point
 			$str .= $key.','.$val."\r\n";
 		}
 
-		@file_put_contents('./files/cache/pointRecal.txt', $str, LOCK_EX);
+		Rhymix\Framework\Storage::write(\RX_BASEDIR . 'files/cache/pointRecal.txt', $str);
 
 		$this->add('total', count($member));
 		$this->add('position', 0);


### PR DESCRIPTION
#311 과 비슷한 문제가 또다시 제보되어서, 원인을 추정하고 대응책을 마련해 보았습니다.

### 발생하는 문제

캐시파일 등 자주 변경되는 PHP 파일을 인클루드할 때 간헐적으로 문법 오류가 발생합니다. 그러나 해당 파일을 실제로 열어보면 문법 오류가 없습니다.

문제가 발생하는 파일은 대개 용량이 4KB 이상입니다.

### 원인 추정

용량이 큰 파일을 덮어쓰는 도중에 다른 스크립트에서 동일한 파일을 읽으려고 시도하면 내용이 깨져서 나올 수 있습니다. 예를 들어 6KB짜리 파일을 아직 4KB밖에 덮어쓰지 않았는데 읽으려고 하면 처음 4KB는 새 내용, 나머지 2KB는 예전 내용이 나오는 거지요. (대부분의 시스템에서는 4KB 단위로 파일을 기록합니다.)

PHP의 `file_put_content()` 함수를 사용하면서 `LOCK_EX` 파라미터를 넣는 것만으로는 이런 문제를 막을 수 없습니다. `LOCK_EX`는 파일을 덮어쓰는 도중에 다른 스크립트에서 동일한 파일에 **쓰지** 못하도록 하는 기능이지, **읽지** 못하도록 하는 기능은 아니거든요.

라이믹스는 캐시파일을 PHP 형식으로 저장하여 Opcache를 통한 성능 향상을 노리고 있기 때문에 더욱 심각한 문제가 생길 수 있습니다. Opcache는 파일의 최종 변경 시각(mtime)이 2초 이상 바뀌지 않으면 예전에 읽은 내용을 그대로 사용하니까요. 그래서 캐시파일을 정상적으로 모두 덮어쓴 후에도 깨진 내용을 기억하고 계속 에러를 낼 가능성이 있습니다.

### 해결책

PHP 형식의 캐시파일을 사용하는 [Smarty 템플릿 엔진](https://github.com/smarty-php/smarty/blob/ff6a8521bb588187eefa2695c3959fe101d22c18/libs/sysplugins/smarty_internal_runtime_writefile.php#L52)에서 힌트를 얻었습니다. 일단 임시파일에 내용을 모두 기록한 후, `rename()`으로 한 번에 덮어쓰는 방법입니다. 리눅스는 atomic rename을 지원하므로 이렇게 하면 절대로 예전 내용과 새 내용이 섞이지 않습니다. 단, 윈도우에서는 실패할 수도 있다고 하므로, 실패 여부를 확인하여 예전 파일을 삭제하고 다시 시도합니다.

절묘하게 타이밍이 맞아야 발생하는 버그이므로 이것으로 100% 고쳐졌다고 확신할 수는 없습니다. 비슷한 문제가 재발할 경우 다시 살펴보아야 하겠습니다.

버그 제보: @bjrambo 