### PR TITLE
태블릿 설정여부와 상관없이 모바일최적화 버튼이 뜨는 문제 고침

### DIFF
--- a/classes/module/ModuleHandler.class.php
+++ b/classes/module/ModuleHandler.class.php
@@ -780,7 +780,9 @@ class ModuleHandler extends Handler
 				'dispLayoutPreviewWithModule' => 1
 		);
 		$db_use_mobile = Mobile::isMobileEnabled();
-		if($type == "view" && $this->module_info->use_mobile == "Y" && Mobile::isMobileCheckByAgent() && !isset($skipAct[Context::get('act')]) && $db_use_mobile === true)
+		$tablet_use = Rhymix\Framework\UA::isTablet();
+		$config_talbet_use = config('mobile.tablets');
+		if($type == "view" && $this->module_info->use_mobile == "Y" && Mobile::isMobileCheckByAgent() && !isset($skipAct[Context::get('act')]) && $db_use_mobile === true && ($tablet_use === true && $config_talbet_use === false) === false)
 		{
 			global $lang;
 			$header = '<style>div.xe_mobile{opacity:0.7;margin:1em 0;padding:.5em;background:#333;border:1px solid #666;border-left:0;border-right:0}p.xe_mobile{text-align:center;margin:1em 0}a.xe_mobile{color:#ff0;font-weight:bold;font-size:24px}@media only screen and (min-width:500px){a.xe_mobile{font-size:15px}}</style>';

--- a/classes/module/ModuleHandler.class.php
+++ b/classes/module/ModuleHandler.class.php
@@ -781,8 +781,8 @@ class ModuleHandler extends Handler
 		);
 		$db_use_mobile = Mobile::isMobileEnabled();
 		$tablet_use = Rhymix\Framework\UA::isTablet();
-		$config_talbet_use = config('mobile.tablets');
-		if($type == "view" && $this->module_info->use_mobile == "Y" && Mobile::isMobileCheckByAgent() && !isset($skipAct[Context::get('act')]) && $db_use_mobile === true && ($tablet_use === true && $config_talbet_use === false) === false)
+		$config_telbet_use = config('mobile.tablets');
+		if($type == "view" && $this->module_info->use_mobile == "Y" && Mobile::isMobileCheckByAgent() && !isset($skipAct[Context::get('act')]) && $db_use_mobile === true && ($tablet_use === true && $config_telbet_use === false) === false)
 		{
 			global $lang;
 			$header = '<style>div.xe_mobile{opacity:0.7;margin:1em 0;padding:.5em;background:#333;border:1px solid #666;border-left:0;border-right:0}p.xe_mobile{text-align:center;margin:1em 0}a.xe_mobile{color:#ff0;font-weight:bold;font-size:24px}@media only screen and (min-width:500px){a.xe_mobile{font-size:15px}}</style>';


### PR DESCRIPTION
태블릿 설정여부와 상관없이 모바일 최적화 버튼이 뜨는 문제점이 있었습니다.

태블릿을 PC사용자들이 보는 화면처럼 뜨는 과정에서 모바일으로 최적화 하기 버튼으로 인해 다음과 같은 문제가 발생했습니다.

이를 해결하는 PR입니다.

![slack_for_ios_upload](https://cloud.githubusercontent.com/assets/4381756/17479673/c521ce24-5dae-11e6-92b7-26a6035e5c57.jpg)
