### PR TITLE
Merge with XE 1.8.23

### DIFF
--- a/classes/security/Password.class.php
+++ b/classes/security/Password.class.php
@@ -58,7 +58,22 @@ class Password
 	{
 		return Rhymix\Framework\Password::getRandomPassword($length);
 	}
-
+	
+	public function createSignature($string)
+	{
+		return Rhymix\Framework\Security::createSignature($string);
+	}
+	
+	public function checkSignature($string, $signature)
+	{
+		return Rhymix\Framework\Security::verifySignature($string, $signature);
+	}
+	
+	public function getSecretKey()
+	{
+		return config('crypto.authentication_key');
+	}
+	
 	public function pbkdf2($password, $salt, $algorithm = 'sha256', $iterations = 8192, $length = 24)
 	{
 		$hash = Rhymix\Framework\Security::pbkdf2($password, $salt, $algorithm, $iterations, $length);

--- a/classes/validator/Validator.class.php
+++ b/classes/validator/Validator.class.php
@@ -92,7 +92,7 @@ class Validator
 			'alpha' => '/^[a-z]*$/i',
 			'alpha_number' => '/^[a-z][a-z0-9_]*$/i',
 			'number' => '/^(?:[1-9]\\d*|0)$/',
-			'float' => '/^\d*(\.?\d*)$/'
+			'float' => '/^\d+(\.\d+)?$/'
 		));
 
 		$this->_has_mb_func = is_callable('mb_strlen');

--- a/classes/validator/Validator.class.php
+++ b/classes/validator/Validator.class.php
@@ -92,7 +92,7 @@ class Validator
 			'alpha' => '/^[a-z]*$/i',
 			'alpha_number' => '/^[a-z][a-z0-9_]*$/i',
 			'number' => '/^(?:[1-9]\\d*|0)$/',
-			'real' => '/^\d*(\.?\d*)$/'
+			'float' => '/^\d*(\.?\d*)$/'
 		));
 
 		$this->_has_mb_func = is_callable('mb_strlen');
@@ -715,7 +715,7 @@ class Validator
 		{
 			$name = strtolower($name);
 
-			if(in_array($name, array('email', 'userid', 'url', 'alpha', 'alpha_number', 'number', 'real')))
+			if(in_array($name, array('email', 'userid', 'url', 'alpha', 'alpha_number', 'number', 'float')))
 			{
 				continue;
 			}

--- a/classes/validator/Validator.class.php
+++ b/classes/validator/Validator.class.php
@@ -91,7 +91,8 @@ class Validator
 			'url' => '/^(https?|ftp|mms):\/\/[0-9a-z-]+(\.[_0-9a-z-]+)+(:\d+)?/',
 			'alpha' => '/^[a-z]*$/i',
 			'alpha_number' => '/^[a-z][a-z0-9_]*$/i',
-			'number' => '/^(?:[1-9]\\d*|0)$/'
+			'number' => '/^(?:[1-9]\\d*|0)$/',
+			'real' => '/^\d*(\.?\d*)$/'
 		));
 
 		$this->_has_mb_func = is_callable('mb_strlen');
@@ -714,7 +715,7 @@ class Validator
 		{
 			$name = strtolower($name);
 
-			if(in_array($name, array('email', 'userid', 'url', 'alpha', 'alpha_number', 'number')))
+			if(in_array($name, array('email', 'userid', 'url', 'alpha', 'alpha_number', 'number', 'real')))
 			{
 				continue;
 			}

--- a/common/constants.php
+++ b/common/constants.php
@@ -3,7 +3,7 @@
 /**
  * RX_VERSION is the version number of the Rhymix CMS.
  */
-define('RX_VERSION', '1.8.22');
+define('RX_VERSION', '1.8.23');
 
 /**
  * RX_MICROTIME is the startup time of the current script, in microseconds since the Unix epoch.

--- a/common/framework/parsers/configparser.php
+++ b/common/framework/parsers/configparser.php
@@ -160,7 +160,7 @@ class ConfigParser
 		
 		// Create new crypto keys.
 		$config['crypto']['encryption_key'] = Security::getRandom(64, 'alnum');
-		$config['crypto']['authentication_key'] = Security::getRandom(64, 'alnum');
+		$config['crypto']['authentication_key'] = $db_info->secret_key ?: Security::getRandom(64, 'alnum');
 		$config['crypto']['session_key'] = Security::getRandom(64, 'alnum');
 		
 		// Convert language configuration.

--- a/common/framework/security.php
+++ b/common/framework/security.php
@@ -113,6 +113,40 @@ class Security
 	}
 	
 	/**
+	 * Create a digital signature to verify the authenticity of a string.
+	 * 
+	 * @param string $string
+	 * @return string
+	 */
+	public static function createSignature($string)
+	{
+		$key = config('crypto.authentication_key');
+		$salt = self::getRandom(8, 'alnum');
+		$hash = substr(base64_encode(hash_hmac('sha256', hash_hmac('sha256', $string, $salt), $key, true)), 0, 32);
+		return $salt . strtr($hash, '+/', '-_');
+	}
+	
+	/**
+	 * Check whether a signature is valid.
+	 * 
+	 * @param string $string
+	 * @param string $signature
+	 * @return bool
+	 */
+	public static function verifySignature($string, $signature)
+	{
+		if(strlen($signature) !== 40)
+		{
+			return false;
+		}
+		
+		$key = config('crypto.authentication_key');
+		$salt = substr($signature, 0, 8);
+		$hash = substr(base64_encode(hash_hmac('sha256', hash_hmac('sha256', $string, $salt), $key, true)), 0, 32);
+		return self::compareStrings(substr($signature, 8), strtr($hash, '+/', '-_'));
+	}
+	
+	/**
 	 * Generate a cryptographically secure random string.
 	 * 
 	 * @param int $length

--- a/common/js/common.js
+++ b/common/js/common.js
@@ -294,10 +294,15 @@ jQuery(function($) {
 			}
 		}
 
-		re = /http:\/\/([^:\/]+)(:\d+|)/i;
+		re = /https?:\/\/([^:\/]+)(:\d+|)/i;
 		if (bUseSSL && re.test(uri)) {
 			toReplace = 'https://'+RegExp.$1;
 			if (window.https_port && https_port != 443) toReplace += ':' + https_port;
+			uri = uri.replace(re, toReplace);
+		}
+		if (!bUseSSL && re.test(uri)) {
+			toReplace = 'http://'+RegExp.$1;
+			if (window.http_port && http_port != 80) toReplace += ':' + http_port;
 			uri = uri.replace(re, toReplace);
 		}
 

--- a/common/js/xml_js_filter.js
+++ b/common/js/xml_js_filter.js
@@ -51,6 +51,10 @@
 			// number
 			var regNum = /^[0-9]*$/;
 			this.cast('ADD_RULE', ['number', regNum]);
+
+			// float
+			var regFloat = /^\d+(\.\d+)?$/;
+			this.cast('ADD_RULE', ['float', regFloat]);
 			// }}} add filters
 		},
 		// run validator

--- a/common/lang/en.php
+++ b/common/lang/en.php
@@ -310,6 +310,7 @@ $lang->filter['invalid_alpha'] = 'The format of %s is invalid. Please enter Engl
 $lang->filter['invalid_alpha_number'] = 'The format of %s is invalid. Please enter English alphabets and numbers only.';
 $lang->filter['invalid_mid'] = 'The format of %s is invalid. Module ID should be begun with a letter. Subsequent characters may be letters, digits or underscore characters.';
 $lang->filter['invalid_number'] = 'The format of %s is invalid. Please enter numbers only.';
+$lang->filter['invalid_float'] = 'The format of %s is invalid. Please enter numbers only.';
 $lang->filter['invalid_extension'] = 'The format of %s is invalid. e.g.) *.* or *.jpg;*.gif;.';
 $lang->security_warning_embed = 'Due to security concern, administrators are not allowed to view embedded items.<BR /> To view them, please use another non-administrator ID.';
 $lang->msg_pc_to_mobile = 'View mobile optimized version of this page';

--- a/common/lang/ja.php
+++ b/common/lang/ja.php
@@ -293,6 +293,7 @@ $lang->filter['invalid_alpha'] = '%sの形式が正しくありません。半�
 $lang->filter['invalid_alpha_number'] = '%sの形式が正しくありません。半角英数字で入力してください。';
 $lang->filter['invalid_mid'] = '%sの形式が正しくありません。 最初の文字は英文から始め、「英文＋数字＋_」組合せで入力が必要です。';
 $lang->filter['invalid_number'] = '%sの形式が正しくありません。半角数字で入力してください。';
+$lang->filter['invalid_float'] = '%sの形式が正しくありません。半角数字で入力してください。';
 $lang->security_warning_embed = 'セキュリティ問題のため、管理者IDではembedを見ることができません。<br />他のIDでログインしてください。';
 $lang->msg_pc_to_mobile = 'このページは、モバイル表示が可能です。モバイル表示へ移動しますか?';
 $lang->cmd_yes = 'はい';

--- a/common/lang/ko.php
+++ b/common/lang/ko.php
@@ -310,6 +310,7 @@ $lang->filter['invalid_alpha'] = '%s의 형식이 잘못되었습니다. 영문�
 $lang->filter['invalid_alpha_number'] = '%s의 형식이 잘못되었습니다. 영문과 숫자로만 입력해야 합니다.';
 $lang->filter['invalid_mid'] = '%s의 형식이 잘못되었습니다. 첫 글자는 영문으로 시작해야 하며 \'영문+숫자+_\'로만 입력해야 합니다.';
 $lang->filter['invalid_number'] = '%s의 형식이 잘못되었습니다. 숫자로만 입력해야 합니다.';
+$lang->filter['invalid_float'] = '%s의 형식이 잘못되었습니다. 숫자로만 입력해야 합니다.';
 $lang->filter['invalid_extension'] = '%s의 형식이 잘못되었습니다. *.* 나 *.jpg;*.gif; 처럼 입력해야 합니다.';
 $lang->security_invalid_session = '바르지 않은 접근입니다. 인증을 위해 다시 로그인해야 합니다.';
 $lang->security_warning_embed = '보안 문제로 관리자 아이디로는 embed를 볼 수 없습니다. 확인하려면 다른 아이디로 접속하세요';

--- a/common/lang/zh-CN.php
+++ b/common/lang/zh-CN.php
@@ -277,6 +277,7 @@ $lang->filter['invalid_alpha'] = '%s只能输入英文字母';
 $lang->filter['invalid_alpha_number'] = '%s只能输入英文或数字';
 $lang->filter['invalid_mid'] = '%s 格式错误。 模块名称只能用英文、数字及下划线，开头必须是英文。';
 $lang->filter['invalid_number'] = '%s只能输入数字';
+$lang->filter['invalid_float'] = '%s只能输入数字';
 $lang->security_warning_embed = '由于安全问题，不允许用系统管理员ID操作embed对象，请使用其他拥有管理权限的ID操作。';
 $lang->cmd_yes = '是';
 $lang->cmd_no = '否';

--- a/common/lang/zh-TW.php
+++ b/common/lang/zh-TW.php
@@ -276,6 +276,7 @@ $lang->filter['invalid_alpha'] = '%s只能輸入英文字母';
 $lang->filter['invalid_alpha_number'] = '%s只能輸入英文或數字';
 $lang->filter['invalid_mid'] = '%s 格式錯誤。 模組名稱只能使用英文、數字及底線，開頭必須是英文。';
 $lang->filter['invalid_number'] = '%s只能輸入數字';
+$lang->filter['invalid_float'] = '%s只能輸入數字';
 $lang->security_warning_embed = '基於安全因素，管理員無法檢視嵌入的物件。<BR /> 請使用其他非管理員帳號檢視。';
 $lang->msg_pc_to_mobile = '此頁面有手機頁面，要移至手機頁面嗎？';
 $lang->cmd_yes = '是';

--- a/modules/board/board.mobile.php
+++ b/modules/board/board.mobile.php
@@ -55,7 +55,7 @@ class boardMobile extends boardView
 		 * check the consultation function, if the user is admin then swich off consultation function
 		 * if the user is not logged, then disppear write document/write comment./ view document
 		 **/
-		if($this->module_info->consultation == 'Y' && !$this->grant->manager)
+		if($this->module_info->consultation == 'Y' && !$this->grant->manager && !$this->grant->consultation_read)
 		{
 			$this->consultation = true;
 			if(!Context::get('is_logged')) $this->grant->list = $this->grant->write_document = $this->grant->write_comment = $this->grant->view = false;

--- a/modules/board/board.view.php
+++ b/modules/board/board.view.php
@@ -74,7 +74,7 @@ class boardView extends board
 		 * check the consultation function, if the user is admin then swich off consultation function
 		 * if the user is not logged, then disppear write document/write comment./ view document
 		 **/
-		if($this->module_info->consultation == 'Y' && !$this->grant->manager)
+		if($this->module_info->consultation == 'Y' && !$this->grant->manager && !$this->grant->consultation_read)
 		{
 			$this->consultation = TRUE;
 			if(!Context::get('is_logged'))

--- a/modules/board/conf/module.xml
+++ b/modules/board/conf/module.xml
@@ -44,6 +44,11 @@
 			<title xml:lang="zh-TW">發表評論</title>
 			<title xml:lang="es">yorum yaz</title>
 		</grant>
+		<grant name="consultation_read" default="manager">
+			<title xml:lang="ko">상담글 조회</title>
+			<title xml:lang="en">Consultation Document Read</title>
+			<title xml:lang="jp">相談文照会</title>
+		</grant>
 	</grants>
 	<permissions>
 		<permission action="dispBoardAdminInsertBoard" target="manager" />

--- a/modules/file/file.model.php
+++ b/modules/file/file.model.php
@@ -175,6 +175,16 @@ class fileModel extends file
 		if(!$config->allow_outlink) $config->allow_outlink = 'Y';
 		if(!$config->download_grant) $config->download_grant = array();
 
+		$size = preg_replace('/[a-z]/is', '', ini_get('upload_max_filesize'));
+		if($config->allowed_filesize > $size) 
+		{	
+			$config->allowed_filesize = $size;
+		}
+		if($config->allowed_attach_size > $size) 
+		{
+			$config->allowed_attach_size = $size;
+		}
+		
 		return $config;
 	}
 

--- a/modules/file/ruleset/fileModuleConfig.xml
+++ b/modules/file/ruleset/fileModuleConfig.xml
@@ -4,8 +4,8 @@
 		<rule name="extension" type="regex" test="/^(?:\*\.\*|(\*\.\w+;\s*)*\*\.\w+;?)$/i"  />
     </customrules>
     <fields>
-		<field name="allowed_filesize" required="true" rule="number" default="2" />
-		<field name="allowed_attach_size" required="true" rule="number" default="2" />
+		<field name="allowed_filesize" required="true" rule="real" default="2" />
+		<field name="allowed_attach_size" required="true" rule="real" default="2" />
 		<field name="allowed_filetypes" required="true" rule="extension" />
     </fields>
 </ruleset>

--- a/modules/file/ruleset/fileModuleConfig.xml
+++ b/modules/file/ruleset/fileModuleConfig.xml
@@ -4,8 +4,8 @@
 		<rule name="extension" type="regex" test="/^(?:\*\.\*|(\*\.\w+;\s*)*\*\.\w+;?)$/i"  />
     </customrules>
     <fields>
-		<field name="allowed_filesize" required="true" rule="real" default="2" />
-		<field name="allowed_attach_size" required="true" rule="real" default="2" />
+		<field name="allowed_filesize" required="true" rule="float" default="2" />
+		<field name="allowed_attach_size" required="true" rule="float" default="2" />
 		<field name="allowed_filetypes" required="true" rule="extension" />
     </fields>
 </ruleset>

--- a/modules/file/ruleset/insertConfig.xml
+++ b/modules/file/ruleset/insertConfig.xml
@@ -4,8 +4,8 @@
 		<rule name="extension" type="regex" test="/^(?:\*\.\*|(\*\.\w+;\s*)*\*\.\w+;?)$/i"  />
     </customrules>
     <fields>
-		<field name="allowed_filesize" required="true" rule="number" default="2" />
-		<field name="allowed_attach_size" required="true" rule="number" default="2" />
+		<field name="allowed_filesize" required="true" rule="float" default="2" />
+		<field name="allowed_attach_size" required="true" rule="float" default="2" />
 		<field name="allowed_filetypes" required="true" rule="extension" />
     </fields>
 </ruleset>

--- a/modules/file/tpl/adminConfig.html
+++ b/modules/file/tpl/adminConfig.html
@@ -34,13 +34,13 @@
 	<div class="x_control-group">
 		<label for="filesize" class="x_control-label">{$lang->allowed_filesize} <a class="x_icon-question-sign" href="./common/manual/admin/index.html#UMAN_config_file_size" target="_blank">{$lang->help}</a></label>
 		<div class="x_controls">
-			<input type="number" id="filesize" name="allowed_filesize" value="{$config->allowed_filesize}" /> MB/{$upload_max_filesize}
+			<input type="number" step="any" id="filesize" name="allowed_filesize" value="{$config->allowed_filesize}" /> MB / {$upload_max_filesize}
 		</div>
 	</div>
 	<div class="x_control-group">
 		<label for="attachSize" class="x_control-label">{$lang->allowed_attach_size} <a class="x_icon-question-sign" href="./common/manual/admin/index.html#UMAN_config_file_document_attach_limit" target="_blank">{$lang->help}</a></label>
 		<div class="x_controls">
-			<input type="number" id="attachSize" name="allowed_attach_size" value="{$config->allowed_attach_size}" /> MB
+			<input type="number" step="any" id="attachSize" name="allowed_attach_size" value="{$config->allowed_attach_size}" /> MB
 		</div>
 	</div>
 	<div class="x_control-group">

--- a/modules/member/lang/zh-TW.php
+++ b/modules/member/lang/zh-TW.php
@@ -180,6 +180,7 @@ $lang->about_member_default = '將成為註冊會員時的預設群組。';
 $lang->about_find_member_account = '帳號/密碼將發送到您註冊時，所輸入的電子郵件當中。輸入註冊時的電子郵件地址後，請按「查詢帳號/密碼」按鈕。<br />';
 $lang->about_temp_password = '已發送臨時密碼。<br />請登入後修改密碼。<br />';
 $lang->about_ssl_port = '請輸入想要使用 SSL 預設埠口以外的埠口。';
+$lang->about_reset_auth_mail = '目前註冊的電子郵件地址為 %s 。如果你想改變你的e-mail>地址，你可以註冊更新，新的E-mail地址認證信息後重新發送郵件';
 $lang->about_resend_auth_mail = '如果沒有收到認證郵件可以再重寄一次。';
 $lang->no_article = '主題不存在';
 $lang->find_account_question = '密碼提示問答';

--- a/tests/unit/classes/validator/condition.en.js
+++ b/tests/unit/classes/validator/condition.en.js
@@ -17,5 +17,6 @@ v.cast('ADD_MESSAGE',['invalid_alpha','%s의 형식이 잘못되었습니다. �
 v.cast('ADD_MESSAGE',['invalid_alpha_number','%s의 형식이 잘못되었습니다. 영문과 숫자로만 입력해야 합니다.']);
 v.cast('ADD_MESSAGE',['invalid_mid','%s의 형식이 잘못되었습니다. 첫 글자는 영문으로 시작해야 하며 \'영문+숫자+_\'로만 입력해야 합니다.']);
 v.cast('ADD_MESSAGE',['invalid_number','%s의 형식이 잘못되었습니다. 숫자로만 입력해야 합니다.']);
+v.cast('ADD_MESSAGE',['invalid_float','%s의 형식이 잘못되었습니다. 숫자로만 입력해야 합니다.']);
 v.cast('ADD_MESSAGE',['invalid_extension','%s의 형식이 잘못되었습니다. *.* 나 *.jpg;*.gif; 처럼 입력해야 합니다.']);
 })(jQuery);

--- a/tests/unit/framework/SecurityTest.php
+++ b/tests/unit/framework/SecurityTest.php
@@ -20,6 +20,7 @@ class SecurityTest extends \Codeception\TestCase\Test
 	public function testEncryption()
 	{
 		$plaintext = Rhymix\Framework\Security::getRandom();
+		config('crypto.encryption_key', Rhymix\Framework\Security::getRandom());
 		
 		// Encryption with default key.
 		$encrypted = Rhymix\Framework\Security::encrypt($plaintext);
@@ -58,6 +59,7 @@ class SecurityTest extends \Codeception\TestCase\Test
 	public function testSignature()
 	{
 		$plaintext = Rhymix\Framework\Security::getRandom();
+		config('crypto.authentication_key', Rhymix\Framework\Security::getRandom());
 		
 		$signature = Rhymix\Framework\Security::createSignature($plaintext);
 		$this->assertRegexp('/^[a-zA-Z0-9-_]{40}$/', $signature);

--- a/tests/unit/framework/SecurityTest.php
+++ b/tests/unit/framework/SecurityTest.php
@@ -55,6 +55,17 @@ class SecurityTest extends \Codeception\TestCase\Test
 		$this->assertEquals(false, $decrypted);
 	}
 	
+	public function testSignature()
+	{
+		$plaintext = Rhymix\Framework\Security::getRandom();
+		
+		$signature = Rhymix\Framework\Security::createSignature($plaintext);
+		$this->assertRegexp('/^[a-zA-Z0-9-_]{40}$/', $signature);
+		$this->assertEquals(true, Rhymix\Framework\Security::verifySignature($plaintext, $signature));
+		$this->assertEquals(false, Rhymix\Framework\Security::verifySignature($plaintext, $signature . 'x'));
+		$this->assertEquals(false, Rhymix\Framework\Security::verifySignature($plaintext, 'x' . $signature));
+	}
+	
 	public function testGetRandom()
 	{
 		$this->assertRegExp('/^[0-9a-zA-Z]{32}$/', Rhymix\Framework\Security::getRandom());


### PR DESCRIPTION
아래의 PR들을 머지합니다.

- xpressengine/xe-core#887 첨부 용량 제한에 소수점 사용 가능하게
- xpressengine/xe-core#1817 about_reset_auth_mail 대만어(zh-TW) 번역
- xpressengine/xe-core#1831 게시판 상담글 조회 권한 추가
- xpressengine/xe-core#1891 "다른 레이아웃 설치" 다운로드 이미지 경로 수정
- xpressengine/xe-core#1939 setQuery() 함수에서 HTTPS 처리 개선

XE의 Password 클래스에 추가된 위변조 방지 전자서명 관련 함수들을 라이믹스에도 적용합니다.

그 밖의 패치들은 라이믹스에는 해당되지 않는 것으로 보입니다.