### PR TITLE
네모의 꿈 레이아웃 메뉴 보이기/감추기 스크립트 수정, 메시지 모듈 스킨을 모바일에서도 보이도록 코드 추가

### DIFF
--- a/layouts/simple_world/layout.js
+++ b/layouts/simple_world/layout.js
@@ -31,29 +31,48 @@ $(function()
 		});
 	});
 
-	/* detect scrolling up or down to hide or show hamburger menu */
+	/* detect scrolling up or down to hide or show the hamburger menu */
 	var previousScroll = 0;
+	var simpleScrolled = false;
+	var scrollThreshold = 5;
+
+	/* detect window scrolling */
 	$( window ).scroll(function()
 	{
-		var currentScroll = $(this).scrollTop();
+		simpleScrolled = true;
+	});
+
+	/* refresh window scrolling per 250 ms, and show/hide the menu */
+	setInterval(function()
+	{
+		if (simpleScrolled) {
+			display_menu();
+			simpleScrolled = false;
+		}
+	}, 250);
+
+	/* function to show/hide the menu */
+	var display_menu = function()
+	{
+		var currentScroll = $(window).scrollTop();
+
 		if (currentScroll > previousScroll)
 		{
-			if($("#layout_menu_toggle").css( 'position' ) === 'fixed' && $("#layout_menu_toggle").attr('data-scroll-down') !== 'true')
+			if($("#layout_menu_toggle").css( 'position' ) === 'fixed')
 			{
-				$("#layout_menu_toggle").attr('data-scroll-down', 'true');
 				$("#layout_menu_toggle").fadeOut();
 			}
 		}
 		else
 		{
-			if($("#layout_menu_toggle").css( 'position' ) === 'fixed' && $("#layout_menu_toggle").attr('data-scroll-down') === 'true')
+			if($("#layout_menu_toggle").css( 'position' ) === 'fixed')
 			{
-				$("#layout_menu_toggle").attr('data-scroll-down', '');
 				$("#layout_menu_toggle").fadeIn();
+				$("#layout_menu_toggle").css('display', '');
 			}
 		}
 		previousScroll = currentScroll;
-	});
+	}
 
 	/* keyboard accessibility for dropdown menu */
 	$(".layout_dropdown").each(function()

--- a/modules/message/skins/simple_world/common_header.html
+++ b/modules/message/skins/simple_world/common_header.html
@@ -1,3 +1,6 @@
+<!--// responsible layout -->
+{Context::addMetaTag("viewport", "width=device-width, user-scalable=yes")}
+
 <!--// Check layout. If it is Simple World, select layout primary colors as a primary color of this skin -->
 {@
 	$material_colors = array(


### PR DESCRIPTION
- 네모의 꿈 레이아웃 메뉴 보이기/감추기 스크립트가 iOS 기기에서 의도하지 않은 방식으로 작동하던 것 수정.
- 메시지 모듈 스킨을 모바일에서도 보이도록 헤더 코드 추가