### PR TITLE
유닛 테스트에서 PHP 5.4를 제거하고 PHP 7.1을 추가

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,21 @@
 language: php
 php:
-- 5.4
 - 5.5
 - 5.6
 - 7.0
+- 7.1
 - hhvm
 sudo: false
 before_script:
 - npm install grunt grunt-cli grunt-contrib-jshint grunt-contrib-csslint grunt-phplint --save-dev
 - mysql -u root -e "CREATE DATABASE rhymix"
 - mysql -u root -e "SET PASSWORD FOR 'travis'@'localhost' = PASSWORD('travis')"
-- if [[ $TRAVIS_PHP_VERSION != "5.4" && $TRAVIS_PHP_VERSION != "hhvm" ]]; then php -S localhost:8000 & fi
-- if [[ $TRAVIS_PHP_VERSION == "5.4" ]]; then wget http://codeception.com/releases/2.0.16/codecept.phar; fi
-- if [[ ! -f codecept.phar ]]; then wget http://codeception.com/releases/2.1.6/codecept.phar; fi
+- if [[ $TRAVIS_PHP_VERSION != "hhvm" ]]; then php -S localhost:8000 & fi
+- wget http://codeception.com/releases/2.1.11/codecept.phar
 script:
-- if [[ -s codecept.phar ]]; then php codecept.phar build; fi
-- if [[ -s codecept.phar && $TRAVIS_PHP_VERSION == "hhvm" ]]; then php codecept.phar run -d --fail-fast --env travis --skip install; fi
-- if [[ -s codecept.phar && $TRAVIS_PHP_VERSION == "5.4" ]]; then php codecept.phar run -d --fail-fast --env travis --skip install; fi
-- if [[ -s codecept.phar && $TRAVIS_PHP_VERSION != "5.4" && $TRAVIS_PHP_VERSION != "hhvm" ]]; then php codecept.phar run -d --fail-fast --env travis; fi
+- php codecept.phar build
+- if [[ $TRAVIS_PHP_VERSION == "hhvm" ]]; then php codecept.phar run -d --fail-fast --env travis --skip install; fi
+- if [[ $TRAVIS_PHP_VERSION != "hhvm" ]]; then php codecept.phar run -d --fail-fast --env travis; fi
 - grunt lint
 notifications:
   email: false

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -42,6 +42,7 @@ module.exports = function(grunt) {
 					'box-sizing' : false,
 					'font-sizes' : false,
 					'duplicate-background-images' : false,
+					'order-alphabetical' : false,
 					'ids' : false,
 					'important' : false,
 					'overqualified-elements' : false,

--- a/tests/unit/framework/StorageTest.php
+++ b/tests/unit/framework/StorageTest.php
@@ -362,7 +362,7 @@ class StorageTest extends \Codeception\TestCase\Test
 		
 		if (strncasecmp(\PHP_OS, 'Win', 3) !== 0)
 		{
-			if (get_current_user() === exec('whoami'))
+			if (fileowner(__FILE__) == exec('id -u'))
 			{
 				$this->assertEquals('0022', $umask);
 			}


### PR DESCRIPTION
PHP 5.4 호환을 위해 남아 있던 지저분한 설정을 들어내고, PHP 7.1 테스트를 추가합니다.