### PR TITLE
User-Agent 감지 기능 개선

### DIFF
--- a/common/framework/ua.php
+++ b/common/framework/ua.php
@@ -303,13 +303,21 @@ class UA
 		{
 			$output_format = 'rfc5987';
 		}
+		elseif ($browser->browser === 'Edge')
+		{
+			$output_format = 'rfc5987';
+		}
 		elseif ($browser->browser === 'IE')
 		{
 			$output_format = 'old_ie';
 		}
-		else
+		elseif ($browser->browser === 'Android' || $browser->browser === 'Chrome' || $browser->browser === 'Safari')
 		{
 			$output_format = 'raw';
+		}
+		else
+		{
+			$output_format = 'old_ie';
 		}
 		
 		// Clean the filename.

--- a/common/framework/ua.php
+++ b/common/framework/ua.php
@@ -191,9 +191,9 @@ class UA
 			{
 				$result->os = 'iOS';
 			}
-			elseif ($matches[1] === 'Macintosh' && strpos($ua, 'OS X') !== false)
+			elseif ($matches[1] === 'Macintosh' || $matches[1] === 'OS X')
 			{
-				$result->os = 'OS X';
+				$result->os = 'macOS';
 			}
 			else
 			{

--- a/common/framework/ua.php
+++ b/common/framework/ua.php
@@ -228,7 +228,7 @@ class UA
 			$result->version = ($matches[1] + 4) . '.0';
 			return $result;
 		}
-		if (preg_match('#(MSIE|OPR|CriOS|Firefox|FxiOS|Iceweasel|Yeti|[a-z]+bot(?:-Image)?)[ /:]([0-9]+\\.[0-9]+)#i', $ua, $matches))
+		if (preg_match('#(MSIE|OPR|CriOS|Firefox|FxiOS|Iceweasel|Yeti|[a-z]+(?:bot|spider)(?:-Image)?|wget|curl)[ /:]([0-9]+\\.[0-9]+)#i', $ua, $matches))
 		{
 			if ($matches[1] === 'MSIE')
 			{
@@ -282,6 +282,24 @@ class UA
 		{
 			$result->browser = 'Safari';
 			$result->version = $matches[1];
+			return $result;
+		}
+		if (preg_match('#\\bPHP(/[0-9]+\\.[0-9]+)?#', $ua, $matches))
+		{
+			$result->browser = 'PHP';
+			$result->version = (isset($matches[1]) && $matches[1]) ? substr($matches[1], 1) : null;
+			return $result;
+		}
+		if (preg_match('#^Mozilla/([0-9]+\\.[0-9]+)#', $ua, $matches))
+		{
+			$result->browser = 'Mozilla';
+			$result->version = $matches[1];
+			return $result;
+		}
+		if (preg_match('#^([a-zA-Z0-9_-]+)/([0-9]+\\.[0-9]+)#', $ua, $matches))
+		{
+			$result->browser = ucfirst($matches[1]);
+			$result->version = $matches[2];
 			return $result;
 		}
 		

--- a/common/framework/ua.php
+++ b/common/framework/ua.php
@@ -228,7 +228,7 @@ class UA
 			$result->version = ($matches[1] + 4) . '.0';
 			return $result;
 		}
-		if (preg_match('#(MSIE|Chrome|CriOS|Firefox|FxiOS|Yeti|[a-z]+bot(?:-Image)?)[ /:]([0-9]+\\.[0-9]+)#i', $ua, $matches))
+		if (preg_match('#(MSIE|OPR|CriOS|Firefox|FxiOS|Iceweasel|Yeti|[a-z]+bot(?:-Image)?)[ /:]([0-9]+\\.[0-9]+)#i', $ua, $matches))
 		{
 			if ($matches[1] === 'MSIE')
 			{
@@ -238,9 +238,13 @@ class UA
 			{
 				$result->browser = 'Chrome';
 			}
-			elseif ($matches[1] === 'FxiOS')
+			elseif ($matches[1] === 'FxiOS' || $matches[1] === 'Iceweasel')
 			{
 				$result->browser = 'Firefox';
+			}
+			elseif ($matches[1] === 'OPR')
+			{
+				$result->browser = 'Opera';
 			}
 			else
 			{
@@ -249,21 +253,34 @@ class UA
 			$result->version = $matches[2];
 			return $result;
 		}
-		if (preg_match('#Safari/[0-9]+#', $ua) && preg_match('#Version/([0-9]+\\.[0-9]+)#', $ua, $matches) && $matches[1] < 500)
-		{
-			$result->browser = 'Safari';
-			$result->version = $matches[1];
-			return $result;
-		}
-		if (preg_match('#^Opera/.+(?:Opera |Version/)([0-9]+\\.[0-9]+)$#', $ua, $matches))
+		if (preg_match('#(?:Opera|OPR)[/ ]([0-9]+\\.[0-9]+)#', $ua, $matches))
 		{
 			$result->browser = 'Opera';
-			$result->version = $matches[1];
+			if ($matches[1] >= 9.79 && preg_match('#Version/([0-9]+\\.[0-9]+)#', $ua, $operamatches))
+			{
+				$result->version = $operamatches[1];
+			}
+			else
+			{
+				$result->version = $matches[1];
+			}
 			return $result;
 		}
 		if (preg_match('#(?:Konqueror|KHTML)/([0-9]+\\.[0-9]+)$#', $ua, $matches))
 		{
 			$result->browser = 'Konqueror';
+			$result->version = $matches[1];
+			return $result;
+		}
+		if (preg_match('#Chrome/([0-9]+\\.[0-9]+)#', $ua, $matches))
+		{
+			$result->browser = 'Chrome';
+			$result->version = $matches[1];
+			return $result;
+		}
+		if (preg_match('#Safari/[0-9]+#', $ua) && preg_match('#Version/([0-9]+\\.[0-9]+)#', $ua, $matches) && $matches[1] < 500)
+		{
+			$result->browser = 'Safari';
 			$result->version = $matches[1];
 			return $result;
 		}

--- a/modules/file/file.controller.php
+++ b/modules/file/file.controller.php
@@ -342,25 +342,8 @@ class fileController extends file
 			exit();
 		}
 
-		// Filename encoding for browsers that support RFC 5987
-		if(preg_match('#(?:Chrome|Edge)/(\d+)\.#', $_SERVER['HTTP_USER_AGENT'], $matches) && $matches[1] >= 11)
-		{
-			$filename_param = "filename*=UTF-8''" . rawurlencode($filename) . '; filename="' . rawurlencode($filename) . '"';
-		}
-		elseif(preg_match('#(?:Firefox|Safari|Trident)/(\d+)\.#', $_SERVER['HTTP_USER_AGENT'], $matches) && $matches[1] >= 6)
-		{
-			$filename_param = "filename*=UTF-8''" . rawurlencode($filename) . '; filename="' . rawurlencode($filename) . '"';
-		}
-		// Filename encoding for browsers that do not support RFC 5987
-		elseif(strpos($_SERVER['HTTP_USER_AGENT'], 'MSIE') !== FALSE)
-		{
-			$filename = rawurlencode($filename);
-			$filename_param = 'filename="' . preg_replace('/\./', '%2e', $filename, substr_count($filename, '.') - 1) . '"';
-		}
-		else
-		{
-			$filename_param = 'filename="' . $filename . '"';
-		}
+		// Encode the filename.
+		$filename_param = Rhymix\Framework\UA::encodeFilenameForDownload($filename);
 
 		// Close context to prevent blocking the session
 		Context::close();

--- a/tests/unit/framework/UATest.php
+++ b/tests/unit/framework/UATest.php
@@ -229,6 +229,50 @@ class UATest extends \Codeception\TestCase\Test
 		$this->assertEquals('Yeti', $browser->browser);
 		$this->assertEquals('1.0', $browser->version);
 		$this->assertTrue($browser->is_robot);
+		
+		// Baiduspider
+		$browser = Rhymix\Framework\UA::getBrowserInfo('Mozilla/5.0 (compatible; Baiduspider/2.0; +http://www.baidu.com/search/spider.html)');
+		$this->assertEquals('Baiduspider', $browser->browser);
+		$this->assertEquals('2.0', $browser->version);
+		$this->assertTrue($browser->is_robot);
+		
+		// wget
+		$browser = Rhymix\Framework\UA::getBrowserInfo('wget/1.17.1');
+		$this->assertEquals('Wget', $browser->browser);
+		$this->assertEquals('1.17', $browser->version);
+		$this->assertFalse($browser->is_robot);
+		
+		// curl
+		$browser = Rhymix\Framework\UA::getBrowserInfo('curl/7.47.0');
+		$this->assertEquals('Curl', $browser->browser);
+		$this->assertEquals('7.47', $browser->version);
+		$this->assertFalse($browser->is_robot);
+		
+		// PHP with version
+		$browser = Rhymix\Framework\UA::getBrowserInfo('PHP/5.2.9');
+		$this->assertEquals('PHP', $browser->browser);
+		$this->assertEquals('5.2', $browser->version);
+		$this->assertFalse($browser->is_robot);
+		
+		// PHP without version
+		$browser = Rhymix\Framework\UA::getBrowserInfo('PHP');
+		$this->assertEquals('PHP', $browser->browser);
+		$this->assertNull($browser->version);
+		
+		// PHP with HTTP_Request2
+		$browser = Rhymix\Framework\UA::getBrowserInfo('HTTP_Request2/2.1.1 (http://pear.php.net/package/http_request2) PHP/5.3.2');
+		$this->assertEquals('PHP', $browser->browser);
+		$this->assertEquals('5.3', $browser->version);
+		
+		// Some random browser with the 'Mozilla' version
+		$browser = Rhymix\Framework\UA::getBrowserInfo('Mozilla/5.0 (Macintosh; U; PPC Mac OS X Mach-O; XH; rv:8.578.498) fr, Gecko/20121021 Camino/8.723+ (Firefox compatible)');
+		$this->assertEquals('Mozilla', $browser->browser);
+		$this->assertEquals('5.0', $browser->version);
+		
+		// Some random browser without the 'Mozilla' version
+		$browser = Rhymix\Framework\UA::getBrowserInfo('W3C_Validator/1.650');
+		$this->assertEquals('W3C_Validator', $browser->browser);
+		$this->assertEquals('1.650', $browser->version);
 	}
 	
 	public function testEncodeFilenameForDownload()

--- a/tests/unit/framework/UATest.php
+++ b/tests/unit/framework/UATest.php
@@ -206,4 +206,16 @@ class UATest extends \Codeception\TestCase\Test
 		$this->assertEquals('1.0', $browser->version);
 		$this->assertTrue($browser->is_robot);
 	}
+	
+	public function testEncodeFilenameForDownload()
+	{
+		$this->assertEquals('filename*=UTF-8\'\'%ED%95%9C%EA%B8%80%20filename.jpg; filename="%ED%95%9C%EA%B8%80%20filename.jpg"', Rhymix\Framework\UA::encodeFilenameForDownload('한글 filename.jpg', 'Chrome/50.0'));
+		$this->assertEquals('filename*=UTF-8\'\'%ED%95%9C%EA%B8%80%20filename.jpg; filename="%ED%95%9C%EA%B8%80%20filename.jpg"', Rhymix\Framework\UA::encodeFilenameForDownload('한글 filename.jpg', 'Firefox/46.0'));
+		$this->assertEquals('filename*=UTF-8\'\'%ED%95%9C%EA%B8%80%20filename.jpg; filename="%ED%95%9C%EA%B8%80%20filename.jpg"', Rhymix\Framework\UA::encodeFilenameForDownload('한글 filename.jpg', 'Edge/12.10240'));
+		$this->assertEquals('filename*=UTF-8\'\'%ED%95%9C%EA%B8%80%20filename.jpg; filename="%ED%95%9C%EA%B8%80%20filename.jpg"', Rhymix\Framework\UA::encodeFilenameForDownload('한글 filename.jpg', 'MSIE/7.0 Trident/7.0'));
+		$this->assertEquals('filename="%ED%95%9C%EA%B8%80%20filename.jpg"', Rhymix\Framework\UA::encodeFilenameForDownload('한글 filename.jpg', 'MSIE 8.0'));
+		$this->assertEquals('filename="%ED%95%9C%EA%B8%80%20filename.jpg"', Rhymix\Framework\UA::encodeFilenameForDownload('한글 filename.jpg', 'Unknown Browser'));
+		$this->assertEquals('filename="한글 filename.jpg"', Rhymix\Framework\UA::encodeFilenameForDownload('한글 filename.jpg', 'Safari/5.0 Version/5.0'));
+		$this->assertEquals('filename="한글 filename.jpg"', Rhymix\Framework\UA::encodeFilenameForDownload('한글 filename.jpg', 'Linux; Android 5.1.1; Version/4.0 Chrome/43.0.2357.65 Mobile Safari/537.36'));
+	}
 }

--- a/tests/unit/framework/UATest.php
+++ b/tests/unit/framework/UATest.php
@@ -89,6 +89,19 @@ class UATest extends \Codeception\TestCase\Test
 		$this->assertEquals('Windows', $browser->os);
 		$this->assertFalse($browser->is_mobile);
 		
+		// Linux Chrome
+		$browser = Rhymix\Framework\UA::getBrowserInfo('Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2227.0 Safari/537.36');
+		$this->assertEquals('Chrome', $browser->browser);
+		$this->assertEquals('41.0', $browser->version);
+		$this->assertEquals('Linux', $browser->os);
+		$this->assertFalse($browser->is_mobile);
+		
+		// Linux Konqueror
+		$browser = Rhymix\Framework\UA::getBrowserInfo('Mozilla/5.0 (X11; Linux) KHTML/4.9.1 (like Gecko) Konqueror/4.9');
+		$this->assertEquals('Konqueror', $browser->browser);
+		$this->assertEquals('4.9', $browser->version);
+		$this->assertEquals('Linux', $browser->os);
+		
 		// Edge 13
 		$browser = Rhymix\Framework\UA::getBrowserInfo('Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2486.0 Safari/537.36 Edge/13.10586');
 		$this->assertEquals('Edge', $browser->browser);
@@ -123,19 +136,6 @@ class UATest extends \Codeception\TestCase\Test
 		$browser = Rhymix\Framework\UA::getBrowserInfo('Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0; Trident/4.0)');
 		$this->assertEquals('IE', $browser->browser);
 		$this->assertEquals('8.0', $browser->version);
-		
-		// Linux Chrome
-		$browser = Rhymix\Framework\UA::getBrowserInfo('Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2227.0 Safari/537.36');
-		$this->assertEquals('Chrome', $browser->browser);
-		$this->assertEquals('41.0', $browser->version);
-		$this->assertEquals('Linux', $browser->os);
-		$this->assertFalse($browser->is_mobile);
-		
-		// Linux Konqueror
-		$browser = Rhymix\Framework\UA::getBrowserInfo('Mozilla/5.0 (X11; Linux) KHTML/4.9.1 (like Gecko) Konqueror/4.9');
-		$this->assertEquals('Konqueror', $browser->browser);
-		$this->assertEquals('4.9', $browser->version);
-		$this->assertEquals('Linux', $browser->os);
 		
 		// iOS Safari
 		$browser = Rhymix\Framework\UA::getBrowserInfo('iPad: Mozilla/5.0 (iPad; CPU OS 5_1 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) Version/5.1 Mobile/9B176 Safari/7534.48.3');
@@ -180,6 +180,30 @@ class UATest extends \Codeception\TestCase\Test
 		$this->assertEquals('Firefox', $browser->browser);
 		$this->assertEquals('33.0', $browser->version);
 		$this->assertEquals('macOS', $browser->os);
+		$this->assertFalse($browser->is_mobile);
+		
+		// Opera 15
+		$browser = Rhymix\Framework\UA::getBrowserInfo('Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.52 Safari/537.36 OPR/15.0.1147.100');
+		$this->assertEquals('Opera', $browser->browser);
+		$this->assertEquals('15.0', $browser->version);
+		$this->assertFalse($browser->is_mobile);
+		
+		// Opera 12
+		$browser = Rhymix\Framework\UA::getBrowserInfo('Opera/9.80 (X11; Linux i686; Ubuntu/14.10) Presto/2.12.388 Version/12.16');
+		$this->assertEquals('Opera', $browser->browser);
+		$this->assertEquals('12.16', $browser->version);
+		$this->assertFalse($browser->is_mobile);
+		
+		// Opera 9.x
+		$browser = Rhymix\Framework\UA::getBrowserInfo('Opera/9.64 (X11; Linux x86_64; U; en) Presto/2.1.1');
+		$this->assertEquals('Opera', $browser->browser);
+		$this->assertEquals('9.64', $browser->version);
+		$this->assertFalse($browser->is_mobile);
+		
+		// Iceweasel (Debian Firefox)
+		$browser = Rhymix\Framework\UA::getBrowserInfo('Mozilla/5.0 (X11; Linux i686; rv:10.0.7) Gecko/20100101 Iceweasel/10.0.7');
+		$this->assertEquals('Firefox', $browser->browser);
+		$this->assertEquals('10.0', $browser->version);
 		$this->assertFalse($browser->is_mobile);
 		
 		// Googlebot

--- a/tests/unit/framework/UATest.php
+++ b/tests/unit/framework/UATest.php
@@ -56,8 +56,25 @@ class UATest extends \Codeception\TestCase\Test
 		$this->assertEquals('Android', $browser->os);
 		$this->assertTrue($browser->is_mobile);
 		$this->assertTrue($browser->is_tablet);
+		$this->assertFalse($browser->is_robot);
 		
-		// Mobile Chrome
+		// Android default browser (possible confusion with Chrome)
+		$browser = Rhymix\Framework\UA::getBrowserInfo('Mozilla/5.0 (Linux; Android 4.4.4; One Build/KTU84L.H4) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/33.0.0.0 Mobile Safari/537.36');
+		$this->assertEquals('Android', $browser->browser);
+		$this->assertEquals('4.4', $browser->version);
+		$this->assertTrue($browser->is_mobile);
+		$this->assertFalse($browser->is_tablet);
+		$this->assertFalse($browser->is_robot);
+		
+		// Android webview (possible confusion with Chrome)
+		$browser = Rhymix\Framework\UA::getBrowserInfo('Mozilla/5.0 (Linux; Android 5.1.1; Nexus 5 Build/LMY48B; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/43.0.2357.65 Mobile Safari/537.36');
+		$this->assertEquals('Android', $browser->browser);
+		$this->assertEquals('5.1', $browser->version);
+		$this->assertTrue($browser->is_mobile);
+		$this->assertFalse($browser->is_tablet);
+		$this->assertFalse($browser->is_robot);
+		
+		// Android Chrome
 		$browser = Rhymix\Framework\UA::getBrowserInfo('Mozilla/5.0 (Linux; Android 5.0; Nexus 5 Build/LPX13D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/38.0.2125.102 Mobile Safari/537.36');
 		$this->assertEquals('Chrome', $browser->browser);
 		$this->assertEquals('38.0', $browser->version);
@@ -65,13 +82,26 @@ class UATest extends \Codeception\TestCase\Test
 		$this->assertTrue($browser->is_mobile);
 		$this->assertFalse($browser->is_tablet);
 		
-		// Edge
+		// Windows Chrome
+		$browser = Rhymix\Framework\UA::getBrowserInfo('Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36');
+		$this->assertEquals('Chrome', $browser->browser);
+		$this->assertEquals('51.0', $browser->version);
+		$this->assertEquals('Windows', $browser->os);
+		$this->assertFalse($browser->is_mobile);
+		
+		// Edge 13
+		$browser = Rhymix\Framework\UA::getBrowserInfo('Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2486.0 Safari/537.36 Edge/13.10586');
+		$this->assertEquals('Edge', $browser->browser);
+		$this->assertEquals('13.0', $browser->version);
+		$this->assertEquals('Windows', $browser->os);
+		$this->assertFalse($browser->is_mobile);
+		
+		// Edge 12
 		$browser = Rhymix\Framework\UA::getBrowserInfo('Mozilla/5.0 (Windows NT 10.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.10136');
 		$this->assertEquals('Edge', $browser->browser);
 		$this->assertEquals('12.0', $browser->version);
 		$this->assertEquals('Windows', $browser->os);
 		$this->assertFalse($browser->is_mobile);
-		$this->assertFalse($browser->is_tablet);
 		
 		// IE 11
 		$browser = Rhymix\Framework\UA::getBrowserInfo('Mozilla/5.0 (Windows NT 10.0; WOW64; Trident/7.0; rv:11.0) like Gecko');
@@ -84,6 +114,11 @@ class UATest extends \Codeception\TestCase\Test
 		$this->assertEquals('IE', $browser->browser);
 		$this->assertEquals('10.0', $browser->version);
 		
+		// IE 9
+		$browser = Rhymix\Framework\UA::getBrowserInfo('Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; WOW64; Trident/5.0; .NET CLR 3.5.30729; .NET CLR 3.0.30729; .NET CLR 2.0.50727; Media Center PC 6.0)');
+		$this->assertEquals('IE', $browser->browser);
+		$this->assertEquals('9.0', $browser->version);
+		
 		// IE 8 in compatibility mode
 		$browser = Rhymix\Framework\UA::getBrowserInfo('Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0; Trident/4.0)');
 		$this->assertEquals('IE', $browser->browser);
@@ -94,11 +129,81 @@ class UATest extends \Codeception\TestCase\Test
 		$this->assertEquals('Chrome', $browser->browser);
 		$this->assertEquals('41.0', $browser->version);
 		$this->assertEquals('Linux', $browser->os);
+		$this->assertFalse($browser->is_mobile);
+		
+		// Linux Konqueror
+		$browser = Rhymix\Framework\UA::getBrowserInfo('Mozilla/5.0 (X11; Linux) KHTML/4.9.1 (like Gecko) Konqueror/4.9');
+		$this->assertEquals('Konqueror', $browser->browser);
+		$this->assertEquals('4.9', $browser->version);
+		$this->assertEquals('Linux', $browser->os);
+		
+		// iOS Safari
+		$browser = Rhymix\Framework\UA::getBrowserInfo('iPad: Mozilla/5.0 (iPad; CPU OS 5_1 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) Version/5.1 Mobile/9B176 Safari/7534.48.3');
+		$this->assertEquals('Safari', $browser->browser);
+		$this->assertEquals('5.1', $browser->version);
+		$this->assertEquals('iOS', $browser->os);
+		$this->assertTrue($browser->is_mobile);
+		$this->assertTrue($browser->is_tablet);
+		
+		// iOS Chrome
+		$browser = Rhymix\Framework\UA::getBrowserInfo('Mozilla/5.0 (iPhone; U; CPU iPhone OS 5_1_1 like Mac OS X; en) AppleWebKit/534.46.0 (KHTML, like Gecko) CriOS/19.0.1084.60 Mobile/9B206 Safari/7534.48.3');
+		$this->assertEquals('Chrome', $browser->browser);
+		$this->assertEquals('19.0', $browser->version);
+		$this->assertEquals('iOS', $browser->os);
+		$this->assertTrue($browser->is_mobile);
+		$this->assertFalse($browser->is_tablet);
+		
+		// iOS Firefox
+		$browser = Rhymix\Framework\UA::getBrowserInfo('Mozilla/5.0 (iPad; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) FxiOS/1.0 Mobile/12F69 Safari/600.1.4');
+		$this->assertEquals('Firefox', $browser->browser);
+		$this->assertEquals('1.0', $browser->version);
+		$this->assertEquals('iOS', $browser->os);
+		$this->assertTrue($browser->is_mobile);
+		$this->assertTrue($browser->is_tablet);
+		
+		// OS X Safari
+		$browser = Rhymix\Framework\UA::getBrowserInfo('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_2) AppleWebKit/600.3.18 (KHTML, like Gecko) Version/8.0.3 Safari/600.3.18');
+		$this->assertEquals('Safari', $browser->browser);
+		$this->assertEquals('8.0', $browser->version);
+		$this->assertEquals('OS X', $browser->os);
+		$this->assertFalse($browser->is_mobile);
+		
+		// OS X Chrome
+		$browser = Rhymix\Framework\UA::getBrowserInfo('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2227.1 Safari/537.36');
+		$this->assertEquals('Chrome', $browser->browser);
+		$this->assertEquals('41.0', $browser->version);
+		$this->assertEquals('OS X', $browser->os);
+		$this->assertFalse($browser->is_mobile);
 		
 		// OS X Firefox
 		$browser = Rhymix\Framework\UA::getBrowserInfo('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10; rv:33.0) Gecko/20100101 Firefox/33.0');
 		$this->assertEquals('Firefox', $browser->browser);
 		$this->assertEquals('33.0', $browser->version);
 		$this->assertEquals('OS X', $browser->os);
+		$this->assertFalse($browser->is_mobile);
+		
+		// Googlebot
+		$browser = Rhymix\Framework\UA::getBrowserInfo('Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)');
+		$this->assertEquals('Googlebot', $browser->browser);
+		$this->assertEquals('2.1', $browser->version);
+		$this->assertTrue($browser->is_robot);
+		
+		// Googlebot-Image
+		$browser = Rhymix\Framework\UA::getBrowserInfo('Googlebot-Image/1.0');
+		$this->assertEquals('Googlebot-Image', $browser->browser);
+		$this->assertEquals('1.0', $browser->version);
+		$this->assertTrue($browser->is_robot);
+		
+		// Bingbot
+		$browser = Rhymix\Framework\UA::getBrowserInfo('Mozilla/5.0 (compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm)');
+		$this->assertEquals('Bingbot', $browser->browser);
+		$this->assertEquals('2.0', $browser->version);
+		$this->assertTrue($browser->is_robot);
+		
+		// Yeti
+		$browser = Rhymix\Framework\UA::getBrowserInfo('Yeti/1.0 (+http://help.naver.com/robots/)');
+		$this->assertEquals('Yeti', $browser->browser);
+		$this->assertEquals('1.0', $browser->version);
+		$this->assertTrue($browser->is_robot);
 	}
 }

--- a/tests/unit/framework/UATest.php
+++ b/tests/unit/framework/UATest.php
@@ -161,25 +161,25 @@ class UATest extends \Codeception\TestCase\Test
 		$this->assertTrue($browser->is_mobile);
 		$this->assertTrue($browser->is_tablet);
 		
-		// OS X Safari
+		// macOS (OS X) Safari
 		$browser = Rhymix\Framework\UA::getBrowserInfo('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_2) AppleWebKit/600.3.18 (KHTML, like Gecko) Version/8.0.3 Safari/600.3.18');
 		$this->assertEquals('Safari', $browser->browser);
 		$this->assertEquals('8.0', $browser->version);
-		$this->assertEquals('OS X', $browser->os);
+		$this->assertEquals('macOS', $browser->os);
 		$this->assertFalse($browser->is_mobile);
 		
-		// OS X Chrome
+		// macOS (OS X) Chrome
 		$browser = Rhymix\Framework\UA::getBrowserInfo('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2227.1 Safari/537.36');
 		$this->assertEquals('Chrome', $browser->browser);
 		$this->assertEquals('41.0', $browser->version);
-		$this->assertEquals('OS X', $browser->os);
+		$this->assertEquals('macOS', $browser->os);
 		$this->assertFalse($browser->is_mobile);
 		
-		// OS X Firefox
+		// macOS (OS X) Firefox
 		$browser = Rhymix\Framework\UA::getBrowserInfo('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10; rv:33.0) Gecko/20100101 Firefox/33.0');
 		$this->assertEquals('Firefox', $browser->browser);
 		$this->assertEquals('33.0', $browser->version);
-		$this->assertEquals('OS X', $browser->os);
+		$this->assertEquals('macOS', $browser->os);
 		$this->assertFalse($browser->is_mobile);
 		
 		// Googlebot


### PR DESCRIPTION
`Rhymix\Framework\UA::getBrowserInfo()`

- 안드로이드 기본 브라우저와 웹뷰를 진짜 크롬과 구분함
- iOS를 OS X와 구분함
- iOS용 크롬과 파이어폭스를 감지
- 사파리 및 오페라 버전을 더 정확하게 감지
- 구글봇, 빙봇, 네이버 Yeti 등 흔한 검색로봇도 이 함수로 파악할 수 있도록 함
- 파일 다운로드시 파일명 인코딩 방식을 브라우저 버전에 따라 좀더 정확하게 구분하도록 변경
  - `FileHandler`에 하드코딩되어 있던 것을 `UA` 클래스를 사용하도록 변경
  - 안드로이드 기본 브라우저는 RFC 5987을 지원하지 않는 것으로 처리
  - #534 버그도 해결된 것으로 보입니다.
- 관련 유닛 테스트 대폭 강화