### PR TITLE
파일 작업 도중 오류 발생시 WARNING을 표시하도록 변경

### DIFF
--- a/common/framework/debug.php
+++ b/common/framework/debug.php
@@ -626,8 +626,8 @@ class Debug
 			case \E_COMPILE_ERROR: return 'Compile-time Error';
 			case \E_COMPILE_WARNING: return 'Compile-time Warning';
 			case \E_USER_ERROR: return 'User Error';
-			case \E_USER_WARNING: return 'User Warning';
-			case \E_USER_NOTICE: return 'User Notice';
+			case \E_USER_WARNING: return 'Warning';
+			case \E_USER_NOTICE: return 'Notice';
 			case \E_STRICT: return 'Strict Standards';
 			case \E_PARSE: return 'Parse Error';
 			case \E_DEPRECATED: return 'Deprecated';

--- a/tests/unit/framework/StorageTest.php
+++ b/tests/unit/framework/StorageTest.php
@@ -253,7 +253,7 @@ class StorageTest extends \Codeception\TestCase\Test
 		$this->assertTrue(Rhymix\Framework\Storage::copyDirectory($sourcedir, $targetdir));
 		$this->assertTrue(file_exists($targetdir . '/bar'));
 		$this->assertTrue(file_exists($targetdir . '/subdir/baz'));
-		$this->assertFalse(Rhymix\Framework\Storage::copyDirectory($sourcedir, '/opt/nonexistent.foobar'));
+		$this->assertFalse(@Rhymix\Framework\Storage::copyDirectory($sourcedir, '/opt/nonexistent.foobar'));
 	}
 	
 	public function testMoveDirectory()


### PR DESCRIPTION
웹호스팅 환경에서는 퍼미션이 꼬여서 오래된 캐시파일이 남거나 파일이 정상적으로 삭제되지 않는 등의 문제가 종종 발생합니다. 그러나 XE에서 물려받은 대부분의 파일 작업 관련 코드는 오류가 발생하더라도 `false`를 반환할 뿐이고, 반환값을 체크하지도 않기 때문에 문제의 원인을 찾기가 쉽지 않습니다.

이 PR에서는 파일 작업 도중 오류가 발생할 경우 WARNING을 표시하여, 디버그 기능을 통해 쉽게 확인할 수 있도록 변경합니다.

WARNING이 표시되는 것은 아래와 같은 상황입니다.

- 파일을 읽을 수 없는 경우
- 파일을 쓸 수 없는 경우
- 파일을 삭제할 수 없는 경우
- 디렉토리를 생성하거나 삭제할 수 없는 경우
- 복사나 이동시 원본 파일을 찾을 수 없는 경우
- 복사나 이동시 대상 디렉토리를 생성할 수 없는 경우

아래와 같은 경우는 오류로 취급하지 않고 `false`만 반환합니다. 기존 코드에서 이런 경우가 너무 많기 때문이기도 하고, 실패하더라도 전체적인 작동에 큰 문제를 일으키지 않기 때문입니다.

- 존재하지 않는 파일을 읽으려고 하는 경우
- 파일이 아닌 것을 읽으려고 하는 경우
- 이미 존재하는 디렉토리를 또 생성하려고 하는 경우
- 존재하지 않는 파일이나 디렉토리를 삭제하려고 하는 경우