### PR TITLE
쓰기 퍼미션이 없는 폴더 내에서 쓰기 퍼미션이 있는 파일을 덮어쓸 때 오류 해결

### DIFF
--- a/tests/unit/framework/StorageTest.php
+++ b/tests/unit/framework/StorageTest.php
@@ -9,11 +9,13 @@ class StorageTest extends \Codeception\TestCase\Test
 	
 	public function _after()
 	{
+		@chmod(\RX_BASEDIR . 'tests/_output', 0755);
 		Rhymix\Framework\Storage::deleteDirectory(\RX_BASEDIR . 'tests/_output', false);
 	}
 	
 	public function _failed()
 	{
+		@chmod(\RX_BASEDIR . 'tests/_output', 0755);
 		Rhymix\Framework\Storage::deleteDirectory(\RX_BASEDIR . 'tests/_output', false);
 	}
 	
@@ -191,12 +193,27 @@ class StorageTest extends \Codeception\TestCase\Test
 	{
 		$source = \RX_BASEDIR . 'tests/_output/copy.source.txt';
 		$target = \RX_BASEDIR . 'tests/_output/copy.target.txt';
+		$target_dir = \RX_BASEDIR . 'tests/_output';
 		file_put_contents($source, 'foobarbaz');
 		chmod($source, 0646);
 		
+		// Copy with exact destination filename
 		$this->assertTrue(Rhymix\Framework\Storage::copy($source, $target));
 		$this->assertTrue(file_exists($target));
 		$this->assertTrue(file_get_contents($target) === 'foobarbaz');
+		
+		// Copy into directory with source filename
+		$this->assertTrue(Rhymix\Framework\Storage::copy($source, $target_dir));
+		$this->assertTrue(file_exists($target_dir . '/copy.source.txt'));
+		$this->assertTrue(file_get_contents($target_dir . '/copy.source.txt') === 'foobarbaz');
+		
+		// Copy into directory with no write permissions
+		chmod($target_dir, 0555);
+		file_put_contents($source, 'foobarbaz has changed');
+		$this->assertTrue(Rhymix\Framework\Storage::copy($source, $target));
+		$this->assertTrue(file_exists($target));
+		$this->assertTrue(file_get_contents($target) === 'foobarbaz has changed');
+		chmod($target_dir, 0755);
 		
 		if (strncasecmp(\PHP_OS, 'Win', 3) !== 0)
 		{


### PR DESCRIPTION
#532 때문에 생긴 버그입니다.

원래 있는 파일을 그대로 덮어쓰지 않고 다른 파일을 만든 후 이름을 바꾸는 atomic rename 방식이기 때문에, 파일에 쓰기 퍼미션이 있어도 상위폴더에 쓰기 퍼미션이 없으면 실패하게 됩니다.

상위폴더에 쓰기 퍼미션이 없을 때는 atomic rename을 사용하지 않고 그대로 덮어쓰도록 변경합니다.

파일 복사 함수에 대한 유닛 테스트도 좀더 보강했습니다.
