### PR TITLE
동영상 소스를 에디터에 붙여넣으면 자동 삽입되도록 개선

### DIFF
--- a/common/js/common.js
+++ b/common/js/common.js
@@ -327,6 +327,14 @@ jQuery(function($) {
 	};
 
 	/**
+	 * @brief string prototype으로 unescape 함수 추가
+	 **/
+	String.prototype.unescape = function() {
+		var map = { '&amp;': '&', '&lt;': '<', '&gt;': '>', '&quot;': '"', '&#039;': "'" };
+		return String(this).replace(/&(amp|lt|gt|quot|#039);/g, function(m) { return map[m]; });
+	};
+
+	/**
 	 * @brief string prototype으로 trim 함수 추가
 	 **/
 	if (!String.prototype.trim) {

--- a/modules/editor/styles/ckeditor_light/editor.css
+++ b/modules/editor/styles/ckeditor_light/editor.css
@@ -16,7 +16,7 @@
 .xe_content.editable blockquote.q6{border:1px dashed #707070}
 .xe_content.editable blockquote.q7{border:1px dashed #707070;background:#fbfbfb}
 .xe_content.editable table .xe_selected_cell{background-color:#d6e9ff}
-
+.xe_content.editable img.cke_iframe{background-color:#444}
 .xe_content.editable blockquote
 {
 	padding: 2px 0;

--- a/modules/editor/tpl/js/editor.app.js
+++ b/modules/editor/tpl/js/editor.app.js
@@ -143,6 +143,14 @@ function getAutoSavedSrl(ret_obj, response_tags, c) {
 				if(!opts.enableToolbar) instance.config.toolbar = [];
 			});
 
+			instance.on('paste', function(e) {
+				if (e.data && e.data.dataValue && e.data.dataValue.replace) {
+					e.data.dataValue = e.data.dataValue.replace(/&lt;(iframe|object)\s[^<>]+&lt;\/\1&gt;/g, function(m) {
+						return String(m).unescape() + '<p>&nbsp;</p>';
+					});
+				}
+			});
+
 			$containerEl.data('cke_instance', instance);
 
 			window.editorRelKeys[data.editorSequence] = {};


### PR DESCRIPTION
소스모드로 전환하지 않아도 웬만한 동영상 소스는 자동으로 삽입되도록 합니다.

https://www.xetown.com/alley/470629

관련 변경사항:

- 자바스크립트 문자열에 unescape 함수를 추가합니다. 전에 추가한 escape 함수의 반대 기능입니다.
- CK에디터에서 iframe 배경색을 흰색에서 짙은 회색으로 변경하여 크기와 경계를 구분하기 쉽도록 합니다.