### PR TITLE
암호화된 비밀번호를 출력하지 않도록 고침.

### DIFF
--- a/modules/member/member.admin.controller.php
+++ b/modules/member/member.admin.controller.php
@@ -47,10 +47,31 @@ class memberAdminController extends member
 		{
 			$args->{$val} = Context::get($val);
 		}
-		$args->member_srl = Context::get('member_srl');
-		if(Context::get('reset_password'))
-			$args->password = Context::get('reset_password');
-		else unset($args->password);
+		$member_srl = Context::get('member_srl');
+		// Check if an original member exists having the member_srl
+		$args->member_srl = $member_srl;
+		if($args->member_srl)
+		{
+			// Create a member model object
+			$oMemberModel = getModel('member');
+			// Get memebr profile
+			$columnList = array('member_srl', 'user_id', 'password');
+			$member_info = $oMemberModel->getMemberInfoByMemberSrl($args->member_srl, 0, $columnList);
+			// If no original member exists, make a new one
+			if($member_info->member_srl != $member_srl)
+			{
+				unset($args->member_srl);
+			}
+
+			if(Context::get('reset_password'))
+			{
+				$args->password = Context::get('reset_password');
+			}
+			else
+			{
+				unset($args->password);
+			}
+		}
 
 		// Remove some unnecessary variables from all the vars
 		$all_args = Context::getRequestVars();
@@ -67,17 +88,6 @@ class memberAdminController extends member
 		// Add extra vars after excluding necessary information from all the requested arguments
 		$extra_vars = delObjectVars($all_args, $args);
 		$args->extra_vars = serialize($extra_vars);
-		// Check if an original member exists having the member_srl
-		if($args->member_srl)
-		{
-			// Create a member model object
-			$oMemberModel = getModel('member');
-			// Get memebr profile
-			$columnList = array('member_srl');
-			$member_info = $oMemberModel->getMemberInfoByMemberSrl($args->member_srl, 0, $columnList);
-			// If no original member exists, make a new one
-			if($member_info->member_srl != $args->member_srl) unset($args->member_srl);
-		}
 
 		// remove whitespace
 		$checkInfos = array('user_id', 'user_name', 'nick_name', 'email_address');

--- a/modules/member/member.admin.controller.php
+++ b/modules/member/member.admin.controller.php
@@ -55,7 +55,7 @@ class memberAdminController extends member
 			// Create a member model object
 			$oMemberModel = getModel('member');
 			// Get memebr profile
-			$columnList = array('member_srl', 'user_id', 'password');
+			$columnList = array('member_srl');
 			$member_info = $oMemberModel->getMemberInfoByMemberSrl($args->member_srl, 0, $columnList);
 			// If no original member exists, make a new one
 			if($member_info->member_srl != $member_srl)

--- a/modules/member/tpl/insert_member.html
+++ b/modules/member/tpl/insert_member.html
@@ -36,7 +36,6 @@
 	<div cond="$member_srl" class="x_control-group">
 		<label class="x_control-label" for="password"><em style="color:red">*</em> {$lang->password}</label>
 		<div class="x_controls">
-			<input type="hidden" name="password" value="{$member_info->password}" />
 			<input id="password" type="text" name="reset_password" value="" />
 		</div>
 	</div>


### PR DESCRIPTION
암호화된 비밀번호가 회원관리자페이지의 맴버 수정정보에서 출력이되는 문제가 있었습니다.

해당 정보가 출력되지 않도록 하고, 관련 회원정보 모두 member_srl 가 있을경우 실행되도록 정리했습니다.