### PR TITLE
설명이 필요없고, 번역이 되어 있지 않은 언어 항목 삭제.

### DIFF
--- a/modules/document/tpl/category_list.html
+++ b/modules/document/tpl/category_list.html
@@ -70,7 +70,6 @@
 				<label class="x_control-label" for="lang_category_description">{$lang->category_description}</label>
 				<div class="x_controls">
 					<textarea name="category_description" class="lang_code" id="category_description" rows="8" cols="42"></textarea>
-					<span class="x_help-block">{$lang->about_category_description}</span>
 				</div>
 			</div>
 			<div class="x_control-group category_groups">


### PR DESCRIPTION
카테고리 설명 항목에 대한 설명은 '카테고리에 대한 설명을 입력하세요'가 될 것 같은데, 동어 반복이라서 작성하지 않고 삭제합니다.