### PR TITLE
Grant 정보 캐싱 개선 (#584 보완)

### DIFF
--- a/modules/module/module.admin.controller.php
+++ b/modules/module/module.admin.controller.php
@@ -352,6 +352,8 @@ class moduleAdminController extends module
 				if(!$output->toBool()) return $output;
 			}
 		}
+		
+		Rhymix\Framework\Cache::delete("site_and_module:module_grants:$module_srl");
 		$this->setMessage('success_registed');
 	}
 
@@ -632,7 +634,10 @@ class moduleAdminController extends module
 				}
 			}
 		}
+		
+		Rhymix\Framework\Cache::delete("site_and_module:module_grants:$module_srl");
 		$this->setMessage('success_registed');
+		
 		if(!in_array(Context::getRequestMethod(),array('XMLRPC','JSON')))
 		{
 			if(Context::get('success_return_url'))

--- a/modules/module/module.controller.php
+++ b/modules/module/module.controller.php
@@ -827,6 +827,7 @@ class moduleController extends module
 			$output = executeQueryArray('module.insertSiteAdmin', $args);
 			if(!$output->toBool()) return $output;
 		}
+		Rhymix\Framework\Cache::delete("site_and_module:site_admins:$site_srl");
 		return new Object();
 	}
 
@@ -842,8 +843,11 @@ class moduleController extends module
 			$member_info = $oMemberModel->getMemberInfoByEmailAddress($admin_id);
 		else
 			$member_info = $oMemberModel->getMemberInfoByUserID($admin_id);
-
+		
 		if(!$member_info->member_srl) return;
+		
+		Rhymix\Framework\Cache::delete("site_and_module:module_admins:$module_srl");
+		
 		$args = new stdClass();
 		$args->module_srl = $module_srl;
 		$args->member_srl = $member_info->member_srl;
@@ -864,6 +868,9 @@ class moduleController extends module
 			$member_info = $oMemberModel->getMemberInfoByUserID($admin_id);
 			if($member_info->member_srl) $args->member_srl = $member_info->member_srl;
 		}
+		
+		Rhymix\Framework\Cache::delete("site_and_module:module_admins:$module_srl");
+		
 		return executeQuery('module.deleteAdminId', $args);
 	}
 
@@ -1046,6 +1053,8 @@ class moduleController extends module
 				executeQuery('module.insertModuleGrant', $args);
 			}
 		}
+		
+		Rhymix\Framework\Cache::delete("site_and_module:module_grants:$module_srl");
 	}
 
 	/**
@@ -1055,7 +1064,10 @@ class moduleController extends module
 	{
 		$args = new stdClass();
 		$args->module_srl = $module_srl;
-		return executeQuery('module.deleteModuleGrants', $args);
+		$output = executeQuery('module.deleteModuleGrants', $args);
+		
+		Rhymix\Framework\Cache::delete("site_and_module:module_grants:$module_srl");
+		return $output;
 	}
 
 	/**

--- a/modules/module/queries/getModuleAdmin.xml
+++ b/modules/module/queries/getModuleAdmin.xml
@@ -3,7 +3,7 @@
         <table name="module_admins" />
     </tables>
     <conditions>
-        <condition operation="equal" column="module_srl" var="module_srl" notnull="notnull" filter="number" />
-        <condition operation="equal" column="member_srl" var="member_srl" notnull="notnull" pipe="and" />
+        <condition operation="equal" column="module_srl" var="module_srl" filter="number" />
+        <condition operation="equal" column="member_srl" var="member_srl" pipe="and" />
     </conditions>
 </query>

--- a/modules/module/queries/isSiteAdmin.xml
+++ b/modules/module/queries/isSiteAdmin.xml
@@ -6,7 +6,7 @@
         <column name="member_srl" />
     </columns>
     <conditions>
-        <condition operation="equal" column="site_srl" var="site_srl" notnull="notnull" />
-        <condition operation="equal" column="member_srl" var="member_srl" notnull="notnull" pipe="and" />
+        <condition operation="equal" column="site_srl" var="site_srl" filter="number" />
+        <condition operation="equal" column="member_srl" var="member_srl" pipe="and" />
     </conditions>
 </query>


### PR DESCRIPTION
#584 에서 `getGrant()` 전체를 캐싱하니 회원의 소속그룹이 변경되어도 새 권한이 반영되지 않는 문제가 있어서, DB 쿼리가 많이 발생하는 `isSiteAdmin` (사이트 관리자 여부 확인), `isModuleAdmin` (모듈 관리자 여부 확인), `getModuleGrants` (모듈별 권한 불러오기) 부분을 각각 따로 캐싱하도록 변경합니다.

관리자 이외의 회원이 글을 조회할 때 발생하는 쿼리 수를 크게 줄일 수 있을 것으로 예상됩니다.