### PR TITLE
삭제된 그룹이 포인트/레벨/그룹 연동에 포함되는 것을 방지

### DIFF
--- a/modules/member/member.admin.controller.php
+++ b/modules/member/member.admin.controller.php
@@ -1172,6 +1172,14 @@ class memberAdminController extends member
 	function insertGroup($args)
 	{
 		if(!$args->site_srl) $args->site_srl = 0;
+
+		// Call trigger (before)
+		$trigger_output = ModuleHandler::triggerCall('member.insertGroup', 'before', $args);
+		if(!$trigger_output->toBool())
+		{
+			return $trigger_output;
+		}
+
 		// Check the value of is_default.
 		if($args->is_default != 'Y')
 		{
@@ -1193,6 +1201,9 @@ class memberAdminController extends member
 		$output = executeQuery('member.insertGroup', $args);
 		$this->_deleteMemberGroupCache($args->site_srl);
 
+		// Call trigger (after)
+		ModuleHandler::triggerCall('member.insertGroup', 'after', $args);
+		
 		return $output;
 	}
 
@@ -1204,8 +1215,16 @@ class memberAdminController extends member
 	function updateGroup($args)
 	{
 		if(!$args->site_srl) $args->site_srl = 0;
-		// Check the value of is_default.
 		if(!$args->group_srl) return new Object(-1, 'lang->msg_not_founded');
+		
+		// Call trigger (before)
+		$trigger_output = ModuleHandler::triggerCall('member.updateGroup', 'before', $args);
+		if(!$trigger_output->toBool())
+		{
+			return $trigger_output;
+		}
+
+		// Check the value of is_default.
 		if($args->is_default!='Y')
 		{
 			$args->is_default = 'N';
@@ -1218,6 +1237,10 @@ class memberAdminController extends member
 
 		$output = executeQuery('member.updateGroup', $args);
 		$this->_deleteMemberGroupCache($args->site_srl);
+		
+		// Call trigger (after)
+		ModuleHandler::triggerCall('member.updateGroup', 'after', $args);
+		
 		return $output;
 	}
 
@@ -1238,6 +1261,13 @@ class memberAdminController extends member
 
 		if(!$group_info) return new Object(-1, 'lang->msg_not_founded');
 		if($group_info->is_default == 'Y') return new Object(-1, 'msg_not_delete_default');
+		
+		// Call trigger (before)
+		$trigger_output = ModuleHandler::triggerCall('member.deleteGroup', 'before', $group_info);
+		if(!$trigger_output->toBool())
+		{
+			return $trigger_output;
+		}
 
 		// Get groups where is_default == 'Y'
 		$columnList = array('site_srl', 'group_srl');
@@ -1251,6 +1281,14 @@ class memberAdminController extends member
 		$args->group_srl = $group_srl;
 		$output = executeQuery('member.deleteGroup', $args);
 		$this->_deleteMemberGroupCache($site_srl);
+		if (!$output->toBool())
+		{
+			return $output;
+		}
+
+		// Call trigger (after)
+		ModuleHandler::triggerCall('member.deleteGroup', 'after', $group_info);
+
 		return $output;
 	}
 

--- a/modules/point/point.admin.controller.php
+++ b/modules/point/point.admin.controller.php
@@ -71,7 +71,8 @@ class pointAdminController extends point
 
 			$oMemberModel = getModel('member');
 			$group_list = $oMemberModel->getGroups();
-	
+			$config->point_group = array();
+
 			// Per-level group configurations
 			foreach($group_list as $group)
 			{
@@ -94,10 +95,6 @@ class pointAdminController extends point
 						$args->{'point_group_'.$group_srl} = 1;
 					}
 					$config->point_group[$group_srl] = $args->{'point_group_'.$group_srl};
-				}
-				else
-				{
-					unset($config->point_group[$group_srl]);
 				}
 			}
 

--- a/modules/point/point.class.php
+++ b/modules/point/point.class.php
@@ -85,6 +85,7 @@ class point extends ModuleObject
 		$oModuleController->insertTrigger('file.downloadFile', 'point', 'controller', 'triggerBeforeDownloadFile', 'before');
 		$oModuleController->insertTrigger('file.downloadFile', 'point', 'controller', 'triggerDownloadFile', 'after');
 		$oModuleController->insertTrigger('member.doLogin', 'point', 'controller', 'triggerAfterLogin', 'after');
+		$oModuleController->insertTrigger('member.deleteGroup', 'point', 'controller', 'triggerDeleteGroup', 'after');
 		$oModuleController->insertTrigger('module.dispAdditionSetup', 'point', 'view', 'triggerDispPointAdditionSetup', 'after');
 		$oModuleController->insertTrigger('document.updateReadedCount', 'point', 'controller', 'triggerUpdateReadedCount', 'after');
 		// Add a trigger for voting up and down 2008.05.13 haneul
@@ -121,6 +122,7 @@ class point extends ModuleObject
 			if(!$oModuleModel->getTrigger('file.downloadFile', 'point', 'controller', 'triggerBeforeDownloadFile', 'before')) return true;
 			if(!$oModuleModel->getTrigger('file.downloadFile', 'point', 'controller', 'triggerDownloadFile', 'after')) return true;
 			if(!$oModuleModel->getTrigger('member.doLogin', 'point', 'controller', 'triggerAfterLogin', 'after')) return true;
+			if(!$oModuleModel->getTrigger('member.deleteGroup', 'point', 'controller', 'triggerDeleteGroup', 'after')) return true;
 			if(!$oModuleModel->getTrigger('module.dispAdditionSetup', 'point', 'view', 'triggerDispPointAdditionSetup', 'after')) return true;
 			if(!$oModuleModel->getTrigger('document.updateReadedCount', 'point', 'controller', 'triggerUpdateReadedCount', 'after')) return true;
 			// Add a trigger for voting up and down 2008.05.13 haneul
@@ -169,6 +171,8 @@ class point extends ModuleObject
 			$oModuleController->insertTrigger('file.downloadFile', 'point', 'controller', 'triggerDownloadFile', 'after');
 		if(!$oModuleModel->getTrigger('member.doLogin', 'point', 'controller', 'triggerAfterLogin', 'after'))
 			$oModuleController->insertTrigger('member.doLogin', 'point', 'controller', 'triggerAfterLogin', 'after');
+		if(!$oModuleModel->getTrigger('member.deleteGroup', 'point', 'controller', 'triggerDeleteGroup', 'after'))
+			$oModuleController->insertTrigger('member.deleteGroup', 'point', 'controller', 'triggerDeleteGroup', 'after');
 		if(!$oModuleModel->getTrigger('module.dispAdditionSetup', 'point', 'view', 'triggerDispPointAdditionSetup', 'after')) 
 			$oModuleController->insertTrigger('module.dispAdditionSetup', 'point', 'view', 'triggerDispPointAdditionSetup', 'after');
 		if(!$oModuleModel->getTrigger('document.updateReadedCount', 'point', 'controller', 'triggerUpdateReadedCount', 'after')) 

--- a/modules/point/point.controller.php
+++ b/modules/point/point.controller.php
@@ -61,6 +61,25 @@ class pointController extends point
 	}
 
 	/**
+	 * @brief Member group deletion trigger
+	 */
+	function triggerDeleteGroup(&$obj)
+	{
+		// Get the point module config
+		$config = getModel('module')->getModuleConfig('point');
+		// Get the group_srl of the deleted group
+		$group_srl = $obj->group_srl;
+		// Exclude deleted group from point/level/group integration
+		if($config->point_group && isset($config->point_group[$group_srl]))
+		{
+			unset($config->point_group[$group_srl]);
+			getController('module')->insertModuleConfig('point', $config);
+		}
+
+		return new Object();
+	}
+	
+	/**
 	 * @brief A trigger to add points to the member for creating a post
 	 */
 	function triggerInsertDocument(&$obj)


### PR DESCRIPTION
### 문제 재현 방법

- 포인트 모듈을 아래와 같이 설정
  - 레벨 10 도달시 그룹 A
  - 레벨 20 도달시 그룹 B
  - 레벨 30 도달시 그룹 C
  - 다른 그룹은 초기화하도록 설정
- 관리자가 그룹 B를 삭제함
- 회원이 레벨 20 도달시 그룹 B에 추가되고 기존 그룹은 초기화됨 (그룹 A에서 제외됨)
- 그러나 그룹 B는 존재하지 않으므로
- A에도 B에도 소속되지 않은 상태가 됨 (기본 그룹만 남음)
- 포인트/레벨/그룹 연동 설정을 다시 저장해도 소용없음 (존재하지 않는 그룹은 설정을 변경할 수도 없고 삭제할 수도 없음)

### 패치 방법

- [x] 포인트/레벨/그룹 연동 설정 저장시 존재하지 않는 그룹에 대한 설정이 남지 않도록 변경
- [x] 그룹 삭제시 포인트/레벨/그룹 연동 설정에서도 삭제되도록 변경