### PR TITLE
모듈설정이 빈값으로 설정되지 않던 문제고침.

### DIFF
--- a/modules/ncenterlite/ncenterlite.admin.controller.php
+++ b/modules/ncenterlite/ncenterlite.admin.controller.php
@@ -55,20 +55,19 @@ class ncenterliteAdminController extends ncenterlite
 				$config->mention_suffixes = array_map('trim', explode(',', $config->mention_suffixes));
 			}
 		}
-		
+
 		if ($obj->disp_act == 'dispNcenterliteAdminSeletedmid')
 		{
-			if (!$config->hide_module_srls)
+			if (!$obj->hide_module_srls)
 			{
 				$config->hide_module_srls = array();
 			}
-			if (!$config->admin_notify_module_srls)
+			if (!$obj->admin_notify_module_srls)
 			{
 				$config->admin_notify_module_srls = array();
 			}
 		}
-		
-		$output = $oModuleController->updateModuleConfig('ncenterlite', $config);
+		$output = $oModuleController->insertModuleConfig('ncenterlite', $config);
 		if(!$output->toBool())
 		{
 			return new Object(-1, 'ncenterlite_msg_setting_error');


### PR DESCRIPTION
모듈설정이 빈값으로 설정이 되지 않던 문제 고쳤습니다.
#547 이슈를 해결하는 PR입니다.
