### PR TITLE
알림센터 모듈 인덱스 정리

### DIFF
--- a/modules/ncenterlite/ncenterlite.class.php
+++ b/modules/ncenterlite/ncenterlite.class.php
@@ -124,12 +124,13 @@ class ncenterlite extends ModuleObject
 			return true;
 		}
 
-		if(!$oDB->isIndexExists('ncenterlite_notify', 'idx_notify'))
+		if(!$oDB->isIndexExists('ncenterlite_notify', 'idx_target_member_srl'))
 		{
 			return true;
 		}
 
-		if(!$oDB->isIndexExists('ncenterlite_notify', 'idx_target_member_srl'))
+		// PK duplicate
+		if($oDB->isIndexExists('ncenterlite_notify', 'idx_notify'))
 		{
 			return true;
 		}
@@ -202,14 +203,15 @@ class ncenterlite extends ModuleObject
 			$oDB->addIndex('ncenterlite_notify', 'idx_target_p_srl', array('target_p_srl'));
 		}
 
-		if(!$oDB->isIndexExists('ncenterlite_notify', 'idx_notify'))
-		{
-			$oDB->addIndex('ncenterlite_notify', 'idx_notify', array('notify'));
-		}
-
 		if(!$oDB->isIndexExists('ncenterlite_notify', 'idx_target_member_srl'))
 		{
 			$oDB->addIndex('ncenterlite_notify', 'idx_target_member_srl', array('target_member_srl'));
+		}
+
+		// PK duplicate
+		if($oDB->isIndexExists('ncenterlite_notify', 'idx_notify'))
+		{
+			$oDB->dropIndex('ncenterlite_notify', 'idx_notify');
 		}
 
 		return new Object(0, 'success_updated');

--- a/modules/ncenterlite/ncenterlite.class.php
+++ b/modules/ncenterlite/ncenterlite.class.php
@@ -129,6 +129,12 @@ class ncenterlite extends ModuleObject
 			return true;
 		}
 
+		// Composite index to speed up getNotifyList
+		if(!$oDB->isIndexExists('ncenterlite_notify', 'idx_member_srl_and_readed'))
+		{
+			return true;
+		}
+
 		// PK duplicate
 		if($oDB->isIndexExists('ncenterlite_notify', 'idx_notify'))
 		{
@@ -206,6 +212,12 @@ class ncenterlite extends ModuleObject
 		if(!$oDB->isIndexExists('ncenterlite_notify', 'idx_target_member_srl'))
 		{
 			$oDB->addIndex('ncenterlite_notify', 'idx_target_member_srl', array('target_member_srl'));
+		}
+
+		// Composite index to speed up getNotifyList
+		if(!$oDB->isIndexExists('ncenterlite_notify', 'idx_member_srl_and_readed'))
+		{
+			$oDB->addIndex('ncenterlite_notify', 'idx_member_srl_and_readed', array('member_srl', 'readed'));
 		}
 
 		// PK duplicate

--- a/modules/ncenterlite/schemas/ncenterlite_notify.xml
+++ b/modules/ncenterlite/schemas/ncenterlite_notify.xml
@@ -1,24 +1,24 @@
 <table name="ncenterlite_notify">
-	<column name="notify" type="char" size="32" notnull="notnull" primary_key="primary_key" breif="메시지 ID" />
+	<column name="notify" type="char" size="32" notnull="notnull" primary_key="primary_key" brief="메시지 ID" />
 
-	<column name="srl" type="number" size="11" notnull="notnull" index="idx_srl" breif="이벤트 대상의 상위 srl" />
-	<column name="target_srl" type="number" size="11" notnull="notnull" index="idx_target_srl" breif="이벤트 대상 srl(문서/댓글)" />
-	<column name="target_p_srl" type="number" size="11" notnull="notnull" index="idx_target_p_srl" breif="이벤트 대상 srl(문서/댓글) 대댓글의 경우 앞전 댓글" />
-	<column name="type" type="char" size="1" notnull="notnull" breif="이벤트 대상 타입" />
-	<column name="target_type" type="char" size="1" notnull="notnull" breif="이벤트 타입" />
-    <column name="notify_type" type="number" breif="이벤트 타입 SRL" />
+	<column name="srl" type="number" size="11" notnull="notnull" index="idx_srl" brief="이벤트 대상의 상위 srl" />
+	<column name="target_srl" type="number" size="11" notnull="notnull" index="idx_target_srl" brief="이벤트 대상 srl(문서/댓글)" />
+	<column name="target_p_srl" type="number" size="11" notnull="notnull" index="idx_target_p_srl" brief="이벤트 대상 srl(문서/댓글) 대댓글의 경우 앞전 댓글" />
+	<column name="type" type="char" size="1" notnull="notnull" brief="이벤트 대상 타입" />
+	<column name="target_type" type="char" size="1" notnull="notnull" brief="이벤트 타입" />
+    <column name="notify_type" type="number" brief="이벤트 타입 SRL" />
 
-	<column name="member_srl" type="number" size="11" notnull="notnull" index="idx_member_srl" breif="receiver" />
+	<column name="member_srl" type="number" size="11" notnull="notnull" index="idx_member_srl" brief="receiver" />
 
-	<column name="target_member_srl" type="number" size="11" notnull="notnull" index="idx_target_member_srl" breif="sender" />
-	<column name="target_nick_name" type="varchar" size="50" notnull="notnull" breif="sender" />
-	<column name="target_user_id" type="varchar" size="50" notnull="notnull" breif="sender" />
-	<column name="target_email_address" type="varchar" size="50" notnull="notnull" breif="sender" />
+	<column name="target_member_srl" type="number" size="11" notnull="notnull" index="idx_target_member_srl" brief="sender" />
+	<column name="target_nick_name" type="varchar" size="50" notnull="notnull" brief="sender" />
+	<column name="target_user_id" type="varchar" size="50" notnull="notnull" brief="sender" />
+	<column name="target_email_address" type="varchar" size="50" notnull="notnull" brief="sender" />
 
-	<column name="target_browser" type="varchar" size="50" breif="브라우저 제목" />
-	<column name="target_summary" type="varchar" size="50" breif="메시지 요약문" />
-	<column name="target_body" type="varchar" size="255" breif="커스텀 알림 제목" />
-	<column name="target_url" type="varchar" size="255" notnull="notnull" breif="링크 목적지 주소" />
+	<column name="target_browser" type="varchar" size="50" brief="브라우저 제목" />
+	<column name="target_summary" type="varchar" size="50" brief="메시지 요약문" />
+	<column name="target_body" type="varchar" size="255" brief="커스텀 알림 제목" />
+	<column name="target_url" type="varchar" size="255" notnull="notnull" brief="링크 목적지 주소" />
 	<column name="readed" type="char" size="1" default="N" notnull="notnull" index="idx_readed" />
 	<column name="regdate" type="date" index="idx_regdate" />
 </table>

--- a/modules/ncenterlite/schemas/ncenterlite_notify.xml
+++ b/modules/ncenterlite/schemas/ncenterlite_notify.xml
@@ -1,5 +1,5 @@
 <table name="ncenterlite_notify">
-	<column name="notify" type="char" size="32" notnull="notnull" primary_key="primary_key" index="idx_notify" breif="메시지 ID" />
+	<column name="notify" type="char" size="32" notnull="notnull" primary_key="primary_key" breif="메시지 ID" />
 
 	<column name="srl" type="number" size="11" notnull="notnull" index="idx_srl" breif="이벤트 대상의 상위 srl" />
 	<column name="target_srl" type="number" size="11" notnull="notnull" index="idx_target_srl" breif="이벤트 대상 srl(문서/댓글)" />

--- a/modules/ncenterlite/schemas/ncenterlite_user_set.xml
+++ b/modules/ncenterlite/schemas/ncenterlite_user_set.xml
@@ -1,5 +1,5 @@
 <table name="ncenterlite_user_set">
-	<column name="member_srl" type="number" size="11" notnull="notnull" primary_key="primary_key" breif="member_srl 고유맴버 번호" />
+	<column name="member_srl" type="number" size="11" notnull="notnull" primary_key="primary_key" brief="member_srl 고유맴버 번호" />
 	<column name="comment_notify" type="char" size="1" notnull="notnull" />
 	<column name="mention_notify" type="char" size="1" notnull="notnull" />
 	<column name="message_notify" type="char" size="1" notnull="notnull" />


### PR DESCRIPTION
- PK와 중복되는 idx_notify 인덱스를 제거합니다.
- 한 회원에게 지나치게 많은 알림이 쌓여 있는 경우 (읽음 여부와 상관없이) getNotifyList 쿼리가 느려지는 현상이 [제보되었습니다](https://www.xetown.com/qna/339201). readed 컬럼의 cardinality가 너무 낮아서 인덱스를 타지 않고 검색하기 때문인데요... member_srl + readed 복합 인덱스를 생성하여 cardinality를 높이면 쿼리 느려짐 현상이 해결되는 것을 확인했습니다.