### PR TITLE
템플릿 필터 지원

### DIFF
--- a/classes/template/TemplateHandler.class.php
+++ b/classes/template/TemplateHandler.class.php
@@ -623,6 +623,10 @@ class TemplateHandler
 							$var = $filter_option ? "strip_tags({$var}, {$filter_option})" : "strip_tags({$var})";
 							break;
 							
+						case 'trim':
+							$var = "trim({$var})";
+							break;
+							
 						case 'urlencode':
 							$var = "rawurlencode({$var})";
 							break;
@@ -669,7 +673,8 @@ class TemplateHandler
 							break;
 							
 						default:
-							$var = "INVALID FILTER ({$filter})";
+							$filter = escape_sqstr($filter);
+							$var = "'INVALID FILTER ({$filter})'";
 					}
 				}
 				

--- a/classes/template/TemplateHandler.class.php
+++ b/classes/template/TemplateHandler.class.php
@@ -565,10 +565,10 @@ class TemplateHandler
 				}
 				
 				// Separate filters from variable.
-				if (preg_match('@^(.+?)(?<![|\s])\\|([a-z].+)$@', $m[1], $mm))
+				if (preg_match('@^(.+?)(?<![|\s])((?:\|[a-z]{2}[a-z0-9_]+(?::.+)?)+)$@', $m[1], $mm))
 				{
 					$m[1] = $mm[1];
-					$filters = array_map('trim', explode_with_escape('|', $mm[2]));
+					$filters = array_map('trim', explode_with_escape('|', substr($mm[2], 1)));
 				}
 				else
 				{

--- a/classes/template/TemplateHandler.class.php
+++ b/classes/template/TemplateHandler.class.php
@@ -561,7 +561,7 @@ class TemplateHandler
 				}
 				else
 				{
-					$escape_option = $this->config->autoescape !== null ? 'autoescape' : 'noescape';
+					$escape_option = $this->config->autoescape !== null ? 'auto' : 'noescape';
 				}
 				
 				// Separate filters from variable.
@@ -890,8 +890,9 @@ class TemplateHandler
 				return "htmlspecialchars({$str}, ENT_COMPAT, 'UTF-8', true)";
 			case 'noescape':
 				return "{$str}";
-			case 'auto':
 			case 'autoescape':
+				return "htmlspecialchars({$str}, ENT_COMPAT, 'UTF-8', false)";
+			case 'auto':
 			default:
 				return "(\$this->config->autoescape === 'on' ? htmlspecialchars({$str}, ENT_COMPAT, 'UTF-8', false) : {$str})";
 		}

--- a/classes/template/TemplateHandler.class.php
+++ b/classes/template/TemplateHandler.class.php
@@ -565,7 +565,7 @@ class TemplateHandler
 				}
 				
 				// Separate filters from variable.
-				if (preg_match('@^(.+?)(?<![|\s])\\|([a-z0-9_].+)$@', $m[1], $mm))
+				if (preg_match('@^(.+?)(?<![|\s])\\|([a-z].+)$@', $m[1], $mm))
 				{
 					$m[1] = $mm[1];
 					$filters = array_map('trim', explode_with_escape('|', $mm[2]));

--- a/classes/template/TemplateHandler.class.php
+++ b/classes/template/TemplateHandler.class.php
@@ -554,26 +554,127 @@ class TemplateHandler
 			}
 			else
 			{
-				$escape_option = $this->config->autoescape !== null ? 'auto' : 'noescape';
-				if(preg_match('@^(.+)\\|((?:no)?escape)$@', $m[1], $mm))
-				{
-					$m[1] = $mm[1];
-					$escape_option = $mm[2];
-				}
-				elseif($m[1] === '$content' && preg_match('@/layouts/.+/layout\.html$@', $this->file))
+				// Get escape options.
+				if($m[1] === '$content' && preg_match('@/layouts/.+/layout\.html$@', $this->file))
 				{
 					$escape_option = 'noescape';
 				}
-				$m[1] = self::_replaceVar($m[1]);
-				switch($escape_option)
+				else
 				{
-					case 'auto':
-						return "<?php echo (\$this->config->autoescape === 'on' ? htmlspecialchars({$m[1]}, ENT_COMPAT, 'UTF-8', false) : {$m[1]}) ?>";
-					case 'escape':
-						return "<?php echo htmlspecialchars({$m[1]}, ENT_COMPAT, 'UTF-8', true) ?>";
-					case 'noescape':
-						return "<?php echo {$m[1]} ?>";
+					$escape_option = $this->config->autoescape !== null ? 'autoescape' : 'noescape';
 				}
+				
+				// Separate filters from variable.
+				if (preg_match('@^(.+?)(?<![|\s])\\|([a-z0-9_].+)$@', $m[1], $mm))
+				{
+					$m[1] = $mm[1];
+					$filters = array_map('trim', explode_with_escape('|', $mm[2]));
+				}
+				else
+				{
+					$filters = array();
+				}
+				
+				// Process the variable.
+				$var = self::_replaceVar($m[1]);
+				
+				// Apply filters.
+				foreach ($filters as $filter)
+				{
+					// Separate filter option from the filter name.
+					if (preg_match('/^([a-z0-9_-]+):(.+)$/', $filter, $matches))
+					{
+						$filter = $matches[1];
+						$filter_option = $matches[2];
+						if (!self::_isVar($filter_option) && !preg_match("/^'.*'$/", $filter_option) && !preg_match('/^".*"$/', $filter_option))
+						{
+							$filter_option = "'" . escape_sqstr($filter_option) . "'";
+						}
+						else
+						{
+							$filter_option = self::_replaceVar($filter_option);
+						}
+					}
+					else
+					{
+						$filter_option = null;
+					}
+					
+					// Apply each filter.
+					switch ($filter)
+					{
+						case 'auto':
+						case 'autoescape':
+						case 'escape':
+						case 'noescape':
+							$escape_option = $filter;
+							break;
+							
+						case 'escapejs':
+							$var = "escape_js({$var})";
+							break;
+							
+						case 'json':
+							$var = "json_encode({$var})";
+							break;
+							
+						case 'strip':
+						case 'strip_tags':
+							$var = $filter_option ? "strip_tags({$var}, {$filter_option})" : "strip_tags({$var})";
+							break;
+							
+						case 'urlencode':
+							$var = "rawurlencode({$var})";
+							break;
+							
+						case 'lower':
+							$var = "strtolower({$var})";
+							break;
+							
+						case 'upper':
+							$var = "strtoupper({$var})";
+							break;
+							
+						case 'nl2br':
+							$var = $this->_applyEscapeOption($var, $escape_option);
+							$var = "nl2br({$var})";
+							$escape_option = 'noescape';
+							break;
+							
+						case 'join':
+							$var = $filter_option ? "implode({$filter_option}, {$var})" : "implode(', ', {$var})";
+							break;
+							
+						case 'date':
+							$var = $filter_option ? "getDisplayDateTime(ztime({$var}), {$filter_option})" : "getDisplayDateTime(ztime({$var}), 'Y-m-d H:i:s')";
+							break;
+							
+						case 'format':
+						case 'number_format':
+							$var = $filter_option ? "number_format({$var}, {$filter_option})" : "number_format({$var})";
+							break;
+							
+						case 'link':
+							$var = $this->_applyEscapeOption($var, $escape_option);
+							if ($filter_option)
+							{
+								$filter_option = $this->_applyEscapeOption($filter_option, $escape_option);
+								$var = "'<a href=\"' . {$filter_option} . '\">' . {$var} . '</a>'";
+							}
+							else
+							{
+								$var = "'<a href=\"' . {$var} . '\">' . {$var} . '</a>'";
+							}
+							$escape_option = 'noescape';
+							break;
+							
+						default:
+							$var = "INVALID FILTER ({$filter})";
+					}
+				}
+				
+				// Apply the escape option and return.
+				return '<?php echo ' . $this->_applyEscapeOption($var, $escape_option) . ' ?>';
 			}
 		}
 
@@ -774,6 +875,24 @@ class TemplateHandler
 	}
 
 	/**
+	 * Apply escape option to an expression.
+	 */
+	private function _applyEscapeOption($str, $escape_option)
+	{
+		switch($escape_option)
+		{
+			case 'escape':
+				return "htmlspecialchars({$str}, ENT_COMPAT, 'UTF-8', true)";
+			case 'noescape':
+				return "{$str}";
+			case 'auto':
+			case 'autoescape':
+			default:
+				return "(\$this->config->autoescape === 'on' ? htmlspecialchars({$str}, ENT_COMPAT, 'UTF-8', false) : {$str})";
+		}
+	}
+
+	/**
 	 * change relative path
 	 * @param string $path
 	 * @return string
@@ -810,9 +929,21 @@ class TemplateHandler
 
 		return $path;
 	}
+	
+	/**
+	 * Check if a string seems to contain a variable.
+	 * 
+	 * @param string $str
+	 * @return bool
+	 */
+	private static function _isVar($str)
+	{
+		return preg_match('@(?<!::|\\\\|(?<!eval\()\')\$([a-z_][a-z0-9_]*)@i', $str) ? true : false;
+	}
 
 	/**
-	 * replace PHP variables of $ character
+	 * Replace PHP variables of $ character
+	 * 
 	 * @param string $php
 	 * @return string $__Context->varname
 	 */

--- a/common/legacy.php
+++ b/common/legacy.php
@@ -520,6 +520,11 @@ function ztime($str)
 	{
 		return null;
 	}
+	if (strlen($str) === 9 || (strlen($str) === 10 && $str <= 2147483647))
+	{
+		return intval($str);
+	}
+	
 	$year = (int)substr($str, 0, 4);
 	$month = (int)substr($str, 4, 2) ?: 1;
 	$day = (int)substr($str, 6, 2) ?: 1;

--- a/tests/unit/classes/TemplateHandlerTest.php
+++ b/tests/unit/classes/TemplateHandlerTest.php
@@ -315,8 +315,16 @@ class TemplateHandlerTest extends \Codeception\TestCase\Test
                 PHP_EOL . '$this->config->autoescape = \'on\';' . "\n" . 'echo ($this->config->autoescape === \'on\' ? htmlspecialchars($__Context->foo, ENT_COMPAT, \'UTF-8\', false) : $__Context->foo) ?>'
             ),
             array(
-                '<config autoescape="off" />{$foo|autoescape}',
+                '<config autoescape="off" />{$foo|auto}',
                 PHP_EOL . '$this->config->autoescape = \'off\';' . "\n" . 'echo ($this->config->autoescape === \'on\' ? htmlspecialchars($__Context->foo, ENT_COMPAT, \'UTF-8\', false) : $__Context->foo) ?>'
+            ),
+            array(
+                '<config autoescape="on" />{$foo|autoescape}',
+                PHP_EOL . '$this->config->autoescape = \'on\';' . "\n" . 'echo htmlspecialchars($__Context->foo, ENT_COMPAT, \'UTF-8\', false) ?>'
+            ),
+            array(
+                '<config autoescape="off" />{$foo|autoescape}',
+                PHP_EOL . '$this->config->autoescape = \'off\';' . "\n" . 'echo htmlspecialchars($__Context->foo, ENT_COMPAT, \'UTF-8\', false) ?>'
             ),
             array(
                 '<config autoescape="on" />{$foo|escape}',

--- a/tests/unit/classes/TemplateHandlerTest.php
+++ b/tests/unit/classes/TemplateHandlerTest.php
@@ -301,6 +301,120 @@ class TemplateHandlerTest extends \Codeception\TestCase\Test
                 '<span>{\RX_BASEDIR}</span>',
                 '?><span><?php echo \RX_BASEDIR ?></span>'
             ),
+			// Rhymix autoescape
+            array(
+                '<config autoescape="on" />{$foo}',
+                PHP_EOL . '$this->config->autoescape = \'on\';' . "\n" . 'echo ($this->config->autoescape === \'on\' ? htmlspecialchars($__Context->foo, ENT_COMPAT, \'UTF-8\', false) : $__Context->foo) ?>'
+            ),
+            array(
+                '<config autoescape="off" />{$foo}',
+                PHP_EOL . '$this->config->autoescape = \'off\';' . "\n" . 'echo ($this->config->autoescape === \'on\' ? htmlspecialchars($__Context->foo, ENT_COMPAT, \'UTF-8\', false) : $__Context->foo) ?>'
+            ),
+            array(
+                '<config autoescape="on" />{$foo|auto}',
+                PHP_EOL . '$this->config->autoescape = \'on\';' . "\n" . 'echo ($this->config->autoescape === \'on\' ? htmlspecialchars($__Context->foo, ENT_COMPAT, \'UTF-8\', false) : $__Context->foo) ?>'
+            ),
+            array(
+                '<config autoescape="off" />{$foo|autoescape}',
+                PHP_EOL . '$this->config->autoescape = \'off\';' . "\n" . 'echo ($this->config->autoescape === \'on\' ? htmlspecialchars($__Context->foo, ENT_COMPAT, \'UTF-8\', false) : $__Context->foo) ?>'
+            ),
+            array(
+                '<config autoescape="on" />{$foo|escape}',
+                PHP_EOL . '$this->config->autoescape = \'on\';' . "\n" . 'echo htmlspecialchars($__Context->foo, ENT_COMPAT, \'UTF-8\', true) ?>'
+            ),
+            array(
+                '<config autoescape="off" />{$foo|escape}',
+                PHP_EOL . '$this->config->autoescape = \'off\';' . "\n" . 'echo htmlspecialchars($__Context->foo, ENT_COMPAT, \'UTF-8\', true) ?>'
+            ),
+            array(
+                '<config autoescape="on" />{$foo|noescape}',
+                PHP_EOL . '$this->config->autoescape = \'on\';' . "\n" . 'echo $__Context->foo ?>'
+            ),
+            array(
+                '<config autoescape="off" />{$foo|noescape}',
+                PHP_EOL . '$this->config->autoescape = \'off\';' . "\n" . 'echo $__Context->foo ?>'
+            ),
+			// Rhymix filters
+            array(
+                '<p>{$foo|escape}</p>',
+                '?><p><?php echo htmlspecialchars($__Context->foo, ENT_COMPAT, \'UTF-8\', true) ?></p>'
+            ),
+            array(
+                '<p>{$foo|json}</p>',
+                '?><p><?php echo json_encode($__Context->foo) ?></p>'
+            ),
+            array(
+                '<p>{$foo|urlencode}</p>',
+                '?><p><?php echo rawurlencode($__Context->foo) ?></p>'
+            ),
+            array(
+                '<p>{$foo|lower|nl2br}</p>',
+                '?><p><?php echo nl2br(strtolower($__Context->foo)) ?></p>'
+            ),
+            array(
+                '<p>{$foo|join:/|upper}</p>',
+                '?><p><?php echo strtoupper(implode(\'/\', $__Context->foo)) ?></p>'
+            ),
+            array(
+                '<p>{$foo|join:\||upper}</p>',
+                '?><p><?php echo strtoupper(implode(\'|\', $__Context->foo)) ?></p>'
+            ),
+            array(
+                '<p>{$foo|join:$separator}</p>',
+                '?><p><?php echo implode($__Context->separator, $__Context->foo) ?></p>'
+            ),
+            array(
+                '<p>{$foo|strip}</p>',
+                '?><p><?php echo strip_tags($__Context->foo) ?></p>'
+            ),
+            array(
+                '<p>{$foo|strip:<br>}</p>',
+                '?><p><?php echo strip_tags($__Context->foo, \'<br>\') ?></p>'
+            ),
+            array(
+                '<p>{$foo|strip:$mytags}</p>',
+                '?><p><?php echo strip_tags($__Context->foo, $__Context->mytags) ?></p>'
+            ),
+            array(
+                '<p>{$foo|strip:myfunc($mytags)}</p>',
+                '?><p><?php echo strip_tags($__Context->foo, myfunc($__Context->mytags)) ?></p>'
+            ),
+            array(
+                '<p>{$foo|trim|date}</p>',
+                '?><p><?php echo getDisplayDateTime(ztime(trim($__Context->foo)), \'Y-m-d H:i:s\') ?></p>'
+            ),
+            array(
+                '<p>{$foo|date:His}</p>',
+                '?><p><?php echo getDisplayDateTime(ztime($__Context->foo), \'His\') ?></p>'
+            ),
+            array(
+                '<p>{$foo|format:2}</p>',
+                '?><p><?php echo number_format($__Context->foo, \'2\') ?></p>'
+            ),
+            array(
+                '<p>{$foo|date:His}</p>',
+                '?><p><?php echo getDisplayDateTime(ztime($__Context->foo), \'His\') ?></p>'
+            ),
+            array(
+                '<p>{$foo|link}</p>',
+                '?><p><?php echo \'<a href="\' . $__Context->foo . \'">\' . $__Context->foo . \'</a>\' ?></p>'
+            ),
+            array(
+                '<p>{$foo|link:http://www.rhymix.org}</p>',
+                '?><p><?php echo \'<a href="\' . \'http://www.rhymix.org\' . \'">\' . $__Context->foo . \'</a>\' ?></p>'
+            ),
+            array(
+                '<p>{$foo|link:$url}</p>',
+                '?><p><?php echo \'<a href="\' . $__Context->url . \'">\' . $__Context->foo . \'</a>\' ?></p>'
+            ),
+            array(
+                '<config autoescape="on" /><p>{$foo|link:$url}</p>',
+                PHP_EOL . '$this->config->autoescape = \'on\'; ?><p><?php echo \'<a href="\' . ($this->config->autoescape === \'on\' ? htmlspecialchars($__Context->url, ENT_COMPAT, \'UTF-8\', false) : $__Context->url) . \'">\' . ($this->config->autoescape === \'on\' ? htmlspecialchars($__Context->foo, ENT_COMPAT, \'UTF-8\', false) : $__Context->foo) . \'</a>\' ?></p>'
+            ),
+            array(
+                '<p>{$foo|dafuq}</p>',
+                '?><p><?php echo \'INVALID FILTER (dafuq)\' ?></p>'
+            ),
         );
 
         foreach ($tests as $test)

--- a/tests/unit/classes/TemplateHandlerTest.php
+++ b/tests/unit/classes/TemplateHandlerTest.php
@@ -419,17 +419,42 @@ class TemplateHandlerTest extends \Codeception\TestCase\Test
                 '<config autoescape="on" /><p>{$foo|link:$url}</p>',
                 PHP_EOL . '$this->config->autoescape = \'on\'; ?><p><?php echo \'<a href="\' . ($this->config->autoescape === \'on\' ? htmlspecialchars($__Context->url, ENT_COMPAT, \'UTF-8\', false) : $__Context->url) . \'">\' . ($this->config->autoescape === \'on\' ? htmlspecialchars($__Context->foo, ENT_COMPAT, \'UTF-8\', false) : $__Context->foo) . \'</a>\' ?></p>'
             ),
+			// Rhymix filters (reject malformed filters)
             array(
                 '<p>{$foo|dafuq}</p>',
                 '?><p><?php echo \'INVALID FILTER (dafuq)\' ?></p>'
             ),
             array(
-                '<p>{$foo||$bar}</p>',
-                '?><p><?php echo $__Context->foo||$__Context->bar ?></p>'
+                '<p>{$foo|4}</p>',
+                '?><p><?php echo $__Context->foo|4 ?></p>'
             ),
             array(
-                '<p>{htmlspecialchars($var, ENT_COMPAT|ENT_HTML401)}</p>',
-                '?><p><?php echo htmlspecialchars($__Context->var, ENT_COMPAT|ENT_HTML401) ?></p>'
+                '<p>{$foo|a+7|lower}</p>',
+                '?><p><?php echo strtolower($__Context->foo|a+7) ?></p>'
+            ),
+            array(
+                '<p>{$foo|Filter}</p>',
+                '?><p><?php echo $__Context->foo|Filter ?></p>'
+            ),
+            array(
+                '<p>{$foo|filter++}</p>',
+                '?><p><?php echo $__Context->foo|filter++ ?></p>'
+            ),
+            array(
+                '<p>{$foo|filter:}</p>',
+                '?><p><?php echo $__Context->foo|filter: ?></p>'
+            ),
+            array(
+                '<p>{$foo|$bar}</p>',
+                '?><p><?php echo $__Context->foo|$__Context->bar ?></p>'
+            ),
+            array(
+                '<p>{$foo||bar}</p>',
+                '?><p><?php echo $__Context->foo||bar ?></p>'
+            ),
+            array(
+                '<p>{htmlspecialchars($var, ENT_COMPAT | ENT_HTML401)}</p>',
+                '?><p><?php echo htmlspecialchars($__Context->var, ENT_COMPAT | ENT_HTML401) ?></p>'
             ),
             array(
                 '<p>{$foo | $bar}</p>',

--- a/tests/unit/classes/TemplateHandlerTest.php
+++ b/tests/unit/classes/TemplateHandlerTest.php
@@ -423,6 +423,18 @@ class TemplateHandlerTest extends \Codeception\TestCase\Test
                 '<p>{$foo|dafuq}</p>',
                 '?><p><?php echo \'INVALID FILTER (dafuq)\' ?></p>'
             ),
+            array(
+                '<p>{$foo||$bar}</p>',
+                '?><p><?php echo $__Context->foo||$__Context->bar ?></p>'
+            ),
+            array(
+                '<p>{htmlspecialchars($var, ENT_COMPAT|ENT_HTML401)}</p>',
+                '?><p><?php echo htmlspecialchars($__Context->var, ENT_COMPAT|ENT_HTML401) ?></p>'
+            ),
+            array(
+                '<p>{$foo | $bar}</p>',
+                '?><p><?php echo $__Context->foo | $__Context->bar ?></p>'
+            ),
         );
 
         foreach ($tests as $test)


### PR DESCRIPTION
라이믹스에도 1년 전부터 xpressengine/xe-core#1267 이 적용되어 템플릿에서 escape, noescape 등 간단한 필터의 사용이 가능했으나, 용도가 제한적이어서 널리 사용되지 못하고 있었습니다. 그래서 필터 기능을 대폭 확충하여 편리하게 사용할 수 있도록 하고, 기존의 escape 관련 문법도 여기에 흡수시켰습니다.

필터는 템플릿 컴파일 시점에 PHP 함수로 변환되고, 이후 캐시된 파일을 사용하므로 함수를 직접 사용하는 것과 속도 차이는 없습니다. 단, 필터를 많이 사용하는 템플릿을 처음 컴파일할 때 다소 시간이 소요될 수 있습니다.

### 필터 개요

템플릿에서 변수를 출력할 때

    {$var|필터1|필터2|필터3}

이런 문법을 사용하면 나열한 필터들이 순서대로 적용됩니다.

구분에 사용되는 문자는 백스페이스 키와 `+` 키 사이에 있는 `|` (파이프 문자)입니다.

### 현재 지원하는 필터 목록

간단하게 지원할 수 있는 필터부터 먼저 넣었습니다. 세계적으로 많이 사용되는 템플릿 엔진들을 참고하여 더 많은 필터를 추가할 예정입니다.

- `escape` : 변수에 `htmlspecialchars()` 함수를 적용합니다.
- `autoescape` : 변수에 `htmlspecialchars()` 함수를 적용하되, 이미 인코딩된 `&amp;` 같은 특수문자는 다시 인코딩하지 않습니다. (대부분의 경우 가장 적합한 방법)
- `noescape` : xpressengine/xe-core#1267 의 방법대로 `<config>`를 사용하여 모든 변수에 `htmlspecialchars()` 함수를 일괄 적용하도록 설정해 두었더라도 이 변수에는 적용하지 않습니다. (글 내용 등 태그를 유지해야 하는 변수에만 사용)
- `escapejs` : 변수를 자바스크립트 문자열에 안전하게 넣을 수 있도록 인코딩합니다. (문자열의 일부로 출력하는 경우 사용, 양쪽에 따옴표 필수)
- `json` : 변수를 JSON으로 인코딩합니다. (배열이나 객체 등을 자바스크립트로 전달할 때 사용)
- `strip` : 변수에서 태그를 모두 제거합니다.
  - `strip:<br>` : `<br>` 태그만 남깁니다.
  - `strip:<br><p>` : `<br><p>` 태그만 남깁니다.
  - `strip:$tags` : 남길 태그 목록을 `$tags` 변수에서 불러옵니다.
- `trim` : 변수 앞뒤의 공백을 제거합니다.
- `urlencode` : 변수를 URL에 안전하게 넣을 수 있도록 인코딩합니다.
- `lower` : 변수를 소문자로 바꾸어 출력합니다.
- `upper` : 변수를 대문자로 바꾸어 출력합니다.
- `nl2br` : 변수 내의 줄바꿈 문자를 모두 `<br>` 태그로 바꾸어 출력합니다. (주의: `nl2br` 이후에 `escape`나 `strip`을 사용하면 태그가 사라지니 순서에 주의하십시오.)
- `join` : 배열 내용을 쉼표(`,`)로 구분하여 나열합니다.
  - `join:/` : 배열 내용을 슬래시 문자(`/`)로 구분하여 나열합니다.
  - `join:\|` : 배열 내용을 파이프 문자(`|`)로 구분하여 나열합니다. 필터 구분에도 파이프 문자를 사용하므로 혼동을 막기 위해 여기서는 `\`를 붙여 `\|`로 표기해야 합니다.
  - `join:$separator` : 구분자로 사용할 내용을 `$separator` 변수에서 불러옵니다.
- `date` : 날짜 또는 시간을 `년-월-일 시:분:초` 형식으로 표시합니다. XE에서 흔히 쓰던 14자리 regdate 포맷과 유닉스 타임스탬프를 모두 지원합니다.
  - `date:Y.m.d` : 날짜 또는 시간을 `년.월.일` 형식으로 표시합니다.
  - `date:H:i` : 날짜 또는 시간을 `시:분` 형식으로 표시합니다.
  - `date:$format` : 표시할 형식을 `$format` 변수에서 불러옵니다.
- `format` : 숫자에 쉼표를 찍어서 표시합니다. (예: 12,345,678)
  - `format:2` : 숫자에 쉼표를 찍고, 소수점 아래 2자리까지 표시합니다.
  - `format:$num` : 숫자에 쉼표를 찍고, 소수점 아래 표시할 자릿수는 `$num` 변수에서 불러옵니다.
- `link` : 문자열을 링크로 바꾸어 출력합니다.
  - `link:https://www.rhymix.org` : 링크할 주소를 직접 지정합니다.
  - `link:$url` : 링크할 주소를 `$url` 변수에서 불러옵니다.

### 필터 사용 예제

변수를 소문자로 바꾸어 출력

```
{$var|lower}
```

배열을 하나로 합친 후 (`/` 구분자 사용) 특수문자를 인코딩하고 줄바꿈을 `<br>` 태그로 변환

```
{$array|join:/|escape|nl2br}
```

문서 작성 날짜를 년.월.일 형식으로 표시

```
{$oDocument->get('regdate')|date:Y.m.d}
```

변수의 특수문자를 인코딩한 후 링크로 변환

```
{$url|escape|link}
```

자바스크립트 변수 사용 예제

```
<script>
    var title = '제목은 {$title|escapejs}입니다';  // 문자열 내에 삽입
    var names = {$names|json};  // 배열을 통째로 전달 (따옴표 없음)
</script>
```

### 기타

PHP에서 사용하는 `|` (bitwise or) 및 `||` (boolean or) 연산자가 필터 구분자로 잘못 해석되지 않도록, `|` 문자 앞뒤에 공백이 있거나 `|` 문자 직후에 특수문자가 나오면 필터로 인식하지 않도록 했습니다.

필터 기능을 사용하지 않는 기존 레이아웃이나 스킨 등과의 호환성 문제는 발생하지 않는 것으로 보이며, 다수의 유닛 테스트를 작성하여 필터의 정상 작동을 확인했습니다.

HTML 필터링과 관련하여 xpressengine/xe-core#1267 과 다른 점이 한 가지 있습니다. `autoescape` 필터가 더이상 `<config autoescape="on" />` 설정의 영향을 받지 않고 항상 `htmlspecialchars()` 함수를 적용합니다. 이중 인코딩을 하지 않을 뿐입니다. (설정의 영향을 받는 `auto` 필터는 호환성을 위해 그대로 두었으나 사용을 권장하지 않습니다. 현재 라이믹스 코어에서 이 기능을 사용하는 템플릿은 없습니다.)

기존 방식대로 `<config autoescape="on" />` 설정이 되어 있더라도 `escape`, `autoescape` 등의 필터를 사용하면 필터가 우선순위를 가지므로 이중으로 인코딩될 위험은 없습니다.

### 관련 이슈

#269 
