### PR TITLE
빈 폴더 자동 삭제 및 일괄 삭제

### DIFF
--- a/classes/file/FileHandler.class.php
+++ b/classes/file/FileHandler.class.php
@@ -208,15 +208,7 @@ class FileHandler
 	 */
 	public static function removeBlankDir($path)
 	{
-		$path = self::getRealPath($path);
-		if (Rhymix\Framework\Storage::isEmptyDirectory($path))
-		{
-			return Rhymix\Framework\Storage::deleteDirectory($path);
-		}
-		else
-		{
-			return false;
-		}
+		return Rhymix\Framework\Storage::deleteEmptyDirectory(self::getRealPath($path), false);
 	}
 
 	/**

--- a/common/framework/storage.php
+++ b/common/framework/storage.php
@@ -715,6 +715,35 @@ class Storage
 	}
 	
 	/**
+	 * Delete a directory only if it is empty.
+	 * 
+	 * @param string $dirname
+	 * @param bool $delete_empty_parents (optional)
+	 * @return bool
+	 */
+	public static function deleteEmptyDirectory($dirname, $delete_empty_parents = false)
+	{
+		if (!self::isDirectory($dirname) || !self::isEmptyDirectory($dirname))
+		{
+			return false;
+		}
+		
+		$result = @rmdir($dirname);
+		if (!$result)
+		{
+			return false;
+		}
+		else
+		{
+			if ($delete_empty_parents)
+			{
+				self::deleteEmptyDirectory(dirname($dirname), true);
+			}
+			return true;
+		}
+	}
+	
+	/**
 	 * Get the current umask.
 	 * 
 	 * @return int

--- a/common/framework/storage.php
+++ b/common/framework/storage.php
@@ -723,6 +723,7 @@ class Storage
 	 */
 	public static function deleteEmptyDirectory($dirname, $delete_empty_parents = false)
 	{
+		$dirname = rtrim($dirname, '/\\');
 		if (!self::isDirectory($dirname) || !self::isEmptyDirectory($dirname))
 		{
 			return false;

--- a/common/scripts/clean_empty_dirs.php
+++ b/common/scripts/clean_empty_dirs.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * This script deletes empty directories under the 'files' directory.
+ * 
+ * It may be useful when your web host imposes a hard limit on the number of
+ * inodes, or when your backups take too long due to the large number of
+ * unused directories.
+ * 
+ * This script only works on Unix-like operating systems where the 'find'
+ * command is available.
+ */
+require_once __DIR__ . '/common.php';
+
+// Initialize the exit status.
+$exit_status = 0;
+
+// Delete empty directories in the attachment directory.
+passthru(sprintf('find %s -type d -empty -delete', escapeshellarg(RX_BASEDIR . 'files/attach')), $result);
+if ($result == 0)
+{
+	echo "Successfully deleted all empty directories under files/attach.\n";
+}
+else
+{
+	echo "Error while deleting empty directories under files/attach.\n";
+	$exit_status = $result;
+}
+
+// Delete empty directories in the member extra info directory.
+passthru(sprintf('find %s -type d -empty -delete', escapeshellarg(RX_BASEDIR . 'files/member_extra_info')), $result);
+if ($result == 0)
+{
+	echo "Successfully deleted all empty directories under files/member_extra_info.\n";
+}
+else
+{
+	echo "Error while deleting empty directories under files/member_extra_info.\n";
+	$exit_status = $result;
+}
+
+// Delete empty directories in the thumbnails directory.
+passthru(sprintf('find %s -type d -empty -delete', escapeshellarg(RX_BASEDIR . 'files/thumbnails')), $result);
+if ($result == 0)
+{
+	echo "Successfully deleted all empty directories under files/thumbnails.\n";
+}
+else
+{
+	echo "Error while deleting empty directories under files/thumbnails.\n";
+	$exit_status = $result;
+}
+
+// Set the exit status if there were any errors.
+if ($exit_status != 0)
+{
+	exit($exit_status);
+}

--- a/common/scripts/clean_garbage_files.php
+++ b/common/scripts/clean_garbage_files.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * This script deletes files that were not properly uploaded.
+ * 
+ * Files can remain in an invalid status for two reasons: 1) a user abandons
+ * a document or comment after uploading files; or 2) a chunked upload is
+ * aborted without the server having any opportunity to clean it up.
+ * These files can obviously take up a lot of disk space. In order to prevent
+ * them from accumulating too much, you should run this script at least once
+ * every few days.
+ */
+require_once __DIR__ . '/common.php';
+
+// Delete garbage files older than this number of days.
+$days = 10;
+
+// Initialize the exit status.
+$exit_status = 0;
+
+// Set the exit status if there were any errors.
+if ($exit_status != 0)
+{
+	exit($exit_status);
+}

--- a/common/scripts/clean_garbage_files.php
+++ b/common/scripts/clean_garbage_files.php
@@ -40,6 +40,11 @@ while (true)
 				$oFileController->deleteFile($file_info->file_srl);
 			}
 			$oDB->commit();
+			
+			if ($output->page_navigation && $output->page_navigation->total_count == count($output->data))
+			{
+				break;
+			}
 		}
 		else
 		{

--- a/common/scripts/clean_garbage_files.php
+++ b/common/scripts/clean_garbage_files.php
@@ -18,6 +18,74 @@ $days = 10;
 // Initialize the exit status.
 $exit_status = 0;
 
+// Initialize objects.
+$oDB = DB::getInstance();
+$oFileController = getController('file');
+
+// Find and delete files where isvalid = N.
+$args = new stdClass;
+$args->isvalid = 'N';
+$args->list_count = 50;
+$args->regdate_before = date('YmdHis', time() - ($days * 86400));
+while (true)
+{
+	$output = executeQueryArray('file.getFileList', $args);
+	if ($output->toBool())
+	{
+		if ($output->data)
+		{
+			$oDB->begin();
+			foreach ($output->data as $file_info)
+			{
+				$oFileController->deleteFile($file_info->file_srl);
+			}
+			$oDB->commit();
+		}
+		else
+		{
+			break;
+		}
+	}
+	else
+	{
+		echo "Error while deleting garbage files older than $days days.\n";
+		echo $output->getMessage() . "\n";
+		$exit_status = 11;
+		break;
+	}
+}
+if ($exit_status == 0)
+{
+	echo "Successfully deleted all garbage files older than $days days.\n";
+}
+
+// Find and delete temporary chunks.
+$dirname = RX_BASEDIR . 'files/attach/chunks';
+$threshold = time() - ($days * 86400);
+$chunks = Rhymix\Framework\Storage::readDirectory($dirname);
+if ($chunks)
+{
+	foreach ($chunks as $chunk)
+	{
+		if (@filemtime($chunk) < $threshold)
+		{
+			$result = Rhymix\Framework\Storage::delete($chunk);
+			if (!$result)
+			{
+				$exit_status = 12;
+			}
+		}
+	}
+}
+if ($exit_status == 0)
+{
+	echo "Successfully deleted aborted file chunks older than $days days.\n";
+}
+else
+{
+	echo "Error while deleting aborted file chunks older than $days days.\n";
+}
+
 // Set the exit status if there were any errors.
 if ($exit_status != 0)
 {

--- a/common/scripts/clean_old_notifications.php
+++ b/common/scripts/clean_old_notifications.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * This script deletes old notifications.
+ * 
+ * Notifications must be dismissed as quickly as possible in order to prevent
+ * the ncenterlite_notify table from becoming too large. For best performance,
+ * you should run this script at least once every few days.
+ */
+require_once __DIR__ . '/common.php';
+
+// Delete notifications older than this number of days.
+$days = 30;
+
+// Initialize the exit status.
+$exit_status = 0;
+
+// Execute the query.
+$args = new stdClass;
+$args->old_date = date('YmdHis', time() - ($days * 86400));
+$output = executeQuery('ncenterlite.deleteNotifyAll', $args);
+if ($output->toBool())
+{
+	echo "Successfully deleted all notifications older than $days days.\n";
+}
+else
+{
+	echo "Error while deleting notifications older than $days days.\n";
+	echo $output->getMessage() . "\n";
+	$exit_status = abs($output->getError());
+}
+
+// Set the exit status if there were any errors.
+if ($exit_status != 0)
+{
+	exit($exit_status);
+}

--- a/common/scripts/clean_old_notifications.php
+++ b/common/scripts/clean_old_notifications.php
@@ -27,7 +27,7 @@ else
 {
 	echo "Error while deleting notifications older than $days days.\n";
 	echo $output->getMessage() . "\n";
-	$exit_status = abs($output->getError());
+	$exit_status = 11;
 }
 
 // Set the exit status if there were any errors.

--- a/common/scripts/clean_old_thumbnails.php
+++ b/common/scripts/clean_old_thumbnails.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * This script deletes old thumbnails.
+ * 
+ * Thumbnails can take up a large amount of disk space and inodes if they are
+ * allowed to accumulate. Since most websites only need thumbnails for recent
+ * posts, it is okay to delete old thumbnails.
+ * 
+ * Do not run this script if you have a gallery-style module where visitors
+ * regularly view old posts. This will force thumbnails to be regenerated,
+ * increasing the server load and making your pages load slower.
+ * 
+ * This script only works on Unix-like operating systems where the 'find'
+ * command is available.
+ */
+require_once __DIR__ . '/common.php';
+
+// Delete thumbnails older than this number of days.
+$days = 90;
+
+// Initialize the exit status.
+$exit_status = 0;
+
+// Delete old thumbnails.
+passthru(sprintf('find %s -type f -mtime +%d -delete', escapeshellarg(RX_BASEDIR . 'files/thumbnails'), abs($days)), $result);
+if ($result == 0)
+{
+	echo "Successfully deleted all thumbnails older than $days days.\n";
+}
+else
+{
+	echo "Error while deleting thumbnails older than $days days.\n";
+	$exit_status = $result;
+}
+
+// Set the exit status if there were any errors.
+if ($exit_status != 0)
+{
+	exit($exit_status);
+}

--- a/common/scripts/common.php
+++ b/common/scripts/common.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * This file must be included at the top of all shell scripts (cron jobs).
+ * 
+ * HERE BE DRAGONS.
+ * 
+ * Failure to perform the checks listed in this file at the top of a cron job,
+ * or any attempt to work around the limitations deliberately placed in this
+ * file, may result in errors or degradation of service.
+ * 
+ * Please be warned that errors may not show up immediately, especially if you
+ * screw up the permissions inside deeply nested directory trees. You may find
+ * it difficult and/or costly to undo the damages when errors begin to show up
+ * several months later.
+ */
+
+// Abort if not CLI.
+if (PHP_SAPI !== 'cli')
+{
+	echo "This script must be executed on the command line interface.\n";
+	exit(1);
+}
+
+// Load Rhymix.
+chdir(dirname(dirname(__DIR__)));
+require_once dirname(__DIR__) . '/autoload.php';
+
+// Abort if the UID does not match.
+$uid = Rhymix\Framework\Storage::getServerUID();
+if ($uid === 0)
+{
+	echo "This script must not be executed by the root user.\n";
+	exit(2);
+}
+$web_server_uid = fileowner(RX_BASEDIR . 'files/config/config.php');
+if ($uid !== $web_server_uid)
+{
+	$web_server_uid = posix_getpwuid($web_server_uid);
+	echo "This script must be executed by the same user as the usual web server process ({$web_server_uid['name']}).\n";
+	exit(3);
+}

--- a/modules/comment/comment.controller.php
+++ b/modules/comment/comment.controller.php
@@ -1129,6 +1129,9 @@ class commentController extends comment
 			$output = executeQuery('file.updateFileValid', $args);
 		}
 
+		// Remove the thumbnail file
+		Rhymix\Framework\Storage::deleteEmptyDirectory(RX_BASEDIR . sprintf('files/thumbnails/%s', getNumberingPath($comment_srl, 3)), true);
+
 		// commit
 		$oDB->commit();
 

--- a/modules/document/document.controller.php
+++ b/modules/document/document.controller.php
@@ -919,7 +919,7 @@ class documentController extends document
 		$this->_deleteDocumentUpdateLog($args);
 
 		// Remove the thumbnail file
-		FileHandler::removeDir(sprintf('files/thumbnails/%s',getNumberingPath($document_srl, 3)));
+		Rhymix\Framework\Storage::deleteEmptyDirectory(RX_BASEDIR . sprintf('files/thumbnails/%s', getNumberingPath($document_srl, 3)), true);
 
 		// commit
 		$oDB->commit();

--- a/modules/file/queries/getFileList.xml
+++ b/modules/file/queries/getFileList.xml
@@ -15,6 +15,7 @@
         <condition operation="notin" column="files.module_srl" var="exclude_module_srl" pipe="and" />
         <condition operation="equal" column="files.isvalid" var="isvalid" pipe="and" />
         <condition operation="equal" column="files.direct_download" var="direct_download" pipe="and" />
+		<condition operation="below" column="files.regdate" var="regdate_before" pipe="and" />
         <group pipe="and">
             <condition operation="like" column="files.source_filename" var="s_filename" pipe="or" />
             <condition operation="more" column="files.file_size" var="s_filesize_more" pipe="or" />

--- a/tests/unit/framework/StorageTest.php
+++ b/tests/unit/framework/StorageTest.php
@@ -356,6 +356,29 @@ class StorageTest extends \Codeception\TestCase\Test
 		$this->assertFalse(Rhymix\Framework\Storage::deleteDirectory($nonexistent));
 	}
 	
+	public function testDeleteEmptyDirectory()
+	{
+		$sourcedir = \RX_BASEDIR . 'tests/_output/sourcedir';
+		mkdir($sourcedir);
+		file_put_contents($sourcedir . '/foo', 'bar');
+		mkdir($sourcedir . '/subdir');
+		mkdir($sourcedir . '/subdir/subsubdir');
+		mkdir($sourcedir . '/subdir/subsubdir/subsubdir');
+		file_put_contents($sourcedir . '/subdir/subsubdir/subsubdir/foo', 'bar');
+		
+		$this->assertFalse(Rhymix\Framework\Storage::deleteEmptyDirectory($sourcedir . '/subdir/subsubdir/subsubdir'));
+		Rhymix\Framework\Storage::delete($sourcedir . '/subdir/subsubdir/subsubdir/foo');
+		$this->assertTrue(Rhymix\Framework\Storage::deleteEmptyDirectory($sourcedir . '/subdir/subsubdir/subsubdir'));
+		$this->assertFalse(file_exists($sourcedir . '/subdir/subsubdir/subsubdir'));
+		$this->assertTrue(file_exists($sourcedir . '/subdir/subsubdir'));
+		$this->assertTrue(file_exists($sourcedir . '/foo'));
+		$this->assertTrue(Rhymix\Framework\Storage::deleteEmptyDirectory($sourcedir . '/subdir/subsubdir', true));
+		$this->assertFalse(file_exists($sourcedir . '/subdir/subsubdir'));
+		$this->assertFalse(file_exists($sourcedir . '/subdir'));
+		$this->assertTrue(file_exists($sourcedir));
+		$this->assertTrue(file_exists($sourcedir . '/foo'));
+	}
+	
 	public function testRecommendUmask()
 	{
 		$umask = Rhymix\Framework\Storage::recommendUmask();


### PR DESCRIPTION
불필요한 데이터가 많이 남지 않도록 crontab으로 정리하는 방법을 제공합니다.

- [x] 글, 댓글 삭제시 섬네일 폴더의 상위폴더가 비었으면 자동 삭제
- [x] 첨부파일 삭제시 상위폴더가 비었으면 자동 삭제
- [x] 회원 삭제시 이미지이름, 프로필 사진, 서명, 포인트 등이 저장된 폴더 및 빈 상위폴더 자동 삭제
- [x] files/attach, files/member_extra_info, files/thumbnails 이하의 빈 폴더를 일괄 삭제하는 쉘 스크립트 제공
- [x] 글쓰기를 중단하거나 업로드에 실패하여 남은 찌꺼기 파일을 일괄 삭제하는 쉘 스크립트 제공
- [x] 일정 기간 이상 지난 섬네일 및 상위폴더를 일괄 삭제하는 쉘 스크립트 제공
- [x] 매뉴얼 작성

쉘 스크립트는 실행 시간 때문에 웹 호출이 불가능하며, 반드시 웹서버와 동일한 계정의 crontab을 사용해야 합니다. 웹호스팅에서는 crontab이나 PHP-CLI를 사용하지 못할 수도 있습니다.

#500 #509 #595 #684