### PR TITLE
#632 조회수 설정이 제대로 적용되지 않는 문제 수정

### DIFF
--- a/modules/admin/admin.admin.controller.php
+++ b/modules/admin/admin.admin.controller.php
@@ -700,10 +700,11 @@ class adminAdminController extends admin
 		}
 		
 		// Thumbnail settings
-		$args = new stdClass;
-		$args->thumbnail_type = $vars->thumbnail_type === 'ratio' ? 'ratio' : 'crop';
+		$oDocumentModel = getModel('document');
+		$document_config = $oDocumentModel->getDocumentConfig();
+		$document_config->thumbnail_type = $vars->thumbnail_type === 'ratio' ? 'ratio' : 'crop';
 		$oModuleController = getController('module');
-		$oModuleController->insertModuleConfig('document', $args);
+		$oModuleController->insertModuleConfig('document', $document_config);
 		
 		// Other settings
 		Rhymix\Framework\Config::set('use_rewrite', $vars->use_rewrite === 'Y');

--- a/modules/document/document.model.php
+++ b/modules/document/document.model.php
@@ -928,7 +928,6 @@ class documentModel extends document
 			$config = $oModuleModel->getModuleConfig('document');
 
 			if(!$config) $config = new stdClass();
-			if(!$config->view_count_option) $config->view_count_option = 'once';
 			$GLOBALS['__document_config__'] = $config;
 		}
 		return $GLOBALS['__document_config__'];


### PR DESCRIPTION
#632 조회수 설정 관련 버그를 수정합니다.

- 시스템 설정 / 고급 설정을 저장하면 조회수 설정이 초기화되는 문제를 수정합니다.
- 조회수 설정에 잘못된 값이 들어가면 기본값(중복 방지)으로 인식하지 않고 새로고침할 때마다 조회수가 증가하는 문제를 수정합니다. 라이믹스에서 인식하지 못하는 값은 기본값으로 봅니다.
- 세션 상태에 따라 조회수가 이상하게 집계되는 문제를 수정합니다.
- 조회수 증가시마다 불필요하게 캐시를 갱신하는 코드를 제거합니다.