### PR TITLE
메뉴에 아이콘 등 일부 HTML 사용 허가

### DIFF
--- a/modules/menu/menu.admin.controller.php
+++ b/modules/menu/menu.admin.controller.php
@@ -1987,7 +1987,7 @@ class menuAdminController extends menu
 				}
 				else
 				{
-					$name_arr_str .= sprintf('"%s"=>\'%s\',', $key, str_replace(array('\\','\''), array('\\\\','\\\''), strip_tags($val)));
+					$name_arr_str .= sprintf('"%s"=>\'%s\',', $key, str_replace(array('\\','\''), array('\\\\','\\\''), Rhymix\Framework\Filters\HTMLFilter::clean($val, true)));
 				}
 			}
 			$name_str = sprintf('$_menu_names[%d] = array(%s); %s', $node->menu_item_srl, $name_arr_str, $child_output['name']);

--- a/modules/menu/menu.admin.controller.php
+++ b/modules/menu/menu.admin.controller.php
@@ -1884,29 +1884,32 @@ class menuAdminController extends menu
 			$names = $oMenuAdminModel->getMenuItemNames($node->name, $site_srl);
 			foreach($names as $key => $val)
 			{
-				$name_arr_str .= sprintf('"%s"=>\'%s\',',$key, str_replace(array('\\', '\''), array('\\\\', '\\\''), $val));
+				$name_arr_str .= sprintf('"%s"=>%s,', $key, var_export($val, true));
 			}
 			$name_str = sprintf('$_names = array(%s); print $_names[$lang_type];', $name_arr_str);
 
-			$url = str_replace(array('&','"','<','>'),array('&amp;','&quot;','&lt;','&gt;'),$node->url);
-			$desc = str_replace(array('&','"',"'"),array('&amp;','&quot;','\\\''),$node->desc);
+			$url = escape($node->url);
+			$desc = escape($node->desc, false);
 			if(preg_match('/^([0-9a-zA-Z\_\-]+)$/', $node->url))
 			{
 				$href = "getSiteUrl('$domain', '','mid','$node->url')";
 			}
-			else $href = sprintf('"%s"', $url);
+			else
+			{
+				$href = var_export($url, true);
+			}
 			$is_shortcut = $node->is_shortcut;
 			$open_window = $node->open_window;
 			$expand = $node->expand;
 
 			$normal_btn = $node->normal_btn;
-			if($normal_btn && strncasecmp('./files/attach/menu_button', $normal_btn, 26) === 0) $normal_btn = str_replace(array('&','"','<','>'),array('&amp;','&quot;','&lt;','&gt;'),$normal_btn);
+			if($normal_btn && strncasecmp('./files/attach/menu_button', $normal_btn, 26) === 0) $normal_btn = escape($normal_btn);
 			else $normal_btn = '';
 			$hover_btn = $node->hover_btn;
-			if($hover_btn && strncasecmp('./files/attach/menu_button', $hover_btn, 26) === 0) $hover_btn = str_replace(array('&','"','<','>'),array('&amp;','&quot;','&lt;','&gt;'),$hover_btn);
+			if($hover_btn && strncasecmp('./files/attach/menu_button', $hover_btn, 26) === 0) $hover_btn = escape($hover_btn);
 			else $hover_btn = '';
 			$active_btn = $node->active_btn;
-			if($active_btn && strncasecmp('./files/attach/menu_button', $active_btn, 26) === 0) $active_btn = str_replace(array('&','"','<','>'),array('&amp;','&quot;','&lt;','&gt;'),$active_btn);
+			if($active_btn && strncasecmp('./files/attach/menu_button', $active_btn, 26) === 0) $active_btn = escape($active_btn);
 			else $active_btn = '';
 
 			$group_srls = $node->group_srls;
@@ -1987,7 +1990,7 @@ class menuAdminController extends menu
 				}
 				else
 				{
-					$name_arr_str .= sprintf('"%s"=>\'%s\',', $key, str_replace(array('\\','\''), array('\\\\','\\\''), Rhymix\Framework\Filters\HTMLFilter::clean($val, true)));
+					$name_arr_str .= sprintf('"%s"=>%s,', $key, var_export(Rhymix\Framework\Filters\HTMLFilter::clean($val, true), true));
 				}
 			}
 			$name_str = sprintf('$_menu_names[%d] = array(%s); %s', $node->menu_item_srl, $name_arr_str, $child_output['name']);
@@ -2000,19 +2003,22 @@ class menuAdminController extends menu
 			else $group_check_code = "true";
 
 			// List variables
-			$href = str_replace(array('&','"','<','>'),array('&amp;','&quot;','&lt;','&gt;'),$node->href);
-			$url = str_replace(array('&','"','<','>'),array('&amp;','&quot;','&lt;','&gt;'),$node->url);
-			$desc = str_replace(array('&','"',"'"),array('&amp;','&quot;','\\\''),$node->desc);
+			$href = escape($node->href);
+			$url = escape($node->url);
+			$desc = escape($node->desc, false);
 			if(preg_match('/^([0-9a-zA-Z\_\-]+)$/i', $node->url))
 			{
 				$href = "getSiteUrl('$domain', '','mid','$node->url')";
 			}
-			else $href = sprintf('"%s"', $url);
+			else
+			{
+				$href = var_export($url, true);
+			}
 			$is_shortcut = $node->is_shortcut;
 			$open_window = $node->open_window;
-			$normal_btn = str_replace(array('&','"','<','>'),array('&amp;','&quot;','&lt;','&gt;'),$node->normal_btn);
-			$hover_btn = str_replace(array('&','"','<','>'),array('&amp;','&quot;','&lt;','&gt;'),$node->hover_btn);
-			$active_btn = str_replace(array('&','"','<','>'),array('&amp;','&quot;','&lt;','&gt;'),$node->active_btn);
+			$normal_btn = escape($node->normal_btn);
+			$hover_btn = escape($node->hover_btn);
+			$active_btn = escape($node->active_btn);
 
 			foreach($child_output['url_list'] as $key =>$val)
 			{
@@ -2024,17 +2030,16 @@ class menuAdminController extends menu
 			$expand = $node->expand;
 
 			$normal_btn = $node->normal_btn;
-			if($normal_btn && strncasecmp('./files/attach/menu_button', $normal_btn, 26) === 0) $normal_btn = str_replace(array('&','"','<','>'),array('&amp;','&quot;','&lt;','&gt;'),$normal_btn);
+			if($normal_btn && strncasecmp('./files/attach/menu_button', $normal_btn, 26) === 0) $normal_btn = escape($normal_btn);
 			else $normal_btn = '';
 
 			$hover_btn = $node->hover_btn;
-			if($hover_btn && strncasecmp('./files/attach/menu_button', $hover_btn, 26) === 0) $hover_btn = str_replace(array('&','"','<','>'),array('&amp;','&quot;','&lt;','&gt;'),$hover_btn);
+			if($hover_btn && strncasecmp('./files/attach/menu_button', $hover_btn, 26) === 0) $hover_btn = escape($hover_btn);
 			else $hover_btn = '';
 
 			$active_btn = $node->active_btn;
-			if($active_btn && strncasecmp('./files/attach/menu_button', $active_btn, 26) === 0) $active_btn = str_replace(array('&','"','<','>'),array('&amp;','&quot;','&lt;','&gt;'),$active_btn);
+			if($active_btn && strncasecmp('./files/attach/menu_button', $active_btn, 26) === 0) $active_btn = escape($active_btn);
 			else $active_btn = '';
-
 
 			$group_srls = $node->group_srls;
 

--- a/modules/menu/tpl/sitemap.html
+++ b/modules/menu/tpl/sitemap.html
@@ -1943,8 +1943,7 @@ jQuery(function($){
 			$(this).addClass('page');
 		}
 
-		//$(this).find('#menuName').val(htInfo.sText);
-		$(this).find('#menuName').val(htInfo.sMenuNameKey);
+		$(this).find('#menuName').val(htInfo.sMenuNameKey.match(/\$user_lang->/) ? htInfo.sMenuNameKey : htInfo.sText);
 		$(this).find('#menuDesc').val(htInfo.desc);
 		//menu_name_key
 

--- a/tests/unit/framework/filters/HTMLFilterTest.php
+++ b/tests/unit/framework/filters/HTMLFilterTest.php
@@ -154,6 +154,15 @@ class HTMLFilterTest extends \Codeception\TestCase\Test
 		$source = '<p class="mytest">Hello World</p>';
 		$target = '<p class="mytest">Hello World</p>';
 		$this->assertEquals($target, Rhymix\Framework\Filters\HTMLFilter::clean($source));
+		
+		config('mediafilter.classes', array());
+		$source = '<p class="whatever">Hello World</p>';
+		$target = '<p class="whatever">Hello World</p>';
+		$this->assertEquals($target, Rhymix\Framework\Filters\HTMLFilter::clean($source, true));
+		
+		$source = '<p class="foobar whatever">Hello World</p>';
+		$target = '<p class="foobar">Hello World</p>';
+		$this->assertEquals($target, Rhymix\Framework\Filters\HTMLFilter::clean($source, array('foobar')));
 	}
 	
 	public function testHTMLFilterEditorComponent()
@@ -176,11 +185,11 @@ class HTMLFilterTest extends \Codeception\TestCase\Test
 		
 		$source = '<img somekey="somevalue" otherkey="othervalue" onmouseover="alert(\'xss\');" editor_component="component_name" src="./foo/bar.jpg" alt="My Picture" style="width:320px;height:240px;" width="320" height="240" />';
 		$target = '<img src="./foo/bar.jpg" alt="My Picture" style="width:320px;height:240px;" width="320" height="240" />';
-		$this->assertEquals($target, Rhymix\Framework\Filters\HTMLFilter::clean($source, false));
+		$this->assertEquals($target, Rhymix\Framework\Filters\HTMLFilter::clean($source, false, false));
 		
 		$source = '<img somekey="somevalue" otherkey="othervalue" onkeypress="alert(\'xss\');" editor_component="component_name" />';
 		$target = '';
-		$this->assertEquals($target, Rhymix\Framework\Filters\HTMLFilter::clean($source, false));
+		$this->assertEquals($target, Rhymix\Framework\Filters\HTMLFilter::clean($source, false, false));
 	}
 	
 	public function testHTMLFilterWidgetCode()
@@ -191,11 +200,11 @@ class HTMLFilterTest extends \Codeception\TestCase\Test
 		
 		$source = '<p>Hello World</p><img class="zbxe_widget_output" widget="content" skin="default" colorset="white" widget_sequence="1234" widget_cache="1m" content_type="document" module_srls="56" list_type="normal" tab_type="none" markup_type="table" page_count="1" option_view="title,regdate,nickname" show_browser_title="Y" show_comment_count="Y" show_trackback_count="Y" show_category="Y" show_icon="Y" show_secret="N" order_target="regdate" order_type="desc" thumbnail_type="crop" />';
 		$target = '<p>Hello World</p><img widget="content" skin="default" colorset="white" widget_sequence="1234" widget_cache="1m" content_type="document" module_srls="56" list_type="normal" tab_type="none" markup_type="table" page_count="1" option_view="title,regdate,nickname" show_browser_title="Y" show_comment_count="Y" show_trackback_count="Y" show_category="Y" show_icon="Y" show_secret="N" order_target="regdate" order_type="desc" thumbnail_type="crop" src="" class="zbxe_widget_output" alt="" />';
-		$this->assertEquals($target, Rhymix\Framework\Filters\HTMLFilter::clean($source, true, true));
+		$this->assertEquals($target, Rhymix\Framework\Filters\HTMLFilter::clean($source, true, true, true));
 		
 		$source = '<p>Hello World</p><img class="zbxe_widget_output" widget="content" onmouseover="alert(\'xss\');" skin="default" colorset="white" widget_sequence="1234" widget_cache="1m" content_type="document" module_srls="56" list_type="normal" tab_type="none" markup_type="table" page_count="1" option_view="title,regdate,nickname" show_browser_title="Y" show_comment_count="Y" show_trackback_count="Y" show_category="Y" show_icon="Y" show_secret="N" order_target="regdate" order_type="desc" thumbnail_type="crop" />';
 		$target = '<p>Hello World</p><img widget="content" skin="default" colorset="white" widget_sequence="1234" widget_cache="1m" content_type="document" module_srls="56" list_type="normal" tab_type="none" markup_type="table" page_count="1" option_view="title,regdate,nickname" show_browser_title="Y" show_comment_count="Y" show_trackback_count="Y" show_category="Y" show_icon="Y" show_secret="N" order_target="regdate" order_type="desc" thumbnail_type="crop" src="" class="zbxe_widget_output" alt="" />';
-		$this->assertEquals($target, Rhymix\Framework\Filters\HTMLFilter::clean($source, true, true));
+		$this->assertEquals($target, Rhymix\Framework\Filters\HTMLFilter::clean($source, true, true, true));
 	}
 	
 	public function testHTMLFilterUserContentID()


### PR DESCRIPTION
1.8.29 패치 이후 메뉴에 폰트어썸 아이콘 등을 사용할 수 없는 문제를 해결합니다.

위험한 태그는 여전히 필터링됩니다.

HTML Filter의 기본 설정에서 xi-\*, fa-\* 등의 클래스가 허용되지 않으므로 이것을 조정할 수 있는 옵션을 추가했습니다. 아이콘 폰트와 함께 흔히 사용되는 aria-hidden 속성도 허용하도록 변경했습니다.

메뉴에 태그를 입력할 경우 수정 화면에서 태그가 표시되지 않는 문제도 해결합니다.