### PR TITLE
관리자 이메일 제목 수정 및 관리자메일으로 발신자 조작에 걸리지 않도록 고침.

### DIFF
--- a/modules/board/board.controller.php
+++ b/modules/board/board.controller.php
@@ -177,26 +177,27 @@ class boardController extends board
 			{
 				$oModuleModel = getModel('module');
 				$member_config = $oModuleModel->getModuleConfig('member');
-				$is_logged = Context::get('is_logged');
 
-				if(!$is_logged && !$member_config->webmaster_email)
+				if($member_config->webmaster_email)
 				{
-					$obj->email_address = $this->module_info->admin_mail;
+					$mail_title = sprintf(lang('msg_document_notify_mail'), $obj->mid, cut_str($obj->title, 20, '...'));
+
+					$oMail = new Mail();
+					$oMail->setTitle($mail_title);
+					$oMail->setContent( sprintf("From : <a href=\"%s\">%s</a><br/>\r\n%s", getFullUrl('','document_srl',$obj->document_srl), getFullUrl('','document_srl',$obj->document_srl), $obj->content));
+					$oMail->setSender($member_config->webmaster_name ?: null, $member_config->webmaster_email);
+
+					$target_mail = explode(',',$this->module_info->admin_mail);
+					for($i=0;$i<count($target_mail);$i++)
+					{
+						$email_address = trim($target_mail[$i]);
+						if(!$email_address) continue;
+						$oMail->setReceiptor($email_address, $email_address);
+						$oMail->send();
+					}
 				}
 				
-				$oMail = new Mail();
-				$oMail->setTitle($obj->title);
-				$oMail->setContent( sprintf("From : <a href=\"%s\">%s</a><br/>\r\n%s", getFullUrl('','document_srl',$obj->document_srl), getFullUrl('','document_srl',$obj->document_srl), $obj->content));
-				$oMail->setSender($obj->user_name ?: null, $obj->email_address ? $obj->email_address : $member_config->webmaster_email);
 
-				$target_mail = explode(',',$this->module_info->admin_mail);
-				for($i=0;$i<count($target_mail);$i++)
-				{
-					$email_address = trim($target_mail[$i]);
-					if(!$email_address) continue;
-					$oMail->setReceiptor($email_address, $email_address);
-					$oMail->send();
-				}
 			}
 		}
 

--- a/modules/board/board.controller.php
+++ b/modules/board/board.controller.php
@@ -180,7 +180,7 @@ class boardController extends board
 
 				if($member_config->webmaster_email)
 				{
-					$mail_title = sprintf(lang('msg_document_notify_mail'), $obj->mid, cut_str($obj->title, 20, '...'));
+					$mail_title = sprintf(lang('msg_document_notify_mail'), $this->module_info->browser_title, cut_str($obj->title, 20, '...'));
 
 					$oMail = new Mail();
 					$oMail->setTitle($mail_title);

--- a/modules/board/lang/en.php
+++ b/modules/board/lang/en.php
@@ -48,3 +48,4 @@ $lang->cmd_only_p_comment = 'Only if there are replies';
 $lang->cmd_all_comment_message = 'Always';
 $lang->cmd_do_not_message = 'Never';
 $lang->delete_placeholder = 'Delete Placeholder';
+$lang->msg_document_notify_mail = '[%s] The new post : %s';

--- a/modules/board/lang/ko.php
+++ b/modules/board/lang/ko.php
@@ -77,3 +77,4 @@ $lang->cmd_only_p_comment = '대댓글이 있는 경우에만 남김';
 $lang->cmd_all_comment_message = '모든 댓글에 남김';
 $lang->cmd_do_not_message = '남기지 않음';
 $lang->delete_placeholder = '완전 삭제';
+$lang->msg_document_notify_mail = '[%s] 새로운 게시글이 등록되었습니다 : %s';

--- a/modules/comment/comment.controller.php
+++ b/modules/comment/comment.controller.php
@@ -638,16 +638,22 @@ class commentController extends comment
 		$module_info = $oModuleModel->getModuleInfoByDocumentSrl($obj->document_srl);
 
 		// If there is no problem to register comment then send an email to all admin were set in module admin panel
-		if($module_info->admin_mail && $member_info->is_admin != 'Y')
+		if($module_info->admin_mail/* && $member_info->is_admin != 'Y'*/)
 		{
 			$oMail = new Mail();
 
-			if($is_logged)
+			// 메일 발신자 조작으로 취급하여 스팸으로 직행할 수 있기때문에 회원설정에서 입력된 웹마스터 메일주소를 이용하도록 함
+			$member_config = $oMemberModel->getMemberConfig();
+			$admin_email_adress = $member_config->webmaster_email;
+			// 관리자 메일을 입력하지 않으면 메일을 보내지 않음.
+			if(!$admin_email_adress)
 			{
-				$oMail->setSender($obj->email_address, $obj->email_address);
+				return;
 			}
-
-			$mail_title = "[Rhymix - " . Context::get('mid') . "] A new comment was posted on document: \"" . $oDocument->getTitleText() . "\"";
+			// 매일 보내는 이를 관리자 계정으로 설정한다.
+			$oMail->setSender($member_config->webmaster_name, $member_config->webmaster_email);
+			$mail_title = sprintf(lang('msg_comment_notify_mail'), Context::get('mid'), $oDocument->getTitleText());
+			//$mail_title = "[" . Context::get('mid') . "] A new comment was posted on document: \"" . $oDocument->getTitleText() . "\"";
 			$oMail->setTitle($mail_title);
 			$url_comment = getFullUrl('','document_srl',$obj->document_srl).'#comment_'.$obj->comment_srl;
 			if($using_validation)
@@ -710,7 +716,6 @@ class commentController extends comment
 			// get all admins emails
 			$admins_emails = $module_info->admin_mail;
 			$target_mail = explode(',', $admins_emails);
-
 			// send email to all admins - START
 			for($i = 0; $i < count($target_mail); $i++)
 			{
@@ -718,10 +723,6 @@ class commentController extends comment
 				if(!$email_address)
 				{
 					continue;
-				}
-				if(!$is_logged)
-				{
-					$oMail->setSender($email_address, $email_address);
 				}
 				$oMail->setReceiptor($email_address, $email_address);
 				$oMail->send();

--- a/modules/comment/comment.controller.php
+++ b/modules/comment/comment.controller.php
@@ -652,8 +652,7 @@ class commentController extends comment
 			}
 			// 매일 보내는 이를 관리자 계정으로 설정한다.
 			$oMail->setSender($member_config->webmaster_name, $member_config->webmaster_email);
-			$mail_title = sprintf(lang('msg_comment_notify_mail'), Context::get('mid'), $oDocument->getTitleText());
-			//$mail_title = "[" . Context::get('mid') . "] A new comment was posted on document: \"" . $oDocument->getTitleText() . "\"";
+			$mail_title = sprintf(lang('msg_comment_notify_mail'), Context::get('mid'), cut_str($oDocument->getTitleText(), 20, '...'));
 			$oMail->setTitle($mail_title);
 			$url_comment = getFullUrl('','document_srl',$obj->document_srl).'#comment_'.$obj->comment_srl;
 			if($using_validation)

--- a/modules/comment/comment.controller.php
+++ b/modules/comment/comment.controller.php
@@ -638,7 +638,7 @@ class commentController extends comment
 		$module_info = $oModuleModel->getModuleInfoByDocumentSrl($obj->document_srl);
 
 		// If there is no problem to register comment then send an email to all admin were set in module admin panel
-		if($module_info->admin_mail/* && $member_info->is_admin != 'Y'*/)
+		if($module_info->admin_mail && $member_info->is_admin != 'Y')
 		{
 			$oMail = new Mail();
 

--- a/modules/comment/lang/en.php
+++ b/modules/comment/lang/en.php
@@ -49,3 +49,4 @@ $lang->improper_comment_reasons['others'] = 'Others (Write your own)';
 $lang->about_improper_comment_declare = 'Write here why you report this comment as an improper thing.';
 $lang->msg_deleted_comment = 'This comment has been deleted.';
 $lang->msg_admin_deleted_comment = 'This comment has been deleted by an administrator.';
+$lang->msg_comment_notify_mail = "[%s] A new comment was posted on document: \" %s \"";

--- a/modules/comment/lang/ko.php
+++ b/modules/comment/lang/ko.php
@@ -53,3 +53,4 @@ $lang->improper_comment_reasons['others'] = '기타(직접작성)';
 $lang->about_improper_comment_declare = '댓글을 신고하신 이유를 간단히 적어서 제출해주시면 관리자 검토 후 조치하겠습니다.';
 $lang->msg_deleted_comment = '삭제된 댓글입니다.';
 $lang->msg_admin_deleted_comment = '관리자가 삭제한 댓글입니다.';
+$lang->msg_comment_notify_mail = '[%s] 새로운 댓글이 등록되었습니다 : %s';


### PR DESCRIPTION
#557 에서 나눴던 게시판에 관리자 메일 설정시 메일 제목에 rhymix 가 포함되는 문제가 있어서 이 항목을 정리하는 과정에서 나온 sender설정에 대한 부분도 함께 수정하고 있습니다.

insertDocument 실행시 관리자 메일은 제목이 너무 제목만 뜨는 경향이 있어서 다음과 같이 할려고 합니다.

```
[ mid명 ] 새로운 글이 등록 되었습니다 : 제목
```
다음과 같은 형태로 수정하여 댓글과 연관성 + 각각 사용하는 언어에도 맞게 설정하는것이 목표.

* [x] 댓글 메일 제목 수정
* [x] 댓글 발신자 수정
* [x] 게시글 발신자 수정
* [x] 게시글의 메일제목 수정
* [ ] 전체적으로 코어에서 메일 전송하는 경우 해당 메일 `sender`를 전부 `member`모듈의 웹마스터가 전송하는걸로 고치기