### PR TITLE
댓글 삭제할때에도 휴지통 사용여부에 따라 휴지통으로 이동할 수 있도록 기능 추가

### DIFF
--- a/modules/board/board.controller.php
+++ b/modules/board/board.controller.php
@@ -527,12 +527,14 @@ class boardController extends board
 		// generate comment  controller object
 		$oCommentController = getController('comment');
 
+		$updateComment = false;
 		if($this->module_info->comment_delete_message === 'yes' && $instant_delete != 'Y')
 		{
 			$output = $oCommentController->updateCommentByDelete($comment, $this->grant->manager);
+			$updateComment = true;
 			if($this->module_info->trash_use == 'Y')
 			{
-				$output = $oCommentController->moveCommentToTrash($comment);
+				$output = $oCommentController->moveCommentToTrash($comment, $updateComment);
 			}
 		}
 		elseif(starts_with('only_comm', $this->module_info->comment_delete_message) && $instant_delete != 'Y')
@@ -541,16 +543,17 @@ class boardController extends board
 			if(count($childs) > 0)
 			{
 				$output = $oCommentController->updateCommentByDelete($comment, $this->grant->manager);
+				$updateComment = true;
 				if($this->module_info->trash_use == 'Y')
 				{
-					$output = $oCommentController->moveCommentToTrash($comment);
+					$output = $oCommentController->moveCommentToTrash($comment, $updateComment);
 				}
 			}
 			else
 			{
 				if($this->module_info->trash_use == 'Y')
 				{
-					$output = $oCommentController->moveCommentToTrash($comment);
+					$output = $oCommentController->moveCommentToTrash($comment, $updateComment);
 				}
 				else
 				{
@@ -566,7 +569,7 @@ class boardController extends board
 		{
 			if($this->module_info->trash_use == 'Y')
 			{
-				$output = $oCommentController->moveCommentToTrash($comment);
+				$output = $oCommentController->moveCommentToTrash($comment, $this->module_info->comment_delete_message);
 			}
 			else
 			{

--- a/modules/board/board.controller.php
+++ b/modules/board/board.controller.php
@@ -530,6 +530,10 @@ class boardController extends board
 		if($this->module_info->comment_delete_message === 'yes' && $instant_delete != 'Y')
 		{
 			$output = $oCommentController->updateCommentByDelete($comment, $this->grant->manager);
+			if($this->module_info->trash_use == 'Y')
+			{
+				$output = $oCommentController->moveCommentToTrash($comment);
+			}
 		}
 		elseif(starts_with('only_comm', $this->module_info->comment_delete_message) && $instant_delete != 'Y')
 		{
@@ -537,22 +541,40 @@ class boardController extends board
 			if(count($childs) > 0)
 			{
 				$output = $oCommentController->updateCommentByDelete($comment, $this->grant->manager);
+				if($this->module_info->trash_use == 'Y')
+				{
+					$output = $oCommentController->moveCommentToTrash($comment);
+				}
 			}
 			else
 			{
-				$output = $oCommentController->deleteComment($comment_srl, $this->grant->manager, FALSE, $childs);
-				if(!$output->toBool())
+				if($this->module_info->trash_use == 'Y')
 				{
-					return $output;
+					$output = $oCommentController->moveCommentToTrash($comment);
+				}
+				else
+				{
+					$output = $oCommentController->deleteComment($comment_srl, $this->grant->manager, FALSE, $childs);
+					if(!$output->toBool())
+					{
+						return $output;
+					}
 				}
 			}
 		}
 		else
 		{
-			$output = $oCommentController->deleteComment($comment_srl, $this->grant->manager);
-			if(!$output->toBool())
+			if($this->module_info->trash_use == 'Y')
 			{
-				return $output;
+				$output = $oCommentController->moveCommentToTrash($comment);
+			}
+			else
+			{
+				$output = $oCommentController->deleteComment($comment_srl, $this->grant->manager);
+				if(!$output->toBool())
+				{
+					return $output;
+				}
 			}
 		}
 

--- a/modules/comment/comment.admin.controller.php
+++ b/modules/comment/comment.admin.controller.php
@@ -473,7 +473,7 @@ class commentAdminController extends comment
 
 		if($oComment)
 		{
-			$output = $oCommentController->updateCommentByRestore();
+			$output = $oCommentController->updateCommentByRestore($originObject, true);
 		}
 		else
 		{

--- a/modules/comment/comment.admin.controller.php
+++ b/modules/comment/comment.admin.controller.php
@@ -467,7 +467,18 @@ class commentAdminController extends comment
 		$obj->module_srl = $originObject->module_srl;
 
 		$oCommentController = getController('comment');
-		$output = $oCommentController->insertComment($obj, true);
+		$oCommentModel = getModel('comment');
+
+		$oComment = $oCommentModel->getComment($originObject->comment_srl);
+
+		if($oComment)
+		{
+			$output = $oCommentController->updateCommentByRestore();
+		}
+		else
+		{
+			$output = $oCommentController->insertComment($obj, true);
+		}
 
 		return $output;
 	}

--- a/modules/comment/comment.admin.controller.php
+++ b/modules/comment/comment.admin.controller.php
@@ -473,7 +473,7 @@ class commentAdminController extends comment
 
 		if($oComment)
 		{
-			$output = $oCommentController->updateCommentByRestore($originObject, true);
+			$output = $oCommentController->updateCommentByRestore($originObject);
 		}
 		else
 		{

--- a/modules/comment/comment.admin.controller.php
+++ b/modules/comment/comment.admin.controller.php
@@ -471,9 +471,9 @@ class commentAdminController extends comment
 
 		$oComment = $oCommentModel->getComment($originObject->comment_srl);
 
-		if($oComment)
+		if($oComment->isExists())
 		{
-			$output = $oCommentController->updateCommentByRestore($originObject);
+			$output = $oCommentController->updateCommentByRestore($obj);
 		}
 		else
 		{

--- a/modules/comment/comment.controller.php
+++ b/modules/comment/comment.controller.php
@@ -992,7 +992,6 @@ class commentController extends comment
 		$oDB->begin();
 
 		$obj->status = RX_STATUS_PUBLIC;
-		$obj->member_srl = 0;
 		// use to query default
 		unset($obj->last_update);
 		$output = executeQuery('comment.updateCommentByRestore', $obj);

--- a/modules/comment/comment.controller.php
+++ b/modules/comment/comment.controller.php
@@ -980,7 +980,7 @@ class commentController extends comment
 		return $output;
 	}
 
-	function updateCommentByRestore($obj, $is_admin = FALSE)
+	function updateCommentByRestore($obj)
 	{
 		if (!$obj->comment_srl)
 		{
@@ -993,6 +993,8 @@ class commentController extends comment
 
 		$obj->status = RX_STATUS_PUBLIC;
 		$obj->member_srl = 0;
+		// use to query default
+		unset($obj->last_update);
 		$output = executeQuery('comment.updateCommentByDelete', $obj);
 		if(!$output->toBool())
 		{

--- a/modules/comment/comment.controller.php
+++ b/modules/comment/comment.controller.php
@@ -995,7 +995,7 @@ class commentController extends comment
 		$obj->member_srl = 0;
 		// use to query default
 		unset($obj->last_update);
-		$output = executeQuery('comment.updateCommentByDelete', $obj);
+		$output = executeQuery('comment.updateCommentByRestore', $obj);
 		if(!$output->toBool())
 		{
 			$oDB->rollback();

--- a/modules/comment/lang/ko.php
+++ b/modules/comment/lang/ko.php
@@ -56,3 +56,4 @@ $lang->msg_admin_deleted_comment = '관리자가 삭제한 댓글입니다.';
 $lang->msg_no_text_comment = '글자가 없는 댓글입니다.';
 $lang->msg_comment_notify_mail = '[%s] 새로운 댓글이 등록되었습니다 : %s';
 $lang->msg_admin_comment_no_move_to_trash = '최고관리자의 댓글을 휴지통으로 이동시킬 권한이 없습니다.';
+$lang->msg_module_srl_not_exists = '모듈 번호가 존재하지 않습니다.';

--- a/modules/comment/lang/ko.php
+++ b/modules/comment/lang/ko.php
@@ -55,3 +55,4 @@ $lang->msg_deleted_comment = '삭제된 댓글입니다.';
 $lang->msg_admin_deleted_comment = '관리자가 삭제한 댓글입니다.';
 $lang->msg_no_text_comment = '글자가 없는 댓글입니다.';
 $lang->msg_comment_notify_mail = '[%s] 새로운 댓글이 등록되었습니다 : %s';
+$lang->msg_admin_comment_no_move_to_trash = '최고관리자의 댓글을 휴지통으로 이동시킬 권한이 없습니다.';

--- a/modules/comment/queries/updateCommentByRestore.xml
+++ b/modules/comment/queries/updateCommentByRestore.xml
@@ -1,0 +1,14 @@
+<query id="updateCommentByRestore" action="update">
+	<tables>
+		<table name="comments" />
+	</tables>
+	<columns>
+		<column name="member_srl" var="member_srl" />
+		<column name="content" var="content" notnull="notnull" />
+		<column name="last_update" var="last_update" default="curdate()" />
+		<column name="status" var="status" default="1" />
+	</columns>
+	<conditions>
+		<condition operation="equal" column="comment_srl" var="comment_srl" filter="number" notnull="notnull" />
+	</conditions>
+</query>


### PR DESCRIPTION
#683 댓글 삭제할때에도 휴지통 사용 여부에 따라 휴지통으로 이동할 수 있도록 기능 추가해보았습니다.

댓글 자리남김의 경우 댓글 자리남기면서 해당 게시글을 휴지통에 담아두고 나중에 복원할 경우 해당 댓글이 있는경우를 검사하여 **해당글을 다시 원래글로 수정** 하는 방법으로 수정해보도록 하겠습니다.

- [x] 댓글 삭제시 휴지통 사용여부에 따라 휴지통으로 이동하는 기능 추가
- [x] 댓글 자리 남김 기능여부에 따라 휴지통 복원 처리 개선
