### PR TITLE
템플릿 핸들러 일부 기능 개선

### DIFF
--- a/classes/template/TemplateHandler.class.php
+++ b/classes/template/TemplateHandler.class.php
@@ -235,7 +235,7 @@ class TemplateHandler
 		$buff = $this->_parseInline($buff);
 
 		// include, unload/load, import
-		$buff = preg_replace_callback('/{(@[\s\S]+?|(?=\$\w+|_{1,2}[A-Z]+|[!\(+-]|\w+(?:\(|::)|\d+|[\'"].*?[\'"]).+?)}|<(!--[#%])?(include|import|(un)?load(?(4)|(?:_js_plugin)?)|config)(?(2)\(["\']([^"\']+)["\'])(.*?)(?(2)\)--|\/)>|<!--(@[a-z@]*)([\s\S]*?)-->(\s*)/', array($this, '_parseResource'), $buff);
+		$buff = preg_replace_callback('/{(@[\s\S]+?|(?=[\$\\\\]\w+|_{1,2}[A-Z]+|[!\(+-]|\w+(?:\(|::)|\d+|[\'"].*?[\'"]).+?)}|<(!--[#%])?(include|import|(un)?load(?(4)|(?:_js_plugin)?)|config)(?(2)\(["\']([^"\']+)["\'])(.*?)(?(2)\)--|\/)>|<!--(@[a-z@]*)([\s\S]*?)-->(\s*)/', array($this, '_parseResource'), $buff);
 
 		// remove block which is a virtual tag
 		$buff = preg_replace('@</?block\s*>@is', '', $buff);
@@ -824,7 +824,17 @@ class TemplateHandler
 		{
 			return '';
 		}
-		return preg_replace('@(?<!::|\\\\|(?<!eval\()\')\$([a-z]|_[a-z0-9])@i', '\$__Context->$1', $php);
+		
+		return preg_replace_callback('@(?<!::|\\\\|(?<!eval\()\')\$([a-z_][a-z0-9_]*)@i', function($matches) {
+			if (preg_match('/^(?:GLOBALS|_SERVER|_COOKIE|_GET|_POST|_REQUEST|__Context)$/', $matches[1]))
+			{
+				return '$' . $matches[1];
+			}
+			else
+			{
+				return '$__Context->' . $matches[1];
+			}
+		}, $php);
 	}
 
 }

--- a/classes/template/TemplateHandler.class.php
+++ b/classes/template/TemplateHandler.class.php
@@ -123,7 +123,7 @@ class TemplateHandler
 		// if target file does not exist exit
 		if(!$this->file || !file_exists($this->file))
 		{
-			return "Err : '{$this->file}' template file does not exists.";
+			return escape("Template not found: ${tpl_path}${tpl_filename}" . ($tpl_file ? " (${tpl_file})" : ''));
 		}
 
 		// for backward compatibility
@@ -184,8 +184,7 @@ class TemplateHandler
 		// if target file does not exist exit
 		if(!$this->file || !file_exists($this->file))
 		{
-			Context::close();
-			exit("Cannot find the template file: '{$this->file}'");
+			return escape("Template not found: ${tpl_path}${tpl_filename}");
 		}
 
 		return $this->parse();

--- a/classes/template/TemplateHandler.class.php
+++ b/classes/template/TemplateHandler.class.php
@@ -123,7 +123,9 @@ class TemplateHandler
 		// if target file does not exist exit
 		if(!$this->file || !file_exists($this->file))
 		{
-			return escape("Template not found: ${tpl_path}${tpl_filename}" . ($tpl_file ? " (${tpl_file})" : ''));
+			$error_message = "Template not found: ${tpl_path}${tpl_filename}" . ($tpl_file ? " (${tpl_file})" : '');
+			trigger_error($error_message, \E_USER_WARNING);
+			return escape($error_message);
 		}
 
 		// for backward compatibility
@@ -184,7 +186,9 @@ class TemplateHandler
 		// if target file does not exist exit
 		if(!$this->file || !file_exists($this->file))
 		{
-			return escape("Template not found: ${tpl_path}${tpl_filename}");
+			$error_message = "Template not found: ${tpl_path}${tpl_filename}";
+			trigger_error($error_message, \E_USER_WARNING);
+			return escape($error_message);
 		}
 
 		return $this->parse();

--- a/classes/template/TemplateHandler.class.php
+++ b/classes/template/TemplateHandler.class.php
@@ -11,11 +11,9 @@
  */
 class TemplateHandler
 {
-	private $compiled_path = 'files/cache/template_compiled/'; ///< path of compiled caches files
 	private $path = NULL; ///< target directory
 	private $filename = NULL; ///< target filename
 	private $file = NULL; ///< target file (fullpath)
-	private $xe_path = NULL;  ///< XpressEngine base path
 	private $web_path = NULL; ///< tpl file web path
 	private $compiled_file = NULL; ///< tpl file web path
 	private $config = NULL;
@@ -29,9 +27,8 @@ class TemplateHandler
 	 */
 	public function __construct()
 	{
-		$this->xe_path = rtrim(preg_replace('/([^\.^\/]+)\.php$/i', '', $_SERVER['SCRIPT_NAME']), '/');
-		$this->compiled_path = _XE_PATH_ . $this->compiled_path;
-		$this->config = new stdClass();
+		$this->config = new stdClass;
+		$this->handler_mtime = filemtime(__FILE__);
 	}
 
 	/**
@@ -93,16 +90,12 @@ class TemplateHandler
 		$this->filename = $tpl_filename;
 		$this->file = $tpl_file;
 
-		$this->web_path = $this->xe_path . '/' . ltrim(preg_replace('@^' . preg_quote(_XE_PATH_, '@') . '|\./@', '', $this->path), '/');
+		// set absolute URL of template path
+		$this->web_path = \RX_BASEURL . ltrim(preg_replace('@^' . preg_quote(\RX_BASEDIR, '@') . '|\./@', '', $this->path), '/');
 
-		// get compiled file name
-		$hash = md5($this->file . __XE_VERSION__);
-		$this->compiled_file = "{$this->compiled_path}{$hash}.compiled.php";
-
-		// compare various file's modified time for check changed
-		$this->handler_mtime = filemtime(__FILE__);
-
-		$skip = array('');
+		// set compiled file name
+		$converted_path = str_replace(array('\\', '..'), array('/', 'dotdot'), ltrim($this->file, './'));
+		$this->compiled_file = \RX_BASEDIR . 'files/cache/template/' . $converted_path . '.php'; 
 	}
 
 	/**
@@ -134,8 +127,7 @@ class TemplateHandler
 			self::$rootTpl = $this->file;
 		}
 
-		$source_template_mtime = filemtime($this->file);
-		$latest_mtime = $source_template_mtime > $this->handler_mtime ? $source_template_mtime : $this->handler_mtime;
+		$latest_mtime = max(filemtime($this->file), $this->handler_mtime);
 		
 		// make compiled file
 		if(!file_exists($this->compiled_file) || filemtime($this->compiled_file) < $latest_mtime)
@@ -808,7 +800,7 @@ class TemplateHandler
 			}
 		}
 
-		$path = preg_replace('/^' . preg_quote(_XE_PATH_, '/') . '/', '', $path);
+		$path = preg_replace('/^' . preg_quote(\RX_BASEDIR, '/') . '/', '', $path);
 
 		return $path;
 	}

--- a/tests/unit/classes/TemplateHandlerTest.php
+++ b/tests/unit/classes/TemplateHandlerTest.php
@@ -276,6 +276,31 @@ class TemplateHandlerTest extends \Codeception\TestCase\Test
                 '<input>asdf src="../img/img.gif" asdf</input>',
                 '?><input>asdf src="../img/img.gif" asdf</input>'
             ),
+			// Rhymix improvements (PR #604)
+            array(
+                '<span>{$_SERVER["REMOTE_ADDR"]}</span>',
+                '?><span><?php echo $_SERVER["REMOTE_ADDR"] ?></span>'
+            ),
+            array(
+                '<span>{escape($_COOKIE[$var], false)}</span>',
+                '?><span><?php echo escape($_COOKIE[$__Context->var], false) ?></span>'
+            ),
+            array(
+                '<span>{$GLOBALS[$__Context->rhymix->rules]}</span>',
+                '?><span><?php echo $GLOBALS[$__Context->rhymix->rules] ?></span>'
+            ),
+            array(
+                '<span>{$FOOBAR}</span>',
+                '?><span><?php echo $__Context->FOOBAR ?></span>'
+            ),
+            array(
+                '<span>{RX_BASEDIR}</span>',
+                '?><span>{RX_BASEDIR}</span>'
+            ),
+            array(
+                '<span>{\RX_BASEDIR}</span>',
+                '?><span><?php echo \RX_BASEDIR ?></span>'
+            ),
         );
 
         foreach ($tests as $test)


### PR DESCRIPTION
첫째, 템플릿 파일을 찾을 수 없을 때 무조건 종료하는 문제를 해결합니다. (#579)

- 종료하지 않고 Warning만 출력합니다.
- 존재하지 않는 템플릿 파일의 정확한 위치를 표시합니다.

둘째, `$_SERVER` 등의 초전역변수와 `\RX_VERSION` 등의 상수를 템플릿에서 사용할 수 있도록 합니다.

- #174 에서 시도되었다가 #180 과 같이 예상치 못한 부작용으로 취소된 기능입니다.
- 과거에 문제가 발생했던 부분을 분석하여, 동일한 문제가 재발하지 않는 것을 확인했습니다.
- 상수는 `\RX_VERSION`처럼 맨 앞에 백슬래시를 붙여서 사용해야 합니다.

셋째, 템플릿과 관련된 경로 처리 방식을 개선했습니다.

- 컴파일된 템플릿을 `af3d864491ea3214985da0dcdaeac8c5.php`처럼 난해한 이름의 캐시파일에 저장하지 않고 `files/cache/template` 아래에 원본 파일의 폴더 구조 및 파일명을 그대로 재현하여, 오류 발생시 원본 파일이 무엇인지 쉽게 파악할 수 있도록 했습니다.
- 원본 파일이 변경되거나 템플릿 핸들러 자체의 소스가 변경되면 자동으로 파악하고 다시 컴파일하는 것은 예전과 같습니다.
- 주먹구구식 경로 파악 방식을 라이믹스에서 기본 제공하는 `\RX_BASEDIR` 및 `\RX_BASEURL` 상수로 대체하여 깔끔하게 정리했습니다.