### PR TITLE
HTMLFilter 기능 개선

### DIFF
--- a/common/defaults/config.php
+++ b/common/defaults/config.php
@@ -103,6 +103,7 @@ return array(
 	'mediafilter' => array(
 		'iframe' => array(),
 		'object' => array(),
+		'classes' => array(),
 	),
 	'mobile' => array(
 		'enabled' => true,

--- a/modules/admin/admin.admin.controller.php
+++ b/modules/admin/admin.admin.controller.php
@@ -690,6 +690,14 @@ class adminAdminController extends admin
 		natcasesort($object_whitelist);
 		Rhymix\Framework\Config::set('mediafilter.object', array_values($object_whitelist));
 		
+		// HTML classes
+		$classes = $vars->mediafilter_classes;
+		$classes = array_filter(array_map('trim', preg_split('/[\r\n]/', $classes)), function($item) {
+			return preg_match('/^[a-zA-Z0-9_-]+$/u', $item);
+		});
+		natcasesort($classes);
+		Rhymix\Framework\Config::set('mediafilter.classes', array_values($classes));
+		
 		// Remove old embed filter
 		$config = Rhymix\Framework\Config::getAll();
 		unset($config['embedfilter']);

--- a/modules/admin/admin.admin.view.php
+++ b/modules/admin/admin.admin.view.php
@@ -490,6 +490,7 @@ class adminAdminView extends admin
 		// Load embed filter.
 		context::set('mediafilter_iframe', implode(PHP_EOL, Rhymix\Framework\Filters\MediaFilter::getIframeWhitelist()));
 		context::set('mediafilter_object', implode(PHP_EOL, Rhymix\Framework\Filters\MediaFilter::getObjectWhitelist()));
+		context::set('mediafilter_classes', implode(PHP_EOL, Rhymix\Framework\Config::get('mediafilter.classes') ?: array()));
 		
 		// Admin IP access control
 		$allowed_ip = Rhymix\Framework\Config::get('admin.allow');

--- a/modules/admin/tpl/config_security.html
+++ b/modules/admin/tpl/config_security.html
@@ -20,6 +20,12 @@
 			</div>
 		</div>
 		<div class="x_control-group">
+			<label class="x_control-label" for="mediafilter_classes">HTML class</label>
+			<div class="x_controls" style="margin-right:14px">
+				<textarea name="mediafilter_classes" id="mediafilter_classes" rows="4" style="width:100%;">{$mediafilter_classes}</textarea>
+			</div>
+		</div>
+		<div class="x_control-group">
 			<label class="x_control-label" for="admin_allowed_ip">{$lang->admin_ip_allow}</label>
 			<div class="x_controls">
 				<textarea name="admin_allowed_ip" id="admin_allowed_ip" rows="4" cols="42" placeholder="{$remote_addr} ({$lang->local_ip_address})" style="margin-right:10px">{$admin_allowed_ip}</textarea>

--- a/tests/unit/framework/filters/HTMLFilterTest.php
+++ b/tests/unit/framework/filters/HTMLFilterTest.php
@@ -59,6 +59,7 @@ class HTMLFilterTest extends \Codeception\TestCase\Test
 			)
 		);
 		
+		config('mediafilter.classes', array());
 		foreach ($tests as $test)
 		{
 			$this->assertEquals($test[1], Rhymix\Framework\Filters\HTMLFilter::clean($test[0]));
@@ -142,6 +143,19 @@ class HTMLFilterTest extends \Codeception\TestCase\Test
 		$this->assertEquals($target, Rhymix\Framework\Filters\HTMLFilter::clean($source));
 	}
 	
+	public function testHTMLFilterAllowedClasses()
+	{
+		config('mediafilter.classes', array());
+		$source = '<p class="mytest">Hello World</p>';
+		$target = '<p>Hello World</p>';
+		$this->assertEquals($target, Rhymix\Framework\Filters\HTMLFilter::clean($source));
+		
+		config('mediafilter.classes', array('mytest'));
+		$source = '<p class="mytest">Hello World</p>';
+		$target = '<p class="mytest">Hello World</p>';
+		$this->assertEquals($target, Rhymix\Framework\Filters\HTMLFilter::clean($source));
+	}
+	
 	public function testHTMLFilterEditorComponent()
 	{
 		$source = '<img somekey="somevalue" otherkey="othervalue" onmouseover="alert(\'xss\');" editor_component="component_name" src="./foo/bar.jpg" alt="My Picture" style="width:320px;height:240px;" width="320" height="240" />';
@@ -159,6 +173,29 @@ class HTMLFilterTest extends \Codeception\TestCase\Test
 		$source = '<div editor_component="component_name" style="width:400px;height:300px;" draggable dropzone contextmenu="whatever"></div>';
 		$target = '<div editor_component="component_name" style="width:400px;height:300px;"></div>';
 		$this->assertEquals($target, Rhymix\Framework\Filters\HTMLFilter::clean($source));
+		
+		$source = '<img somekey="somevalue" otherkey="othervalue" onmouseover="alert(\'xss\');" editor_component="component_name" src="./foo/bar.jpg" alt="My Picture" style="width:320px;height:240px;" width="320" height="240" />';
+		$target = '<img src="./foo/bar.jpg" alt="My Picture" style="width:320px;height:240px;" width="320" height="240" />';
+		$this->assertEquals($target, Rhymix\Framework\Filters\HTMLFilter::clean($source, false));
+		
+		$source = '<img somekey="somevalue" otherkey="othervalue" onkeypress="alert(\'xss\');" editor_component="component_name" />';
+		$target = '';
+		$this->assertEquals($target, Rhymix\Framework\Filters\HTMLFilter::clean($source, false));
+	}
+	
+	public function testHTMLFilterWidgetCode()
+	{
+		$source = '<p>Hello World</p><img class="zbxe_widget_output" widget="content" skin="default" colorset="white" widget_sequence="1234" widget_cache="1m" content_type="document" module_srls="56" list_type="normal" tab_type="none" markup_type="table" page_count="1" option_view="title,regdate,nickname" show_browser_title="Y" show_comment_count="Y" show_trackback_count="Y" show_category="Y" show_icon="Y" show_secret="N" order_target="regdate" order_type="desc" thumbnail_type="crop" />';
+		$target = '<p>Hello World</p>';
+		$this->assertEquals($target, Rhymix\Framework\Filters\HTMLFilter::clean($source));
+		
+		$source = '<p>Hello World</p><img class="zbxe_widget_output" widget="content" skin="default" colorset="white" widget_sequence="1234" widget_cache="1m" content_type="document" module_srls="56" list_type="normal" tab_type="none" markup_type="table" page_count="1" option_view="title,regdate,nickname" show_browser_title="Y" show_comment_count="Y" show_trackback_count="Y" show_category="Y" show_icon="Y" show_secret="N" order_target="regdate" order_type="desc" thumbnail_type="crop" />';
+		$target = '<p>Hello World</p><img widget="content" skin="default" colorset="white" widget_sequence="1234" widget_cache="1m" content_type="document" module_srls="56" list_type="normal" tab_type="none" markup_type="table" page_count="1" option_view="title,regdate,nickname" show_browser_title="Y" show_comment_count="Y" show_trackback_count="Y" show_category="Y" show_icon="Y" show_secret="N" order_target="regdate" order_type="desc" thumbnail_type="crop" src="" class="zbxe_widget_output" alt="" />';
+		$this->assertEquals($target, Rhymix\Framework\Filters\HTMLFilter::clean($source, true, true));
+		
+		$source = '<p>Hello World</p><img class="zbxe_widget_output" widget="content" onmouseover="alert(\'xss\');" skin="default" colorset="white" widget_sequence="1234" widget_cache="1m" content_type="document" module_srls="56" list_type="normal" tab_type="none" markup_type="table" page_count="1" option_view="title,regdate,nickname" show_browser_title="Y" show_comment_count="Y" show_trackback_count="Y" show_category="Y" show_icon="Y" show_secret="N" order_target="regdate" order_type="desc" thumbnail_type="crop" />';
+		$target = '<p>Hello World</p><img widget="content" skin="default" colorset="white" widget_sequence="1234" widget_cache="1m" content_type="document" module_srls="56" list_type="normal" tab_type="none" markup_type="table" page_count="1" option_view="title,regdate,nickname" show_browser_title="Y" show_comment_count="Y" show_trackback_count="Y" show_category="Y" show_icon="Y" show_secret="N" order_target="regdate" order_type="desc" thumbnail_type="crop" src="" class="zbxe_widget_output" alt="" />';
+		$this->assertEquals($target, Rhymix\Framework\Filters\HTMLFilter::clean($source, true, true));
 	}
 	
 	public function testHTMLFilterUserContentID()


### PR DESCRIPTION
- e9bfb0e 에서 클래스 사용을 금지한 것 때문에 클래스에 의존하는 각주 등 일부 기능이 오작동할 가능성이 있으므로, iframe이나 object와 마찬가지로 허용할 class 목록을 관리자가 지정할 수 있도록 변경
- 필터링시 에디터 컴포넌트 및 위젯 코드 허용 여부를 설정할 수 있도록 변경
- XE와 달리 위젯 코드가 기본으로 허용되던 보안취약점 수정
- 관련 유닛 테스트 보강