### PR TITLE
messageMobile::dispMessage() 메서드의 인자값호환성 개선.

### DIFF
--- a/modules/message/message.mobile.php
+++ b/modules/message/message.mobile.php
@@ -13,7 +13,7 @@ class messageMobile extends messageView
 	/**
 	 * @brief Message output
 	 **/
-	function dispMessage()
+	function dispMessage($detail = null)
 	{
 		// Get configurations (using module model object)
 		$oModuleModel = getModel('module');


### PR DESCRIPTION
messageMobile::dispMessage() 메서드에 보면 선언함수가 없습니다.
그렇지만 messageView::dispMessage() 에는 ($detail=NULL)이라는 선언함수가 있습니다.
그래서 php7.1 에서 messageView와 선언함수의 호환성이 안맞다고 오류가 나타납니다.

이를 해결합니다.

기본적으로 함수값 추가정도만 해뒀는데 mobileView에서는 해당 함수를 사용할 필요가 없어서 함수를 추가하지 않아서 생긴 오류같네요.