### PR TITLE
임시 제한된 회원에게 임시 제한 사유를 표시하도록 변경

### DIFF
--- a/modules/member/lang/en.php
+++ b/modules/member/lang/en.php
@@ -48,6 +48,7 @@ $lang->enable_find_account_question = 'Account recovery using question/answer';
 $lang->enable_ssl = 'Enable SSL';
 $lang->msg_email_confirmation_required = 'A confirmation e-mail will be sent. Please check your email address carefully.';
 $lang->security_sign_in = 'Sign in using enhanced security';
+$lang->member_limited = 'Limited';
 $lang->limit_day = 'Temporary Limit Date';
 $lang->limit_day_description = 'Description for Temporary Limit Date';
 $lang->limit_date = 'Limit Date';

--- a/modules/member/lang/ko.php
+++ b/modules/member/lang/ko.php
@@ -48,6 +48,7 @@ $lang->enable_find_account_question = '질문/답변 인증 사용';
 $lang->enable_ssl = 'SSL 기능 사용';
 $lang->msg_email_confirmation_required = '인증 메일이 발송되니 정확하게 입력해 주시기 바랍니다.';
 $lang->security_sign_in = '보안로그인 사용';
+$lang->member_limited = '임시 제한';
 $lang->limit_day = '임시 제한 일자';
 $lang->limit_day_description = '임시 제한 일자 설명';
 $lang->limit_date = '제한일';

--- a/modules/member/member.controller.php
+++ b/modules/member/member.controller.php
@@ -1756,13 +1756,16 @@ class memberController extends member
 				$redirectUrl = getUrl('', 'act', 'dispMemberResendAuthMail');
 				return $this->setRedirectUrl($redirectUrl, new Object(-1,'msg_user_not_confirmed'));
 			}
-			return new Object(-1, ($this->memberInfo->refused_reason)? lang('msg_user_denied') . "\n" . $this->memberInfo->refused_reason : 'msg_user_denied');
+			
+			$refused_reason = $this->memberInfo->refused_reason ? ('<br>' . lang('refused_reason') . ': ' . $this->memberInfo->refused_reason) : '';
+			return new Object(-1, lang('msg_user_denied') . $refused_reason);
 		}
 		
 		// Notify if user is limited
 		if($this->memberInfo->limit_date && substr($this->memberInfo->limit_date,0,8) >= date("Ymd"))
 		{
-			return new Object(-9,sprintf(lang('msg_user_limited'),zdate($this->memberInfo->limit_date,"Y-m-d")));
+			$limited_reason = $this->memberInfo->limited_reason ? ('<br>' . lang('refused_reason') . ': ' . $this->memberInfo->limited_reason) : '';
+			return new Object(-9, sprintf(lang('msg_user_limited'), zdate($this->memberInfo->limit_date,"Y-m-d")) . $limited_reason);
 		}
 		
 		// Do not allow login as admin if not in allowed IP list

--- a/modules/member/tpl/insert_member.html
+++ b/modules/member/tpl/insert_member.html
@@ -92,6 +92,13 @@
 			<span class="x_help-inline">{$lang->about_limit_date}</span>
 		</div>
 	</div>
+	<div class="x_control-group div_limited_reason">
+		<label class="x_control-label">{$lang->refused_reason}</label>
+		<div class="x_controls">
+			<textarea name="limited_reason" id="limited_reason" rows="2" cols="42" style="vertical-align:top">{$member_info->limited_reason}</textarea>
+			<span class="x_help-inline">{$lang->about_refused_reason}</span>
+		</div>
+	</div>
 	<div class="x_control-group">
 		<label class="x_control-label">{$lang->is_admin}</label>
 		<div class="x_controls">
@@ -136,6 +143,11 @@
 
 				onSelect:function(){
 					$(this).prev('input[type="hidden"]').val(this.value.replace(/-/g,""))
+					if($('#until').val()){
+						limited_reason_division.slideDown(200);
+					} else {
+						limited_reason_division.slideUp(200);
+					}
 				}
 			};
 			$.extend($.datepicker.regional['{$lang_type}'],option);
@@ -147,7 +159,9 @@
 		}
 		$(".dateRemover").click(function() {
 			$(this).prevAll('input').val('');
-			return false;});
+			limited_reason_division.slideUp(200);
+			return false;
+		});
     });
 
 	var refused_reason_division = $('.div_refused_reason');
@@ -165,5 +179,11 @@
 			refused_reason_division.slideUp(200);
 		}
 	});
+	
+	var limited_reason_division = $('.div_limited_reason');
+	if(!$('#until').val())
+	{
+		limited_reason_division.hide();
+	}
 })(jQuery);
 </script>

--- a/modules/member/tpl/member_list.html
+++ b/modules/member/tpl/member_list.html
@@ -48,7 +48,15 @@
 				</td>
 				{@ $member_info['group_list'] = implode(', ', $member_info['group_list'])}
 				<td class="nowr" loop="$usedIdentifiers=>$name,$title">{$member_info[$name]}</td>
-				<td class="nowr"><!--@if($member_info['denied']=='Y')--><span style="color:red;">{$lang->denied}</span><!--@else-->{$lang->approval}<!--@end--></td>
+				<td class="nowr">
+					<!--@if($member_info['denied']=='Y')-->
+						<span style="color:red;">{$lang->denied}</span>
+					<!--@elseif($member_info['limit_date'] && substr($member_info['limit_date'], 0, 8) >= date('Ymd'))-->
+						<span style="color:red;">{$lang->member_limited}</span>
+					<!--@else-->
+						{$lang->approval}
+					<!--@end-->
+				</td>
 				<td class="nowr" title="{zdate($member_info['regdate'], 'Y-m-d H:i:s')}">{zdate($member_info['regdate'], 'Y-m-d')}</td>
 				<td class="nowr" title="{zdate($member_info['last_login'], 'Y-m-d H:i:s')}">{zdate($member_info['last_login'], 'Y-m-d')}</td>
 				<td>{$member_info['group_list']}&nbsp;</td>


### PR DESCRIPTION
#58, #173 의 연장선상에 있는 패치입니다.

- 임시 제한된 회원이 로그인하려고 할 경우 표시할 메시지를 관리자가 지정할 수 있습니다.
- 임시 제한된 회원을 회원 목록에서 쉽게 파악할 수 있도록 변경했습니다.
- 거부된 회원에게 표시하는 메시지도 조금 다듬었습니다.