### PR TITLE
모듈 권한 정리 및 퍼미션 체크 지원

### DIFF
--- a/classes/module/ModuleHandler.class.php
+++ b/classes/module/ModuleHandler.class.php
@@ -655,7 +655,7 @@ class ModuleHandler extends Handler
 				{
 					$oModule = self::getModuleInstance($forward->module, $type, $kind);
 				}
-
+				
 				if(!is_object($oModule))
 				{
 					self::_setInputErrorToContext();
@@ -669,57 +669,26 @@ class ModuleHandler extends Handler
 					}
 					return $oMessageObject;
 				}
-
-				if($this->module == "admin" && $type == "view")
+				
+				// Protect admin action
+				if(($this->module == 'admin' || $kind == 'admin') && !$oModuleModel->getGrant($this->module_info, $logged_info)->root)
 				{
-					if($logged_info->is_admin == 'Y')
-					{
-						if($this->act != 'dispLayoutAdminLayoutModify')
-						{
-							$oAdminView = getAdminView('admin');
-							$oAdminView->makeGnbUrl($forward->module);
-							$oModule->setLayoutPath("./modules/admin/tpl");
-							$oModule->setLayoutFile("layout.html");
-						}
-					}
-					else
-					{
-						self::_setInputErrorToContext();
-
-						$this->error = 'admin.msg_is_not_administrator';
-						$oMessageObject = self::getModuleInstance('message', $display_mode);
-						$oMessageObject->setError(-1);
-						$oMessageObject->setMessage($this->error);
-						$oMessageObject->dispMessage();
-						return $oMessageObject;
-					}
+					self::_setInputErrorToContext();
+					$this->error = 'admin.msg_is_not_administrator';
+					$oMessageObject = self::getModuleInstance('message', $display_mode);
+					$oMessageObject->setError(-1);
+					$oMessageObject->setMessage($this->error);
+					$oMessageObject->dispMessage();
+					return $oMessageObject;
 				}
-				if($kind == 'admin')
+				
+				// Admin page layout
+				if($this->module == 'admin' && $type == 'view' && $this->act != 'dispLayoutAdminLayoutModify')
 				{
-					$grant = $oModuleModel->getGrant($this->module_info, $logged_info);
-					if(!$grant->root)
-					{
-						self::_setInputErrorToContext();
-						$this->error = 'admin.msg_is_not_administrator';
-						$oMessageObject = self::getModuleInstance('message', $display_mode);
-						$oMessageObject->setError(-1);
-						$oMessageObject->setMessage($this->error);
-						$oMessageObject->dispMessage();
-						return $oMessageObject;
-					}
-					else
-					{
-						if(!$grant->is_admin && $this->module != $this->orig_module->module && $xml_info->permission->{$this->act} != 'root')
-						{
-							self::_setInputErrorToContext();
-							$this->error = 'admin.msg_is_not_administrator';
-							$oMessageObject = self::getModuleInstance('message', $display_mode);
-							$oMessageObject->setError(-1);
-							$oMessageObject->setMessage($this->error);
-							$oMessageObject->dispMessage();
-							return $oMessageObject;
-						}
-					}
+					$oAdminView = getAdminView('admin');
+					$oAdminView->makeGnbUrl($forward->module);
+					$oModule->setLayoutPath("./modules/admin/tpl");
+					$oModule->setLayoutFile("layout.html");
 				}
 			}
 			else if($xml_info->default_index_act && method_exists($oModule, $xml_info->default_index_act))
@@ -734,7 +703,7 @@ class ModuleHandler extends Handler
 				return $oModule;
 			}
 		}
-
+		
 		// ruleset check...
 		if(!empty($ruleset))
 		{

--- a/classes/module/ModuleHandler.class.php
+++ b/classes/module/ModuleHandler.class.php
@@ -697,7 +697,7 @@ class ModuleHandler extends Handler
 				if($kind == 'admin')
 				{
 					$grant = $oModuleModel->getGrant($this->module_info, $logged_info);
-					if(!$grant->manager)
+					if(!$grant->root)
 					{
 						self::_setInputErrorToContext();
 						$this->error = 'admin.msg_is_not_administrator';
@@ -709,7 +709,7 @@ class ModuleHandler extends Handler
 					}
 					else
 					{
-						if(!$grant->is_admin && $this->module != $this->orig_module->module && $xml_info->permission->{$this->act} != 'manager')
+						if(!$grant->is_admin && $this->module != $this->orig_module->module && $xml_info->permission->{$this->act} != 'root')
 						{
 							self::_setInputErrorToContext();
 							$this->error = 'admin.msg_is_not_administrator';

--- a/classes/module/ModuleHandler.class.php
+++ b/classes/module/ModuleHandler.class.php
@@ -671,15 +671,18 @@ class ModuleHandler extends Handler
 				}
 				
 				// Protect admin action
-				if(($this->module == 'admin' || $kind == 'admin') && !$oModuleModel->getGrant($this->module_info, $logged_info)->root)
+				if(($this->module == 'admin' || $kind == 'admin') && !$oModuleModel->getGrant($forward, $logged_info)->root)
 				{
-					self::_setInputErrorToContext();
-					$this->error = 'admin.msg_is_not_administrator';
-					$oMessageObject = self::getModuleInstance('message', $display_mode);
-					$oMessageObject->setError(-1);
-					$oMessageObject->setMessage($this->error);
-					$oMessageObject->dispMessage();
-					return $oMessageObject;
+					if($this->module == 'admin' || strpos($xml_info->permission->{$this->act}, 'manager') === false)
+					{
+						self::_setInputErrorToContext();
+						$this->error = 'admin.msg_is_not_administrator';
+						$oMessageObject = self::getModuleInstance('message', $display_mode);
+						$oMessageObject->setError(-1);
+						$oMessageObject->setMessage($this->error);
+						$oMessageObject->dispMessage();
+						return $oMessageObject;
+					}
 				}
 				
 				// Admin page layout

--- a/classes/module/ModuleObject.class.php
+++ b/classes/module/ModuleObject.class.php
@@ -298,7 +298,7 @@ class ModuleObject extends Object
 			else if(strpos($permission, 'manager') !== false && !$grant->manager)
 			{
 				// If permission is '*-managers', search modules to find manager privilege of the member
-				if(Context::get('is_logged') && $find && preg_match('/^(.+)-managers$/', $permission, $type) && $type[1])
+				if(Context::get('is_logged') && $find && preg_match('/^([a-z0-9\_]+)-managers$/', $permission, $type) && $type[1])
 				{
 					// Manager privilege of the member is found by search all modules, Pass
 					if($type[1] == 'all' && getModel('module')->findManagerPrivilege($member_info) !== false)

--- a/classes/module/ModuleObject.class.php
+++ b/classes/module/ModuleObject.class.php
@@ -246,7 +246,7 @@ class ModuleObject extends Object
 	 * */
 	function checkPermissionBySrl($target_srl, $type = null, $xml_info = null)
 	{
-		if(!preg_match('/^([0-9]+)$/', $target_srl))
+		if(!preg_match('/^([0-9]+)$/', $target_srl) && $type != 'module')
 		{
 			$this->stop('msg_invalid_request');
 			return false;
@@ -258,13 +258,24 @@ class ModuleObject extends Object
 			{
 				$target_srl = getModel('document')->getDocument($target_srl, false, false)->get('module_srl');
 			}
-			if($type == 'comment')
+			else if($type == 'comment')
 			{
 				$target_srl = getModel('comment')->getComment($target_srl)->get('module_srl');
 			}
+			else if($type == 'file')
+			{
+				$target_srl = getModel('file')->getFile($target_srl)->module_srl;
+			}
+			else if($type == 'module')
+			{
+				$module_info = getModel('module')->getModuleInfoByMid($target_srl)->module_srl;
+			}
 		}
 		
-		$module_info = getModel('module')->getModuleInfoByModuleSrl($target_srl);
+		if(!isset($module_info))
+		{
+			$module_info = getModel('module')->getModuleInfoByModuleSrl($target_srl);
+		}
 		
 		if(!$module_info->module_srl)
 		{

--- a/classes/module/ModuleObject.class.php
+++ b/classes/module/ModuleObject.class.php
@@ -297,16 +297,21 @@ class ModuleObject extends Object
 			// If permission is 'manager', check 'is user have manager privilege(granted)'
 			else if(strpos($permission, 'manager') !== false && !$grant->manager)
 			{
-				// If permission is 'all-managers','same-managers', search modules to find manager privilege of the member
-				if(Context::get('is_logged') && $find)
+				// If permission is '*-managers', search modules to find manager privilege of the member
+				if(Context::get('is_logged') && $find && preg_match('/^(.+)-managers$/', $permission, $type) && $type[1])
 				{
-					// if permission is 'all-managers', and manager privilege of the member is found by search all modules, Pass
-					if($permission == 'all-managers' && getModel('module')->findManagerPrivilege($member_info) !== false)
+					// Manager privilege of the member is found by search all modules, Pass
+					if($type[1] == 'all' && getModel('module')->findManagerPrivilege($member_info) !== false)
 					{
 						return true;
 					}
-					// if permission is 'same-managers', and manager privilege of the member is found by search same modules, Pass
-					else if($permission == 'same-managers' && getModel('module')->findManagerPrivilege($member_info, $this->module) !== false)
+					// Manager privilege of the member is found by search same module as this module, Pass
+					else if($type[1] == 'same' && getModel('module')->findManagerPrivilege($member_info, $this->module) !== false)
+					{
+						return true;
+					}
+					// Manager privilege of the member is found by search same module as the module, Pass
+					else if(getModel('module')->findManagerPrivilege($member_info, $type[1]) !== false)
 					{
 						return true;
 					}

--- a/classes/module/ModuleObject.class.php
+++ b/classes/module/ModuleObject.class.php
@@ -213,7 +213,7 @@ class ModuleObject extends Object
 					$module_grant = $oModuleModel->getGrant($request_module, $logged_info);
 					
 					// Check permissions
-					if(!$this->checkPermission($module_grant, $xml_info))
+					if(!$this->checkPermission($xml_info, $module_grant))
 					{
 						return;
 					}
@@ -230,7 +230,7 @@ class ModuleObject extends Object
 		}
 		
 		// Check permissions
-		if(!isset($checked) && !$this->checkPermission($grant, $xml_info))
+		if(!isset($checked) && !$this->checkPermission($xml_info, $grant))
 		{
 			return;
 		}

--- a/classes/module/ModuleObject.class.php
+++ b/classes/module/ModuleObject.class.php
@@ -302,8 +302,8 @@ class ModuleObject extends Object
 			$grant = getModel('module')->getGrant($this->module_info, Context::get('logged_info'), $xml_info);
 		}
 		
-		// If manager, Pass
-		if($grant->manager)
+		// If an administrator, Pass
+		if($grant->root)
 		{
 			return true;
 		}
@@ -325,7 +325,12 @@ class ModuleObject extends Object
 				$this->stop('msg_not_permitted_act');
 				return false;
 			}
-			else if(in_array($permission, array('root', 'manager')))
+			else if($permission == 'manager' && !$grant->manager)
+			{
+				$this->stop('admin.msg_is_not_administrator');
+				return false;
+			}
+			else if($permission == 'root')
 			{
 				$this->stop('admin.msg_is_not_administrator');
 				return false;

--- a/classes/module/ModuleObject.class.php
+++ b/classes/module/ModuleObject.class.php
@@ -268,7 +268,7 @@ class ModuleObject extends Object
 			}
 			else if($type == 'module')
 			{
-				$module_info = getModel('module')->getModuleInfoByMid($target_srl)->module_srl;
+				$module_info = getModel('module')->getModuleInfoByMid($target_srl);
 			}
 		}
 		

--- a/classes/module/ModuleObject.class.php
+++ b/classes/module/ModuleObject.class.php
@@ -322,10 +322,10 @@ class ModuleObject extends Object
 		// get permission types(guest, member, manager, root) of the currently requested action
 		$permission = $xml_info->permission->{$this->act};
 		
-		// check manager if a permission in module.xml otherwise action if no permission
-		if(!$permission && substr_count($this->act, 'Admin'))
+		// If admin action, default permission
+		if(!$permission && stripos($this->act, 'admin') !== false)
 		{
-			$permission = 'manager';
+			$permission = 'root';
 		}
 		
 		// Check permissions

--- a/classes/module/ModuleObject.class.php
+++ b/classes/module/ModuleObject.class.php
@@ -171,11 +171,12 @@ class ModuleObject extends Object
 		$this->module_config = $oModuleModel->getModuleConfig($this->module, $module_info->site_srl);
 		
 		$logged_info = Context::get('logged_info');
+		$permission_check = $xml_info->permission_check->{$this->act};
 		
 		// If permission check target is not the current module
-		if($xml_info->permission_check->{$action}->key && $check_module_srl = Context::get($xml_info->permission_check->{$action}->key))
+		if($permission_check->key && $check_module_srl = Context::get($permission_check->key))
 		{
-			if($info->permission_check->{$action}->array === '' && !is_array($check_module_srl))
+			if($permission_check->array === '' && !is_array($check_module_srl))
 			{
 				if(!preg_match('/^([0-9]+)$/', $check_module_srl))
 				{
@@ -197,7 +198,7 @@ class ModuleObject extends Object
 			{
 				if(!is_array($check_module_srl))
 				{
-					$check_module_srl = explode($info->permission_check->{$action}->array, $check_module_srl);
+					$check_module_srl = explode($permission_check->array, $check_module_srl);
 				}
 				
 				foreach($check_module_srl as $module_srl)

--- a/classes/module/ModuleObject.class.php
+++ b/classes/module/ModuleObject.class.php
@@ -174,7 +174,7 @@ class ModuleObject extends Object
 		$permission_check = $xml_info->permission_check->{$this->act};
 		
 		// If permission check target is not the current module
-		if($permission_check->key && $check_module_srl = Context::get($permission_check->key))
+		if($permission_check->key && $check_module_srl = trim(Context::get($permission_check->key)))
 		{
 			// If value is array
 			if(is_array($check_module_srl) || preg_match('/,|\|@\|/', $check_module_srl, $delimiter))
@@ -246,7 +246,7 @@ class ModuleObject extends Object
 	 * */
 	function checkPermissionBySrl($target_srl, $type = null, $xml_info = null)
 	{
-		if(!preg_match('/^([0-9]+)$/', $target_srl) && $type != 'module')
+		if(!($target_srl = trim($target_srl)) || !preg_match('/^([0-9]+)$/', $target_srl) && $type != 'module')
 		{
 			$this->stop('msg_invalid_request');
 			return false;

--- a/modules/addon/conf/info.xml
+++ b/modules/addon/conf/info.xml
@@ -1,39 +1,39 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module version="0.2">
-    <title xml:lang="ko">애드온</title>
-    <title xml:lang="en">Addon</title>
-    <title xml:lang="vi">Addon</title>
-    <title xml:lang="es">Addon</title>
-    <title xml:lang="zh-CN">插件管理</title>
-    <title xml:lang="jp">アドオン</title>
-    <title xml:lang="fr">Additions</title>
-    <title xml:lang="ru">Аддон</title>
-    <title xml:lang="zh-TW">附加元件</title>
-    <title xml:lang="tr">Eklenti</title>
-    <description xml:lang="ko">애드온을 등록하거나 사용/미사용을 설정합니다.</description>
-    <description xml:lang="en">This is for maintaining addons which can toggle between two states when use and not used.</description>
-    <description xml:lang="vi">Module này dành cho việc bảo trì những Addon đang sử dụng và không sử dụng.</description>
-    <description xml:lang="es">Este Módulo es para agregar Addons, como también el manejo de ellos.</description>
-    <description xml:lang="zh-CN">登录插件或设置启用/禁用插件的管理模块。</description>
-    <description xml:lang="jp">アドオンの登録、もしくは「使用・未使用」を設定します。</description>
-    <description xml:lang="fr">Ce module est pour les Additions de maintien qui peuvent basculer des états d'utilisation et de désuétude. </description>
-    <description xml:lang="ru">Этот модуль служит для управления аддонами, использование которых Вы можете включать и выключать.</description>
-    <description xml:lang="zh-TW">設定附加元件「登錄、啟用、禁用」的管理模組。</description>
-    <description xml:lang="tr">Bu modül, kullanımı değişebilecek veya kullanım dışı kalabilecek eklentileri korumak içindir.</description>
-    <version>1.7</version>
-    <date>2013-11-27</date>
-    <category>utility</category>
+	<title xml:lang="ko">애드온</title>
+	<title xml:lang="en">Addon</title>
+	<title xml:lang="vi">Addon</title>
+	<title xml:lang="es">Addon</title>
+	<title xml:lang="zh-CN">插件管理</title>
+	<title xml:lang="jp">アドオン</title>
+	<title xml:lang="fr">Additions</title>
+	<title xml:lang="ru">Аддон</title>
+	<title xml:lang="zh-TW">附加元件</title>
+	<title xml:lang="tr">Eklenti</title>
+	<description xml:lang="ko">애드온을 등록하거나 사용/미사용을 설정합니다.</description>
+	<description xml:lang="en">This is for maintaining addons which can toggle between two states when use and not used.</description>
+	<description xml:lang="vi">Module này dành cho việc bảo trì những Addon đang sử dụng và không sử dụng.</description>
+	<description xml:lang="es">Este Módulo es para agregar Addons, como también el manejo de ellos.</description>
+	<description xml:lang="zh-CN">登录插件或设置启用/禁用插件的管理模块。</description>
+	<description xml:lang="jp">アドオンの登録、もしくは「使用・未使用」を設定します。</description>
+	<description xml:lang="fr">Ce module est pour les Additions de maintien qui peuvent basculer des états d'utilisation et de désuétude. </description>
+	<description xml:lang="ru">Этот модуль служит для управления аддонами, использование которых Вы можете включать и выключать.</description>
+	<description xml:lang="zh-TW">設定附加元件「登錄、啟用、禁用」的管理模組。</description>
+	<description xml:lang="tr">Bu modül, kullanımı değişebilecek veya kullanım dışı kalabilecek eklentileri korumak içindir.</description>
+	<version>1.7</version>
+	<date>2013-11-27</date>
+	<category>utility</category>
 
-    <author email_address="developers@xpressengine.com" link="http://xpressengine.com/">
-        <name xml:lang="ko">NAVER</name>
-        <name xml:lang="en">NAVER</name>
-        <name xml:lang="vi">NAVER</name>
-        <name xml:lang="es">NAVER</name>
-        <name xml:lang="zh-CN">NAVER</name>
-        <name xml:lang="jp">NAVER</name>
-        <name xml:lang="fr">NAVER</name>
-        <name xml:lang="ru">NAVER</name>
-        <name xml:lang="zh-TW">NAVER</name>
-        <name xml:lang="tr">NAVER</name>
-    </author>
+	<author email_address="developers@xpressengine.com" link="http://xpressengine.com/">
+		<name xml:lang="ko">NAVER</name>
+		<name xml:lang="en">NAVER</name>
+		<name xml:lang="vi">NAVER</name>
+		<name xml:lang="es">NAVER</name>
+		<name xml:lang="zh-CN">NAVER</name>
+		<name xml:lang="jp">NAVER</name>
+		<name xml:lang="fr">NAVER</name>
+		<name xml:lang="ru">NAVER</name>
+		<name xml:lang="zh-TW">NAVER</name>
+		<name xml:lang="tr">NAVER</name>
+	</author>
 </module>

--- a/modules/addon/conf/module.xml
+++ b/modules/addon/conf/module.xml
@@ -1,19 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <module>
-    <grants />
-    <permissions>
-	<permission action="procAddonAdminToggleActivate" target="manager" />
-	<permission action="dispAddonAdminSetup" target="manager" />
-	<permission action="procAddonAdminSetupAddon" target="manager" />
-    </permissions>
-    <actions>
-        <action name="dispAddonAdminIndex" type="view" admin_index="true" menu_name="installedAddon" menu_index="true" />
-        <action name="dispAddonAdminInfo" type="view" />
-        <action name="dispAddonAdminSetup" type="view" menu_name="installedAddon" />
-        <action name="procAddonAdminToggleActivate" type="controller" />
-        <action name="procAddonAdminSetupAddon" type="controller" ruleset="updateAddonSetup" />
-	<action name="procAddonAdminSaveActivate" type="controller" />
-    </actions>
+	<grants />
+	<permissions />
+	<actions>
+		<action name="dispAddonAdminIndex" type="view" admin_index="true" menu_name="installedAddon" menu_index="true" />
+		<action name="dispAddonAdminInfo" type="view" />
+		<action name="dispAddonAdminSetup" type="view" menu_name="installedAddon" />
+		
+		<action name="procAddonAdminToggleActivate" type="controller" />
+		<action name="procAddonAdminSetupAddon" type="controller" ruleset="updateAddonSetup" />
+		<action name="procAddonAdminSaveActivate" type="controller" />
+	</actions>
 	<menus>
 		<menu name="installedAddon">
 			<title xml:lang="en">Add-ons</title>

--- a/modules/admin/conf/info.xml
+++ b/modules/admin/conf/info.xml
@@ -1,36 +1,36 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module version="0.2">
-    <title xml:lang="ko">관리자 모듈</title>
-    <title xml:lang="en">Administrator Module</title>
-    <title xml:lang="vi">Administrator Module</title>
-    <title xml:lang="es">Módulo del administrador</title>
-    <title xml:lang="zh-CN">管理员模块</title>
-    <title xml:lang="jp">管理者用モジュール</title>
-    <title xml:lang="ru">Модуль администратора</title>
-    <title xml:lang="zh-TW">管理員模組</title>
-    <title xml:lang="tr">Yönetici Modülü</title>
-    <description xml:lang="ko">각 모듈의 기능을 나열하고 관리자용 레이아웃을 적용하여 관리 기능을 사용할 수 있도록 하는 모듈입니다.</description>
-    <description xml:lang="en">This module shows a list of features for each module. By applying the administrator layout it is possible to use administrator features.</description>
-    <description xml:lang="vi">Module này hiển thị thông tin của những Module đã được cài đặt, và cho phép bạn sử dụng quyền của Administrator để thiết lập giao diện.</description>
-    <description xml:lang="es">Este módulo muestra una lista de características de cada módulo, en donde puede activar la función de la administracion aplicando el diseño del administrador.</description>
-    <description xml:lang="zh-CN">列出各模块的功能并使用管理员布局，可以让其使用管理功能的模块。</description>
-    <description xml:lang="jp">各モジュールの機能を表示し、かつ管理者用のレイアウトを適用させて、管理機能が使用出来るようにします。</description>
-    <description xml:lang="ru">Этот модуль показывает список возможностей каждого модуля, и позволяет Вам использовать несколько менеджеров, применяя лейаут для администратора.</description>
-    <description xml:lang="zh-TW">列出各模組的功能及使用管理員版面，並可使用管理功能的模組。</description>
-    <description xml:lang="tr">Bu modül size, her modülün özelliklerini barındıran bir liste gösterir ve yöneticiler için yerleşim düzeni uygulayarak, yöneticilerin birkaçını kullanma imkanı sunar.</description>
-    <version>1.7</version>
-    <date>2013-11-27</date>
-    <category>system</category>
+	<title xml:lang="ko">관리자 모듈</title>
+	<title xml:lang="en">Administrator Module</title>
+	<title xml:lang="vi">Administrator Module</title>
+	<title xml:lang="es">Módulo del administrador</title>
+	<title xml:lang="zh-CN">管理员模块</title>
+	<title xml:lang="jp">管理者用モジュール</title>
+	<title xml:lang="ru">Модуль администратора</title>
+	<title xml:lang="zh-TW">管理員模組</title>
+	<title xml:lang="tr">Yönetici Modülü</title>
+	<description xml:lang="ko">각 모듈의 기능을 나열하고 관리자용 레이아웃을 적용하여 관리 기능을 사용할 수 있도록 하는 모듈입니다.</description>
+	<description xml:lang="en">This module shows a list of features for each module. By applying the administrator layout it is possible to use administrator features.</description>
+	<description xml:lang="vi">Module này hiển thị thông tin của những Module đã được cài đặt, và cho phép bạn sử dụng quyền của Administrator để thiết lập giao diện.</description>
+	<description xml:lang="es">Este módulo muestra una lista de características de cada módulo, en donde puede activar la función de la administracion aplicando el diseño del administrador.</description>
+	<description xml:lang="zh-CN">列出各模块的功能并使用管理员布局，可以让其使用管理功能的模块。</description>
+	<description xml:lang="jp">各モジュールの機能を表示し、かつ管理者用のレイアウトを適用させて、管理機能が使用出来るようにします。</description>
+	<description xml:lang="ru">Этот модуль показывает список возможностей каждого модуля, и позволяет Вам использовать несколько менеджеров, применяя лейаут для администратора.</description>
+	<description xml:lang="zh-TW">列出各模組的功能及使用管理員版面，並可使用管理功能的模組。</description>
+	<description xml:lang="tr">Bu modül size, her modülün özelliklerini barındıran bir liste gösterir ve yöneticiler için yerleşim düzeni uygulayarak, yöneticilerin birkaçını kullanma imkanı sunar.</description>
+	<version>1.7</version>
+	<date>2013-11-27</date>
+	<category>system</category>
 
-    <author email_address="developers@xpressengine.com" link="http://xpressengine.com/">
-        <name xml:lang="ko">NAVER</name>
-        <name xml:lang="en">NAVER</name>
-        <name xml:lang="vi">NAVER</name>
-        <name xml:lang="es">NAVER</name>
-        <name xml:lang="zh-CN">NAVER</name>
-        <name xml:lang="jp">NAVER</name>
-        <name xml:lang="ru">NAVER</name>
-        <name xml:lang="zh-TW">NAVER</name>
-        <name xml:lang="tr">NAVER</name>
-    </author>
+	<author email_address="developers@xpressengine.com" link="http://xpressengine.com/">
+		<name xml:lang="ko">NAVER</name>
+		<name xml:lang="en">NAVER</name>
+		<name xml:lang="vi">NAVER</name>
+		<name xml:lang="es">NAVER</name>
+		<name xml:lang="zh-CN">NAVER</name>
+		<name xml:lang="jp">NAVER</name>
+		<name xml:lang="ru">NAVER</name>
+		<name xml:lang="zh-TW">NAVER</name>
+		<name xml:lang="tr">NAVER</name>
+	</author>
 </module>

--- a/modules/admin/conf/module.xml
+++ b/modules/admin/conf/module.xml
@@ -1,25 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?>
 <module>
-    <grants />
-    <permissions />
-    <actions>
-        <action name="dispAdminIndex" type="view" index="true" />
-        <action name="dispAdminConfigGeneral" type="view" menu_name="adminConfigurationGeneral" menu_index="true" />
+	<grants />
+	<permissions />
+	<actions>
+		<action name="dispAdminIndex" type="view" index="true" />
+		<action name="dispAdminConfigGeneral" type="view" menu_name="adminConfigurationGeneral" menu_index="true" />
 		<action name="dispAdminConfigNotification" type="view" menu_name="adminConfigurationGeneral" />
-        <action name="dispAdminConfigSecurity" type="view" menu_name="adminConfigurationGeneral" />
-        <action name="dispAdminConfigAdvanced" type="view" menu_name="adminConfigurationGeneral" />
-        <action name="dispAdminConfigDebug" type="view" menu_name="adminConfigurationGeneral" />
-        <action name="dispAdminConfigSEO" type="view" menu_name="adminConfigurationGeneral" />
-        <action name="dispAdminConfigSitelock" type="view" menu_name="adminConfigurationGeneral" />
+		<action name="dispAdminConfigSecurity" type="view" menu_name="adminConfigurationGeneral" />
+		<action name="dispAdminConfigAdvanced" type="view" menu_name="adminConfigurationGeneral" />
+		<action name="dispAdminConfigDebug" type="view" menu_name="adminConfigurationGeneral" />
+		<action name="dispAdminConfigSEO" type="view" menu_name="adminConfigurationGeneral" />
+		<action name="dispAdminConfigSitelock" type="view" menu_name="adminConfigurationGeneral" />
 		<action name="dispAdminInsertDomain" type="view" menu_name="adminConfigurationGeneral" />
-        <action name="dispAdminConfigFtp" type="view" menu_name="adminConfigurationFtp" menu_index="true" />
-        <action name="dispAdminSetup" type="view" menu_name="adminMenuSetup" menu_index="true" />
-        <action name="dispAdminViewServerEnv" type="view" />
-
-        <action name="procAdminRemoveIcons" type="controller" />
+		<action name="dispAdminConfigFtp" type="view" menu_name="adminConfigurationFtp" menu_index="true" />
+		<action name="dispAdminSetup" type="view" menu_name="adminMenuSetup" menu_index="true" />
+		<action name="dispAdminViewServerEnv" type="view" />
+		
+		<action name="getSiteAllList" type="model" />
+		
+		<action name="procAdminRemoveIcons" type="controller" />
 		<action name="procAdminRecompileCacheFile" type="controller" />
-        <action name="procAdminLogout" type="controller" method="GET|POST" />
-        <action name="procAdminInsertDefaultDesignInfo" type="controller" />
+		<action name="procAdminLogout" type="controller" method="GET|POST" />
+		<action name="procAdminInsertDefaultDesignInfo" type="controller" />
 		<action name="procAdminToggleFavorite" type="controller" ruleset="toggleFavorite" />
 		<action name="procAdminEnviromentGatheringAgreement" type="controller" />
 		<action name="procAdminUpdateConfig" type="controller" />
@@ -37,9 +39,7 @@
 		<action name="procAdminUpdateFTPInfo" type="controller" />
 		<action name="procAdminRemoveFTPInfo" type="controller" />
 		<action name="procAdminFaviconUpload" type="controller" />
-
-        <action name="getSiteAllList" type="model" />
-    </actions>
+	</actions>
 	<menus>
 		<menu name="adminConfigurationGeneral" type="all">
 			<title xml:lang="en">System Settings</title>

--- a/modules/admin/conf/module.xml
+++ b/modules/admin/conf/module.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <module>
 	<grants />
-	<permissions />
+	<permissions>
+		<permission action="getSiteAllList" target="root" />
+	</permissions>
 	<actions>
+		<action name="getSiteAllList" type="model" />
+		
 		<action name="dispAdminIndex" type="view" index="true" />
 		<action name="dispAdminConfigGeneral" type="view" menu_name="adminConfigurationGeneral" menu_index="true" />
 		<action name="dispAdminConfigNotification" type="view" menu_name="adminConfigurationGeneral" />
@@ -15,8 +19,6 @@
 		<action name="dispAdminConfigFtp" type="view" menu_name="adminConfigurationFtp" menu_index="true" />
 		<action name="dispAdminSetup" type="view" menu_name="adminMenuSetup" menu_index="true" />
 		<action name="dispAdminViewServerEnv" type="view" />
-		
-		<action name="getSiteAllList" type="model" />
 		
 		<action name="procAdminRemoveIcons" type="controller" />
 		<action name="procAdminRecompileCacheFile" type="controller" />

--- a/modules/adminlogging/conf/info.xml
+++ b/modules/adminlogging/conf/info.xml
@@ -1,24 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module version="0.2">
-    <title xml:lang="ko">관리자 로깅</title>
-    <title xml:lang="en">Administrator logging</title>
-    <title xml:lang="jp">管理者ロギング</title>
-    <description xml:lang="ko"></description>
-    <description xml:lang="en"></description>
-    <description xml:lang="jp"></description>
-    <version>1.7</version>
-    <date>2013-11-27</date>
-    <category>system</category>
+	<title xml:lang="ko">관리자 로깅</title>
+	<title xml:lang="en">Administrator logging</title>
+	<title xml:lang="jp">管理者ロギング</title>
+	<description xml:lang="ko"></description>
+	<description xml:lang="en"></description>
+	<description xml:lang="jp"></description>
+	<version>1.7</version>
+	<date>2013-11-27</date>
+	<category>system</category>
 
-    <author email_address="developers@xpressengine.com" link="http://xpressengine.com/">
-        <name xml:lang="ko">NAVER</name>
-        <name xml:lang="en">NAVER</name>
-        <name xml:lang="vi">NAVER</name>
-        <name xml:lang="es">NAVER</name>
-        <name xml:lang="zh-CN">NAVER</name>
-        <name xml:lang="jp">NAVER</name>
-        <name xml:lang="ru">NAVER</name>
-        <name xml:lang="zh-TW">NAVER</name>
-        <name xml:lang="tr">NAVER</name>
-    </author>
+	<author email_address="developers@xpressengine.com" link="http://xpressengine.com/">
+		<name xml:lang="ko">NAVER</name>
+		<name xml:lang="en">NAVER</name>
+		<name xml:lang="vi">NAVER</name>
+		<name xml:lang="es">NAVER</name>
+		<name xml:lang="zh-CN">NAVER</name>
+		<name xml:lang="jp">NAVER</name>
+		<name xml:lang="ru">NAVER</name>
+		<name xml:lang="zh-TW">NAVER</name>
+		<name xml:lang="tr">NAVER</name>
+	</author>
 </module>

--- a/modules/advanced_mailer/conf/module.xml
+++ b/modules/advanced_mailer/conf/module.xml
@@ -12,6 +12,7 @@
 		<action name="dispAdvanced_mailerAdminSMSTest" type="view" />
 		<action name="dispAdvanced_mailerAdminSMSLog" type="view" />
 		<action name="dispAdvanced_mailerAdminSMSErrors" type="view" />
+		
 		<action name="procAdvanced_mailerAdminInsertConfig" type="controller" />
 		<action name="procAdvanced_mailerAdminInsertExceptions" type="controller" />
 		<action name="procAdvanced_mailerAdminCheckDNSRecord" type="controller" />

--- a/modules/autoinstall/conf/info.xml
+++ b/modules/autoinstall/conf/info.xml
@@ -1,30 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module version="0.2">
-    <title xml:lang="ko">쉬운 설치</title>
-    <title xml:lang="en">EasyInstaller</title>
-    <title xml:lang="vi">Cài đặt tự động</title>
-    <title xml:lang="zh-TW">自動安裝</title>
-    <title xml:lang="zh-CN">安装·更新</title>
-    <title xml:lang="jp">簡単インストール</title>
-    <title xml:lang="tr">KolayKurulum</title>
-    <description xml:lang="ko">관리자 모드에서 클릭으로 모듈/스킨/레이아웃/위젯/위젯스타일 등을 설치하는 모듈입니다.</description>
-    <description xml:lang="en">With this module, you can install and upgrade your programs including modules, skins, layouts, etc., from www.xpressengine.com with one-click.</description>
-    <description xml:lang="vi">Với Module này, bạn có thể cập nhật và cài đặt các phiên bản một cách tự động. Bao gồm Module, Layout, Widget, Addon, ... từ trang chủ XE bằng một bấm chuột.</description>
-    <description xml:lang="zh-TW">可以藉由此模組安裝、更新程式包括模組、面板、版面等。</description>
-    <description xml:lang="tr">Bu modül ile modüller, dış görünümler, yerleşim düzenleri.. gibi kendi programlarınızı, www.xpressengine.com adresinden tek bir tık ile kurup-düzenleyebilirsiniz. </description>
-    <description xml:lang="zh-CN">很方便的在线安装/更新XE相关模块(模块/皮肤/布局/控件/控件样式等)。</description>
-    <description xml:lang="jp">管理者モードにてクリックすることだけでモジュール/スキン/レイアウト/ウィジェット/ウィジェットスタイルのインストールを可能にするモジュールです。</description>
-    <description xml:lang="tr">Bu modülle; modüller, dış görünümler, yerleşim düzenleri vs. gibi programlarınızı www.xpressengine.com adresinden tek tıkla kurabilir ve sürümlerini yükseltebilirsiniz. </description>
-    <version>1.7</version>
-    <date>2013-11-27</date>
-    <category>system</category>
-    <author email_address="developers@xpressengine.com" link="http://xpressengine.com/">
-        <name xml:lang="ko">NAVER</name>
-        <name xml:lang="en">NAVER</name>
-        <name xml:lang="vi">NAVER</name>
-        <name xml:lang="zh-TW">NAVER</name>
-        <name xml:lang="zh-CN">NAVER</name>
-        <name xml:lang="jp">NAVER</name>
-        <name xml:lang="tr">NAVER</name>
-    </author>
+	<title xml:lang="ko">쉬운 설치</title>
+	<title xml:lang="en">EasyInstaller</title>
+	<title xml:lang="vi">Cài đặt tự động</title>
+	<title xml:lang="zh-TW">自動安裝</title>
+	<title xml:lang="zh-CN">安装·更新</title>
+	<title xml:lang="jp">簡単インストール</title>
+	<title xml:lang="tr">KolayKurulum</title>
+	<description xml:lang="ko">관리자 모드에서 클릭으로 모듈/스킨/레이아웃/위젯/위젯스타일 등을 설치하는 모듈입니다.</description>
+	<description xml:lang="en">With this module, you can install and upgrade your programs including modules, skins, layouts, etc., from www.xpressengine.com with one-click.</description>
+	<description xml:lang="vi">Với Module này, bạn có thể cập nhật và cài đặt các phiên bản một cách tự động. Bao gồm Module, Layout, Widget, Addon, ... từ trang chủ XE bằng một bấm chuột.</description>
+	<description xml:lang="zh-TW">可以藉由此模組安裝、更新程式包括模組、面板、版面等。</description>
+	<description xml:lang="tr">Bu modül ile modüller, dış görünümler, yerleşim düzenleri.. gibi kendi programlarınızı, www.xpressengine.com adresinden tek bir tık ile kurup-düzenleyebilirsiniz. </description>
+	<description xml:lang="zh-CN">很方便的在线安装/更新XE相关模块(模块/皮肤/布局/控件/控件样式等)。</description>
+	<description xml:lang="jp">管理者モードにてクリックすることだけでモジュール/スキン/レイアウト/ウィジェット/ウィジェットスタイルのインストールを可能にするモジュールです。</description>
+	<description xml:lang="tr">Bu modülle; modüller, dış görünümler, yerleşim düzenleri vs. gibi programlarınızı www.xpressengine.com adresinden tek tıkla kurabilir ve sürümlerini yükseltebilirsiniz. </description>
+	<version>1.7</version>
+	<date>2013-11-27</date>
+	<category>system</category>
+	<author email_address="developers@xpressengine.com" link="http://xpressengine.com/">
+		<name xml:lang="ko">NAVER</name>
+		<name xml:lang="en">NAVER</name>
+		<name xml:lang="vi">NAVER</name>
+		<name xml:lang="zh-TW">NAVER</name>
+		<name xml:lang="zh-CN">NAVER</name>
+		<name xml:lang="jp">NAVER</name>
+		<name xml:lang="tr">NAVER</name>
+	</author>
 </module>

--- a/modules/autoinstall/conf/module.xml
+++ b/modules/autoinstall/conf/module.xml
@@ -1,19 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
 <module>
-    <actions>
-        <action name="dispAutoinstallAdminInstall" type="view" menu_name="easyInstall" />
-        <action name="dispAutoinstallAdminUninstall" type="view" menu_name="easyInstall" />
-        <action name="procAutoinstallAdminUninstallPackage" type="controller" ruleset="ftp" />
-        <action name="dispAutoinstallAdminInstalledPackages" type="view" menu_name="easyInstall" />
-        <action name="dispAutoinstallAdminIndex" type="view" admin_index="true" menu_name="easyInstall" menu_index="true" />
-        <action name="procAutoinstallAdminUpdateinfo" type="controller" />
-        <action name="procAutoinstallAdminPackageinstall" type="controller" ruleset="ftp" />
+	<actions>
+		<action name="dispAutoinstallAdminInstall" type="view" menu_name="easyInstall" />
+		<action name="dispAutoinstallAdminUninstall" type="view" menu_name="easyInstall" />
+		<action name="dispAutoinstallAdminInstalledPackages" type="view" menu_name="easyInstall" />
+		<action name="dispAutoinstallAdminIndex" type="view" admin_index="true" menu_name="easyInstall" menu_index="true" />
+		
 		<action name="getAutoinstallAdminMenuPackageList" type="model" />
 		<action name="getAutoinstallAdminLayoutPackageList" type="model" />
 		<action name="getAutoinstallAdminSkinPackageList" type="model" />
 		<action name="getAutoinstallAdminIsAuthed" type="model" />
 		<action name="getAutoInstallAdminInstallInfo" type="model" />
-    </actions>
+		
+		<action name="procAutoinstallAdminUninstallPackage" type="controller" ruleset="ftp" />
+		<action name="procAutoinstallAdminUpdateinfo" type="controller" />
+		<action name="procAutoinstallAdminPackageinstall" type="controller" ruleset="ftp" />
+	</actions>
 	<menus>
 		<menu name="easyInstall">
 			<title xml:lang="en">Easy Install</title>

--- a/modules/autoinstall/conf/module.xml
+++ b/modules/autoinstall/conf/module.xml
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <module>
+	<grants />
+	<permissions />
 	<actions>
+		<action name="dispAutoinstallAdminIndex" type="view" admin_index="true" menu_name="easyInstall" menu_index="true" />
 		<action name="dispAutoinstallAdminInstall" type="view" menu_name="easyInstall" />
 		<action name="dispAutoinstallAdminUninstall" type="view" menu_name="easyInstall" />
 		<action name="dispAutoinstallAdminInstalledPackages" type="view" menu_name="easyInstall" />
-		<action name="dispAutoinstallAdminIndex" type="view" admin_index="true" menu_name="easyInstall" menu_index="true" />
 		
 		<action name="getAutoinstallAdminMenuPackageList" type="model" />
 		<action name="getAutoinstallAdminLayoutPackageList" type="model" />
@@ -12,9 +14,9 @@
 		<action name="getAutoinstallAdminIsAuthed" type="model" />
 		<action name="getAutoInstallAdminInstallInfo" type="model" />
 		
-		<action name="procAutoinstallAdminUninstallPackage" type="controller" ruleset="ftp" />
 		<action name="procAutoinstallAdminUpdateinfo" type="controller" />
 		<action name="procAutoinstallAdminPackageinstall" type="controller" ruleset="ftp" />
+		<action name="procAutoinstallAdminUninstallPackage" type="controller" ruleset="ftp" />
 	</actions>
 	<menus>
 		<menu name="easyInstall">

--- a/modules/board/conf/module.xml
+++ b/modules/board/conf/module.xml
@@ -66,17 +66,7 @@
 		<permission action="procBoardAdminSaveCategorySettings" target="manager" check_var="module_srl" />
 	</permissions>
 	<actions>
-		<action name="dispBoardContent" type="view" index="true" />
-		<action name="dispBoardNoticeList" type="view" />
-		<action name="dispBoardContentList" type="view" />
-		<action name="dispBoardContentView" type="view" />
-		<action name="dispBoardCategoryList" type="view" />
-		<action name="dispBoardContentCommentList" type="view" />
-		<action name="dispBoardContentFileList" type="view" />
-		<action name="dispBoardUpdateLog" type="view" />
-		<action name="dispBoardUpdateLogView" type="view" />
-		<action name="dispBoardVoteLog" type="view" />
-		<action name="dispBoardTagList" type="view" />
+		<action name="dispBoardContent" type="view" standalone="false" index="true" />
 		<action name="dispBoardWrite" type="view" standalone="false" />
 		<action name="dispBoardDelete" type="view" standalone="false" />
 		<action name="dispBoardWriteComment" type="view" standalone="false" />
@@ -84,30 +74,39 @@
 		<action name="dispBoardModifyComment" type="view" standalone="false" />
 		<action name="dispBoardDeleteComment" type="view" standalone="false" />
 		<action name="dispBoardDeleteTrackback" type="view" standalone="false" />
-		<action name="dispBoardMessage" type="view" />
+		<action name="dispBoardContentList" type="view" standalone="false" />
+		<action name="dispBoardContentView" type="view" standalone="false" />
+		<action name="dispBoardUpdateLog" type="view" standalone="false" />
+		<action name="dispBoardUpdateLogView" type="view" standalone="false" />
+		<action name="dispBoardVoteLog" type="view" standalone="false" />
 		
-		<action name="dispBoardCategory" type="mobile" />
-		<action name="getBoardCommentPage" type="mobile" />
+		<action name="dispBoardNoticeList" type="view" standalone="false" />
+		<action name="dispBoardCategoryList" type="view" standalone="false" />
+		<action name="dispBoardContentCommentList" type="view" standalone="false" />
+		<action name="dispBoardContentFileList" type="view" standalone="false" />
+		<action name="dispBoardTagList" type="view" standalone="false" />
+		<action name="dispBoardCategory" type="mobile" standalone="false" />
+		<action name="getBoardCommentPage" type="mobile" standalone="false" />
 		
 		<action name="procBoardInsertDocument" type="controller" ruleset="insertDocument" standalone="false" />
-		<action name="procBoardRevertDocument" type="controller" />
 		<action name="procBoardDeleteDocument" type="controller" standalone="false" />
-		<action name="procBoardVoteDocument" type="controller" standalone="false" />
+		<action name="procBoardRevertDocument" type="controller" standalone="false" />
 		<action name="procBoardInsertComment" type="controller" standalone="false" />
 		<action name="procBoardDeleteComment" type="controller" standalone="false" />
 		<action name="procBoardDeleteTrackback" type="controller" standalone="false" />
-		<action name="procBoardVerificationPassword" type="controller" />
+		<action name="procBoardVerificationPassword" type="controller" standalone="false" />
+		<action name="procBoardVoteDocument" type="controller" standalone="false" />
 		
 		<action name="dispBoardAdminContent" type="view" admin_index="true" menu_name="board" menu_index="true" />
 		<action name="dispBoardAdminInsertBoard" type="view" setup_index="true" menu_name="board" />
-		<action name="dispBoardAdminDeleteBoard" type="view" menu_name="board"  />
-		<action name="dispBoardAdminBoardInfo" type="view"  menu_name="board" />
-		<action name="dispBoardAdminCategoryInfo" type="view" menu_name="board"  />
-		<action name="dispBoardAdminExtraVars" type="view"  menu_name="board" />
-		<action name="dispBoardAdminGrantInfo" type="view" menu_name="board"  />
-		<action name="dispBoardAdminBoardAdditionSetup" type="view" menu_name="board"  />
-		<action name="dispBoardAdminSkinInfo" type="view" menu_name="board"  />
-		<action name="dispBoardAdminMobileSkinInfo" type="view" menu_name="board"  />
+		<action name="dispBoardAdminDeleteBoard" type="view" menu_name="board" />
+		<action name="dispBoardAdminBoardInfo" type="view" menu_name="board" />
+		<action name="dispBoardAdminCategoryInfo" type="view" menu_name="board" />
+		<action name="dispBoardAdminExtraVars" type="view" menu_name="board" />
+		<action name="dispBoardAdminGrantInfo" type="view" menu_name="board" />
+		<action name="dispBoardAdminBoardAdditionSetup" type="view" menu_name="board" />
+		<action name="dispBoardAdminSkinInfo" type="view" menu_name="board" />
+		<action name="dispBoardAdminMobileSkinInfo" type="view" menu_name="board" />
 		
 		<action name="getBoardAdminSimpleSetup" type="model" simple_setup_index="true" />
 		

--- a/modules/board/conf/module.xml
+++ b/modules/board/conf/module.xml
@@ -54,11 +54,13 @@
 		</grant>
 	</grants>
 	<permissions>
-		<permission action="dispBoardAdminInsertBoard" target="manager" />
 		<permission action="dispBoardAdminBoardInfo" target="manager" />
+		<permission action="dispBoardAdminCategoryInfo" target="manager" />
 		<permission action="dispBoardAdminExtraVars" target="manager" />
+		<permission action="dispBoardAdminGrantInfo" target="manager" />
 		<permission action="dispBoardAdminBoardAdditionSetup" target="manager" />
 		<permission action="dispBoardAdminSkinInfo" target="manager" />
+		<permission action="dispBoardAdminMobileSkinInfo" target="manager" />
 		
 		<permission action="procBoardAdminInsertBoard" target="manager" check_var="module_srl" />
 		<permission action="procBoardAdminSaveCategorySettings" target="manager" check_var="module_srl" />
@@ -72,6 +74,7 @@
 		<action name="dispBoardContentCommentList" type="view" />
 		<action name="dispBoardContentFileList" type="view" />
 		<action name="dispBoardUpdateLog" type="view" />
+		<action name="dispBoardUpdateLogView" type="view" />
 		<action name="dispBoardVoteLog" type="view" />
 		<action name="dispBoardTagList" type="view" />
 		<action name="dispBoardWrite" type="view" standalone="false" />
@@ -82,7 +85,6 @@
 		<action name="dispBoardDeleteComment" type="view" standalone="false" />
 		<action name="dispBoardDeleteTrackback" type="view" standalone="false" />
 		<action name="dispBoardMessage" type="view" />
-		<action name="dispBoardUpdateLogView" type="view" />
 		
 		<action name="dispBoardCategory" type="mobile" />
 		<action name="getBoardCommentPage" type="mobile" />
@@ -97,15 +99,15 @@
 		<action name="procBoardVerificationPassword" type="controller" />
 		
 		<action name="dispBoardAdminContent" type="view" admin_index="true" menu_name="board" menu_index="true" />
-		<action name="dispBoardAdminBoardInfo" type="view"  menu_name="board" />
-		<action name="dispBoardAdminExtraVars" type="view"  menu_name="board" />
-		<action name="dispBoardAdminBoardAdditionSetup" type="view" menu_name="board"  />
 		<action name="dispBoardAdminInsertBoard" type="view" setup_index="true" menu_name="board" />
 		<action name="dispBoardAdminDeleteBoard" type="view" menu_name="board"  />
+		<action name="dispBoardAdminBoardInfo" type="view"  menu_name="board" />
+		<action name="dispBoardAdminCategoryInfo" type="view" menu_name="board"  />
+		<action name="dispBoardAdminExtraVars" type="view"  menu_name="board" />
+		<action name="dispBoardAdminGrantInfo" type="view" menu_name="board"  />
+		<action name="dispBoardAdminBoardAdditionSetup" type="view" menu_name="board"  />
 		<action name="dispBoardAdminSkinInfo" type="view" menu_name="board"  />
 		<action name="dispBoardAdminMobileSkinInfo" type="view" menu_name="board"  />
-		<action name="dispBoardAdminGrantInfo" type="view" menu_name="board"  />
-		<action name="dispBoardAdminCategoryInfo" type="view" menu_name="board"  />
 		
 		<action name="getBoardAdminSimpleSetup" type="model" simple_setup_index="true" />
 		

--- a/modules/board/conf/module.xml
+++ b/modules/board/conf/module.xml
@@ -59,12 +59,9 @@
 		<permission action="dispBoardAdminExtraVars" target="manager" />
 		<permission action="dispBoardAdminBoardAdditionSetup" target="manager" />
 		<permission action="dispBoardAdminSkinInfo" target="manager" />
-
-		<permission action="procBoardAdminInsertBoard" target="manager" />
-		<permission action="procBoardAdminUpdateBoardFroBasic" target="manager" />
-		<permission action="procBoardAdminSaveCategorySettings" target="manager" />
-
-		<permission action="getBoardAdminSimpleSetup" target="manager" />
+		
+		<permission action="procBoardAdminInsertBoard" target="manager" check_var="module_srl" />
+		<permission action="procBoardAdminSaveCategorySettings" target="manager" check_var="module_srl" />
 	</permissions>
 	<actions>
 		<action name="dispBoardContent" type="view" index="true" />
@@ -76,7 +73,6 @@
 		<action name="dispBoardContentFileList" type="view" />
 		<action name="dispBoardUpdateLog" type="view" />
 		<action name="dispBoardVoteLog" type="view" />
-
 		<action name="dispBoardTagList" type="view" />
 		<action name="dispBoardWrite" type="view" standalone="false" />
 		<action name="dispBoardDelete" type="view" standalone="false" />
@@ -87,7 +83,10 @@
 		<action name="dispBoardDeleteTrackback" type="view" standalone="false" />
 		<action name="dispBoardMessage" type="view" />
 		<action name="dispBoardUpdateLogView" type="view" />
-
+		
+		<action name="dispBoardCategory" type="mobile" />
+		<action name="getBoardCommentPage" type="mobile" />
+		
 		<action name="procBoardInsertDocument" type="controller" ruleset="insertDocument" standalone="false" />
 		<action name="procBoardRevertDocument" type="controller" />
 		<action name="procBoardDeleteDocument" type="controller" standalone="false" />
@@ -96,8 +95,7 @@
 		<action name="procBoardDeleteComment" type="controller" standalone="false" />
 		<action name="procBoardDeleteTrackback" type="controller" standalone="false" />
 		<action name="procBoardVerificationPassword" type="controller" />
-
-		<!-- admin -->
+		
 		<action name="dispBoardAdminContent" type="view" admin_index="true" menu_name="board" menu_index="true" />
 		<action name="dispBoardAdminBoardInfo" type="view"  menu_name="board" />
 		<action name="dispBoardAdminExtraVars" type="view"  menu_name="board" />
@@ -108,15 +106,13 @@
 		<action name="dispBoardAdminMobileSkinInfo" type="view" menu_name="board"  />
 		<action name="dispBoardAdminGrantInfo" type="view" menu_name="board"  />
 		<action name="dispBoardAdminCategoryInfo" type="view" menu_name="board"  />
+		
+		<action name="getBoardAdminSimpleSetup" type="model" simple_setup_index="true" />
+		
 		<action name="procBoardAdminInsertBoard" type="controller" ruleset="insertBoard" />
 		<action name="procBoardAdminDeleteBoard" type="controller" />
 		<action name="procBoardAdminUpdateBoardFroBasic" type="controller" ruleset="insertBoardForBasic" />
 		<action name="procBoardAdminSaveCategorySettings" type="controller" ruleset="saveCategorySettings" />
-
-		<action name="getBoardAdminSimpleSetup" type="model" simple_setup_index="true" />
-
-		<action name="dispBoardCategory" type="mobile" />
-		<action name="getBoardCommentPage" type="mobile" />
 	</actions>
 	<menus>
 		<menu name="board" type="all">

--- a/modules/comment/conf/info.xml
+++ b/modules/comment/conf/info.xml
@@ -1,36 +1,36 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module version="0.2">
-    <title xml:lang="ko">댓글</title>
-    <title xml:lang="jp">コメント</title>
-    <title xml:lang="zh-CN">评论管理</title>
-    <title xml:lang="en">Comment</title>
-    <title xml:lang="vi">Bình luận</title>
-    <title xml:lang="es">Commentarios</title>
-    <title xml:lang="ru">Комментарии</title>
-    <title xml:lang="zh-TW">回覆</title>
-    <title xml:lang="tr">Yorum</title>
-    <description xml:lang="ko">게시판이나 블로그등의 댓글을 관리합니다.</description>
-    <description xml:lang="jp">掲示板やブログなどのコメントを管理するモジュールです。</description>
-    <description xml:lang="zh-CN">管理版面或博客评论的模块。</description>
-    <description xml:lang="en">Managing board/blog's comments</description>
-    <description xml:lang="vi">Module quản lý bình luận của bài viết và sổ lưu niệm</description>
-    <description xml:lang="es">Es el módulo para manejar commentarios en blog o boletínes.</description>
-    <description xml:lang="ru">Модуль для управления комментариями форума/блога.</description>
-    <description xml:lang="zh-TW">管理討論板或部落格回覆的模組。</description>
-    <description xml:lang="tr">Pano ve blog yorumlarını yönetme modülü</description>
-    <version>1.7</version>
-    <date>2013-11-27</date>
-    <category>content</category>
+	<title xml:lang="ko">댓글</title>
+	<title xml:lang="jp">コメント</title>
+	<title xml:lang="zh-CN">评论管理</title>
+	<title xml:lang="en">Comment</title>
+	<title xml:lang="vi">Bình luận</title>
+	<title xml:lang="es">Commentarios</title>
+	<title xml:lang="ru">Комментарии</title>
+	<title xml:lang="zh-TW">回覆</title>
+	<title xml:lang="tr">Yorum</title>
+	<description xml:lang="ko">게시판이나 블로그등의 댓글을 관리합니다.</description>
+	<description xml:lang="jp">掲示板やブログなどのコメントを管理するモジュールです。</description>
+	<description xml:lang="zh-CN">管理版面或博客评论的模块。</description>
+	<description xml:lang="en">Managing board/blog's comments</description>
+	<description xml:lang="vi">Module quản lý bình luận của bài viết và sổ lưu niệm</description>
+	<description xml:lang="es">Es el módulo para manejar commentarios en blog o boletínes.</description>
+	<description xml:lang="ru">Модуль для управления комментариями форума/блога.</description>
+	<description xml:lang="zh-TW">管理討論板或部落格回覆的模組。</description>
+	<description xml:lang="tr">Pano ve blog yorumlarını yönetme modülü</description>
+	<version>1.7</version>
+	<date>2013-11-27</date>
+	<category>content</category>
 
-    <author email_address="developers@xpressengine.com" link="http://xpressengine.com/">
-        <name xml:lang="ko">NAVER</name>
-        <name xml:lang="jp">NAVER</name>
-        <name xml:lang="vi">NAVER</name>
-        <name xml:lang="zh-CN">NAVER</name>
-        <name xml:lang="en">NAVER</name>
-        <name xml:lang="es">NAVER</name>
-        <name xml:lang="ru">NAVER</name>
-        <name xml:lang="zh-TW">NAVER</name>
-        <name xml:lang="tr">NAVER</name>
-    </author>
+	<author email_address="developers@xpressengine.com" link="http://xpressengine.com/">
+		<name xml:lang="ko">NAVER</name>
+		<name xml:lang="jp">NAVER</name>
+		<name xml:lang="vi">NAVER</name>
+		<name xml:lang="zh-CN">NAVER</name>
+		<name xml:lang="en">NAVER</name>
+		<name xml:lang="es">NAVER</name>
+		<name xml:lang="ru">NAVER</name>
+		<name xml:lang="zh-TW">NAVER</name>
+		<name xml:lang="tr">NAVER</name>
+	</author>
 </module>

--- a/modules/comment/conf/module.xml
+++ b/modules/comment/conf/module.xml
@@ -5,35 +5,35 @@
 		<permission action="procCommentVoteUp" target="member" />
 		<permission action="procCommentVoteDown" target="member" />
 		<permission action="procCommentDeclare" target="member" />
-
-		<permission action="procCommentGetList" target="manager" />
-		<permission action="procCommentAdminAddCart" target="manager" />
-		<permission action="procCommentAdminMoveToTrash" target="manager" />
-		<permission action="procCommentAdminDeleteChecked" target="manager" />
-		<permission action="procCommentInsertModuleConfig" target="manager" />
+		<permission action="procCommentGetList" target="manager" check_type="comment" check_var="comment_srls" />
+		<permission action="procCommentInsertModuleConfig" target="manager" check_var="target_module_srl" />
+		
+		<permission action="procCommentAdminAddCart" target="manager" check_type="comment" check_var="comment_srl" />
+		<permission action="procCommentAdminMoveToTrash" target="manager" check_type="comment" check_var="comment_srl" />
+		<permission action="procCommentAdminDeleteChecked" target="manager" check_type="comment" check_var="cart" />
 	</permissions>
 	<actions>
-		<action name="getCommentMenu" type="model" />
 		<action name="dispCommentDeclare" type="view" />
+		
+		<action name="getCommentMenu" type="model" />
+		<action name="getCommentVotedMemberList" type="model" />
+		
 		<action name="procCommentVoteUp" type="controller" />
 		<action name="procCommentVoteUpCancel" type="controller" />
 		<action name="procCommentVoteDown" type="controller" />
 		<action name="procCommentVoteDownCancel" type="controller" />
 		<action name="procCommentDeclare" type="controller" />
-		<action name="getCommentVotedMemberList" type="model" />
-		<action name="isModuleUsingPublishValidation" type="controller" />
-
-		<!-- admin -->
 		<action name="procCommentGetList" type="controller" />
 		<action name="procCommentInsertModuleConfig" type="controller" ruleset="insertCommentModuleConfig" />
+		<action name="isModuleUsingPublishValidation" type="controller" />
 		
 		<action name="dispCommentAdminList" type="view" admin_index="true" menu_name="comment" menu_index="true" />
+		<action name="dispCommentAdminDeclared" type="view" menu_name="comment" />
+		<action name="dispCommentAdminDeclaredLogByCommentSrl" type="view" menu_name="comment" />
+		
 		<action name="procCommentAdminChangeStatus" type="controller"/>
 		<action name="procCommentAdminChangePublishedStatusChecked" type="controller" />
-		<action name="dispCommentAdminDeclared" type="view" menu_name="comment" />
 		<action name="procCommentAdminCancelDeclare" type="controller" />
-		<action name="dispCommentAdminDeclaredLogByCommentSrl" type="view" menu_name="comment" />
-
 		<action name="procCommentAdminAddCart" type="controller" />
 		<action name="procCommentAdminDeleteChecked" type="controller" ruleset="deleteChecked" />
 		<action name="procCommentAdminMoveToTrash" type="controller" />

--- a/modules/comment/conf/module.xml
+++ b/modules/comment/conf/module.xml
@@ -2,15 +2,20 @@
 <module>
 	<grants />
 	<permissions>
+		<permission action="dispCommentDeclare" target="member" />
+		<permission action="getCommentVotedMemberList" target="root" />
+		
 		<permission action="procCommentVoteUp" target="member" />
+		<permission action="procCommentVoteUpCancel" target="member" />
 		<permission action="procCommentVoteDown" target="member" />
+		<permission action="procCommentVoteDownCancel" target="member" />
 		<permission action="procCommentDeclare" target="member" />
 		<permission action="procCommentGetList" target="manager" check_type="comment" check_var="comment_srls" />
 		<permission action="procCommentInsertModuleConfig" target="manager" check_var="target_module_srl" />
 		
 		<permission action="procCommentAdminAddCart" target="manager" check_type="comment" check_var="comment_srl" />
-		<permission action="procCommentAdminMoveToTrash" target="manager" check_type="comment" check_var="comment_srl" />
 		<permission action="procCommentAdminDeleteChecked" target="manager" check_type="comment" check_var="cart" />
+		<permission action="procCommentAdminMoveToTrash" target="manager" check_type="comment" check_var="comment_srl" />
 	</permissions>
 	<actions>
 		<action name="dispCommentDeclare" type="view" />
@@ -25,7 +30,6 @@
 		<action name="procCommentDeclare" type="controller" />
 		<action name="procCommentGetList" type="controller" />
 		<action name="procCommentInsertModuleConfig" type="controller" ruleset="insertCommentModuleConfig" />
-		<action name="isModuleUsingPublishValidation" type="controller" />
 		
 		<action name="dispCommentAdminList" type="view" admin_index="true" menu_name="comment" menu_index="true" />
 		<action name="dispCommentAdminDeclared" type="view" menu_name="comment" />

--- a/modules/communication/conf/info.xml
+++ b/modules/communication/conf/info.xml
@@ -1,33 +1,33 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module version="0.2">
-    <title xml:lang="ko">커뮤니케이션</title>
-    <title xml:lang="jp">コミュニケーション</title>
-    <title xml:lang="zh-CN">会员交流</title>
-    <title xml:lang="en">Communication</title>
-    <title xml:lang="ru">Communication</title>
-    <title xml:lang="vi">Liên lạc</title>
-    <title xml:lang="zh-TW">交流</title>
-    <title xml:lang="tr">İletişim</title>
-    <description xml:lang="ko">회원들간의 쪽지, 친구기능을 담당합니다.</description>
-    <description xml:lang="jp">会員間にメッセージや友達管理などコミュニティ機能を提供します。</description>
-    <description xml:lang="zh-CN">管理在线会员间短信息及好友功能的模块。</description>
-    <description xml:lang="en">This is for managing messages, friend functions.</description>
-    <description xml:lang="vi">Module quản lý tin nhắn và bạn bè.</description>
-    <description xml:lang="ru">This module is for managing message, friend functions.</description>
-    <description xml:lang="zh-TW">管理線上會員間短訊及好友功能的模組。</description>
-    <description xml:lang="tr">Bu modül mesaj ve arkadaşlık özelliklerini yönetmek içindir.</description>
-    <version>1.7</version>
-    <date>2013-11-27</date>
-    <category>member</category>
+	<title xml:lang="ko">커뮤니케이션</title>
+	<title xml:lang="jp">コミュニケーション</title>
+	<title xml:lang="zh-CN">会员交流</title>
+	<title xml:lang="en">Communication</title>
+	<title xml:lang="ru">Communication</title>
+	<title xml:lang="vi">Liên lạc</title>
+	<title xml:lang="zh-TW">交流</title>
+	<title xml:lang="tr">İletişim</title>
+	<description xml:lang="ko">회원들간의 쪽지, 친구기능을 담당합니다.</description>
+	<description xml:lang="jp">会員間にメッセージや友達管理などコミュニティ機能を提供します。</description>
+	<description xml:lang="zh-CN">管理在线会员间短信息及好友功能的模块。</description>
+	<description xml:lang="en">This is for managing messages, friend functions.</description>
+	<description xml:lang="vi">Module quản lý tin nhắn và bạn bè.</description>
+	<description xml:lang="ru">This module is for managing message, friend functions.</description>
+	<description xml:lang="zh-TW">管理線上會員間短訊及好友功能的模組。</description>
+	<description xml:lang="tr">Bu modül mesaj ve arkadaşlık özelliklerini yönetmek içindir.</description>
+	<version>1.7</version>
+	<date>2013-11-27</date>
+	<category>member</category>
 
-    <author email_address="developers@xpressengine.com" link="http://xpressengine.com/">
-        <name xml:lang="ko">NAVER</name>
-        <name xml:lang="vi">NAVER</name>
-        <name xml:lang="jp">NAVER</name>
-        <name xml:lang="zh-CN">NAVER</name>
-        <name xml:lang="en">NAVER</name>
-        <name xml:lang="zh-TW">NAVER</name>
+	<author email_address="developers@xpressengine.com" link="http://xpressengine.com/">
+		<name xml:lang="ko">NAVER</name>
+		<name xml:lang="vi">NAVER</name>
+		<name xml:lang="jp">NAVER</name>
+		<name xml:lang="zh-CN">NAVER</name>
+		<name xml:lang="en">NAVER</name>
+		<name xml:lang="zh-TW">NAVER</name>
 		<name xml:lang="ru">NAVER</name>
 		<name xml:lang="tr">NAVER</name>
-    </author>
+	</author>
 </module>

--- a/modules/communication/conf/module.xml
+++ b/modules/communication/conf/module.xml
@@ -16,35 +16,35 @@
 		<permission action="procCommunicationDeleteMessage" target="member" />
 		<permission action="procCommunicationDeleteMessages" target="member" />
 		<permission action="procCommunicationAddFriend" target="member" />
+		<permission action="procCommunicationAddFriendGroup" target="member" />
 		<permission action="procCommunicationMoveFriend" target="member" />
 		<permission action="procCommunicationDeleteFriend" target="member" />
-		<permission action="procCommunicationAddFriendGroup" target="member" />
-		<permission action="procCommunicationRenameFriendGroup" target="member" />
 		<permission action="procCommunicationDeleteFriendGroup" target="member" />
+		<permission action="procCommunicationRenameFriendGroup" target="member" />
 	</permissions>
 	<actions>
-		<action name="dispCommunicationMessages" type="view" standalone="true" />
-		<action name="dispCommunicationSendMessage" type="view" standalone="true" />
-		<action name="dispCommunicationNewMessage" type="view" standalone="true" />
-		<action name="dispCommunicationFriend" type="view" standalone="true" />
-		<action name="dispCommunicationAddFriend" type="view" standalone="true" />
-		<action name="dispCommunicationAddFriendGroup" type="view" standalone="true" />
-		<action name="dispCommunicationMessageBoxList" type="mobile" standalone="true" />
+		<action name="dispCommunicationMessages" type="view" />
+		<action name="dispCommunicationSendMessage" type="view" />
+		<action name="dispCommunicationNewMessage" type="view" />
+		<action name="dispCommunicationFriend" type="view" />
+		<action name="dispCommunicationAddFriend" type="view" />
+		<action name="dispCommunicationAddFriendGroup" type="view" />
+		<action name="dispCommunicationMessageBoxList" type="mobile" />
 		
-		<action name="procCommunicationUpdateAllowMessage" type="controller" standalone="true" />
-		<action name="procCommunicationSendMessage" type="controller" ruleset="sendMessage" standalone="true" />
-		<action name="procCommunicationStoreMessage" type="controller" standalone="true" />
-		<action name="procCommunicationDeleteMessage" type="controller" standalone="true" />
-		<action name="procCommunicationDeleteMessages" type="controller" standalone="true" />
-		<action name="procCommunicationAddFriend" type="controller" ruleset="addFriend" standalone="true" />
-		<action name="procCommunicationMoveFriend" type="controller" ruleset="deleteCheckedFriend" standalone="true" />
-		<action name="procCommunicationDeleteFriend" type="controller" ruleset="deleteCheckedFriend" standalone="true" />
-		<action name="procCommunicationAddFriendGroup" type="controller" ruleset="addFriendGroup" standalone="true" />
-		<action name="procCommunicationRenameFriendGroup" type="controller" standalone="true" />
-		<action name="procCommunicationDeleteFriendGroup" type="controller" standalone="true" />
+		<action name="procCommunicationUpdateAllowMessage" type="controller" />
+		<action name="procCommunicationSendMessage" type="controller" ruleset="sendMessage" />
+		<action name="procCommunicationStoreMessage" type="controller" />
+		<action name="procCommunicationDeleteMessage" type="controller" />
+		<action name="procCommunicationDeleteMessages" type="controller" />
+		<action name="procCommunicationAddFriend" type="controller" ruleset="addFriend" />
+		<action name="procCommunicationAddFriendGroup" type="controller" ruleset="addFriendGroup" />
+		<action name="procCommunicationMoveFriend" type="controller" ruleset="deleteCheckedFriend" />
+		<action name="procCommunicationDeleteFriend" type="controller" ruleset="deleteCheckedFriend" />
+		<action name="procCommunicationDeleteFriendGroup" type="controller" />
+		<action name="procCommunicationRenameFriendGroup" type="controller" />
 		
-		<action name="procCommunicationAdminInsertConfig" type="controller" ruleset="insertConfig" />
 		<action name="dispCommunicationAdminConfig" type="view" admin_index="true" />
 		<action name="getCommunicationAdminColorset" type="model" />
+		<action name="procCommunicationAdminInsertConfig" type="controller" ruleset="insertConfig" />
 	</actions>
 </module>

--- a/modules/communication/conf/module.xml
+++ b/modules/communication/conf/module.xml
@@ -5,22 +5,19 @@
 		<permission action="dispCommunicationMessages" target="member" />
 		<permission action="dispCommunicationSendMessage" target="member" />
 		<permission action="dispCommunicationNewMessage" target="member" />
-
 		<permission action="dispCommunicationFriend" target="member" />
 		<permission action="dispCommunicationAddFriend" target="member" />
 		<permission action="dispCommunicationAddFriendGroup" target="member" />
 		<permission action="dispCommunicationMessageBoxList" target="member" />
-
+		
 		<permission action="procCommunicationUpdateAllowMessage" target="member" />
 		<permission action="procCommunicationSendMessage" target="member" />
 		<permission action="procCommunicationStoreMessage" target="member" />
 		<permission action="procCommunicationDeleteMessage" target="member" />
 		<permission action="procCommunicationDeleteMessages" target="member" />
-
 		<permission action="procCommunicationAddFriend" target="member" />
 		<permission action="procCommunicationMoveFriend" target="member" />
 		<permission action="procCommunicationDeleteFriend" target="member" />
-
 		<permission action="procCommunicationAddFriendGroup" target="member" />
 		<permission action="procCommunicationRenameFriendGroup" target="member" />
 		<permission action="procCommunicationDeleteFriendGroup" target="member" />
@@ -29,29 +26,25 @@
 		<action name="dispCommunicationMessages" type="view" standalone="true" />
 		<action name="dispCommunicationSendMessage" type="view" standalone="true" />
 		<action name="dispCommunicationNewMessage" type="view" standalone="true" />
-
 		<action name="dispCommunicationFriend" type="view" standalone="true" />
 		<action name="dispCommunicationAddFriend" type="view" standalone="true" />
 		<action name="dispCommunicationAddFriendGroup" type="view" standalone="true" />
 		<action name="dispCommunicationMessageBoxList" type="mobile" standalone="true" />
-
+		
 		<action name="procCommunicationUpdateAllowMessage" type="controller" standalone="true" />
 		<action name="procCommunicationSendMessage" type="controller" ruleset="sendMessage" standalone="true" />
 		<action name="procCommunicationStoreMessage" type="controller" standalone="true" />
 		<action name="procCommunicationDeleteMessage" type="controller" standalone="true" />
 		<action name="procCommunicationDeleteMessages" type="controller" standalone="true" />
-
 		<action name="procCommunicationAddFriend" type="controller" ruleset="addFriend" standalone="true" />
 		<action name="procCommunicationMoveFriend" type="controller" ruleset="deleteCheckedFriend" standalone="true" />
 		<action name="procCommunicationDeleteFriend" type="controller" ruleset="deleteCheckedFriend" standalone="true" />
-
 		<action name="procCommunicationAddFriendGroup" type="controller" ruleset="addFriendGroup" standalone="true" />
 		<action name="procCommunicationRenameFriendGroup" type="controller" standalone="true" />
 		<action name="procCommunicationDeleteFriendGroup" type="controller" standalone="true" />
-
-		<!-- admin -->
-		<action name="getCommunicationAdminColorset" type="model" />
+		
 		<action name="procCommunicationAdminInsertConfig" type="controller" ruleset="insertConfig" />
 		<action name="dispCommunicationAdminConfig" type="view" admin_index="true" />
+		<action name="getCommunicationAdminColorset" type="model" />
 	</actions>
 </module>

--- a/modules/counter/conf/info.xml
+++ b/modules/counter/conf/info.xml
@@ -1,36 +1,36 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module version="0.2">
-    <title xml:lang="ko">접속통계</title>
-    <title xml:lang="zh-CN">访问统计</title>
-    <title xml:lang="en">Counter</title>
-    <title xml:lang="vi">Counter</title>
-    <title xml:lang="es">Contador</title>
-    <title xml:lang="jp">アクセスカウンター</title>
-    <title xml:lang="ru">Базовый счетчик</title>
-    <title xml:lang="zh-TW">基本統計</title>
-    <title xml:lang="tr">Sayaç</title>
-    <description xml:lang="ko">기본 접속 통계 프로그램입니다.</description>
-    <description xml:lang="zh-CN">默认访问统计程序。</description>
-    <description xml:lang="en">Basic connection statistics program.</description>
-    <description xml:lang="vi">Chương trình thống kê kết nối cơ bản.</description>
-    <description xml:lang="es">Programa básico para la estadística de la conección.</description>
-    <description xml:lang="jp">デフォルトアクセス統計のプログラムです。</description>
-    <description xml:lang="ru">Базовая программа статистики подключений.</description>
-    <description xml:lang="zh-TW">預設的統計程式。</description>
-    <description xml:lang="tr">Temel bağlantı istatistik programı.</description>
-    <version>1.7</version>
-    <date>2013-11-27</date>
-    <category>statistics</category>
+	<title xml:lang="ko">접속통계</title>
+	<title xml:lang="zh-CN">访问统计</title>
+	<title xml:lang="en">Counter</title>
+	<title xml:lang="vi">Counter</title>
+	<title xml:lang="es">Contador</title>
+	<title xml:lang="jp">アクセスカウンター</title>
+	<title xml:lang="ru">Базовый счетчик</title>
+	<title xml:lang="zh-TW">基本統計</title>
+	<title xml:lang="tr">Sayaç</title>
+	<description xml:lang="ko">기본 접속 통계 프로그램입니다.</description>
+	<description xml:lang="zh-CN">默认访问统计程序。</description>
+	<description xml:lang="en">Basic connection statistics program.</description>
+	<description xml:lang="vi">Chương trình thống kê kết nối cơ bản.</description>
+	<description xml:lang="es">Programa básico para la estadística de la conección.</description>
+	<description xml:lang="jp">デフォルトアクセス統計のプログラムです。</description>
+	<description xml:lang="ru">Базовая программа статистики подключений.</description>
+	<description xml:lang="zh-TW">預設的統計程式。</description>
+	<description xml:lang="tr">Temel bağlantı istatistik programı.</description>
+	<version>1.7</version>
+	<date>2013-11-27</date>
+	<category>statistics</category>
 
-    <author email_address="developers@xpressengine.com" link="http://xpressengine.com/">
-        <name xml:lang="ko">NAVER</name>
-        <name xml:lang="zh-CN">NAVER</name>
-        <name xml:lang="en">NAVER</name>
-        <name xml:lang="es">NAVER</name>
-        <name xml:lang="vi">NAVER</name>
-        <name xml:lang="jp">NAVER</name>
-        <name xml:lang="ru">NAVER</name>
-        <name xml:lang="zh-TW">NAVER</name>
-        <name xml:lang="tr">NAVER</name>
-    </author>
+	<author email_address="developers@xpressengine.com" link="http://xpressengine.com/">
+		<name xml:lang="ko">NAVER</name>
+		<name xml:lang="zh-CN">NAVER</name>
+		<name xml:lang="en">NAVER</name>
+		<name xml:lang="es">NAVER</name>
+		<name xml:lang="vi">NAVER</name>
+		<name xml:lang="jp">NAVER</name>
+		<name xml:lang="ru">NAVER</name>
+		<name xml:lang="zh-TW">NAVER</name>
+		<name xml:lang="tr">NAVER</name>
+	</author>
 </module>

--- a/modules/counter/conf/module.xml
+++ b/modules/counter/conf/module.xml
@@ -1,14 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <module>
-    <grants />
-    <permissions>
-        <permission action="getWeeklyUniqueVisitor" target="manager" />
-        <permission action="getWeeklyPageView" target="manager" />
-    </permissions>
-    <actions>
-        <action name="dispCounterAdminIndex" type="view" admin_index="true" />
-        <action name="procCounterExecute" type="controller" />
-        <action name="getWeeklyUniqueVisitor" type="model" />
-        <action name="getWeeklyPageView" type="model" />
-    </actions>
+	<grants />
+	<permissions>
+		<permission action="getWeeklyUniqueVisitor" target="root" />
+		<permission action="getWeeklyPageView" target="root" />
+	</permissions>
+	<actions>
+		<action name="dispCounterAdminIndex" type="view" admin_index="true" />
+		<action name="getWeeklyUniqueVisitor" type="model" />
+		<action name="getWeeklyPageView" type="model" />
+	</actions>
 </module>

--- a/modules/document/conf/info.xml
+++ b/modules/document/conf/info.xml
@@ -1,36 +1,36 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module version="0.2">
-    <title xml:lang="ko">문서</title>
-    <title xml:lang="en">Document</title>
-    <title xml:lang="vi">Bài viết</title>
-    <title xml:lang="es">Documento</title>
-    <title xml:lang="zh-CN">主题管理</title>
-    <title xml:lang="jp">ドキュメント</title>
-    <title xml:lang="ru">Документы</title>
-    <title xml:lang="zh-TW">主題</title>
-    <title xml:lang="tr">Belge</title>
-    <description xml:lang="ko">게시판, 블로그 등의 문서를 관리합니다. </description>
-    <description xml:lang="en">Managing documents used in a board, blog, etc.</description>
-    <description xml:lang="vi">Module quản lý bài viết trên Board, Sổ lưu niệm và những mục khác.</description>
-    <description xml:lang="es">Módulo para manejar los documentos en blog y en los tableros.</description>
-    <description xml:lang="zh-CN">管理版面，博客等处主题的模块。 </description>
-    <description xml:lang="jp">掲示板、ブログなどのモジュールで使用されるドキュメント（書き込み）を管理します。</description>
-    <description xml:lang="ru">Модуль для управления документами в форуме, блоге и прочее.</description>
-    <description xml:lang="zh-TW">管理討論板，部落格等主題的模組。 </description>
-    <description xml:lang="tr">Panoda, blogda, vb., kullanılan belgeleri yönetmek için olan modüldür.</description>
-    <version>1.7</version>
-    <date>2013-11-27</date>
-    <category>content</category>
+	<title xml:lang="ko">문서</title>
+	<title xml:lang="en">Document</title>
+	<title xml:lang="vi">Bài viết</title>
+	<title xml:lang="es">Documento</title>
+	<title xml:lang="zh-CN">主题管理</title>
+	<title xml:lang="jp">ドキュメント</title>
+	<title xml:lang="ru">Документы</title>
+	<title xml:lang="zh-TW">主題</title>
+	<title xml:lang="tr">Belge</title>
+	<description xml:lang="ko">게시판, 블로그 등의 문서를 관리합니다. </description>
+	<description xml:lang="en">Managing documents used in a board, blog, etc.</description>
+	<description xml:lang="vi">Module quản lý bài viết trên Board, Sổ lưu niệm và những mục khác.</description>
+	<description xml:lang="es">Módulo para manejar los documentos en blog y en los tableros.</description>
+	<description xml:lang="zh-CN">管理版面，博客等处主题的模块。 </description>
+	<description xml:lang="jp">掲示板、ブログなどのモジュールで使用されるドキュメント（書き込み）を管理します。</description>
+	<description xml:lang="ru">Модуль для управления документами в форуме, блоге и прочее.</description>
+	<description xml:lang="zh-TW">管理討論板，部落格等主題的模組。 </description>
+	<description xml:lang="tr">Panoda, blogda, vb., kullanılan belgeleri yönetmek için olan modüldür.</description>
+	<version>1.7</version>
+	<date>2013-11-27</date>
+	<category>content</category>
 
-    <author email_address="developers@xpressengine.com" link="http://xpressengine.com/">
-        <name xml:lang="ko">NAVER</name>
-        <name xml:lang="en">NAVER</name>
-        <name xml:lang="vi">NAVER</name>
-        <name xml:lang="es">NAVER</name>
-        <name xml:lang="zh-CN">NAVER</name>
-        <name xml:lang="jp">NAVER</name>
-        <name xml:lang="ru">NAVER</name>
-        <name xml:lang="zh-TW">NAVER</name>
-        <name xml:lang="tr">NAVER</name>
-    </author>
+	<author email_address="developers@xpressengine.com" link="http://xpressengine.com/">
+		<name xml:lang="ko">NAVER</name>
+		<name xml:lang="en">NAVER</name>
+		<name xml:lang="vi">NAVER</name>
+		<name xml:lang="es">NAVER</name>
+		<name xml:lang="zh-CN">NAVER</name>
+		<name xml:lang="jp">NAVER</name>
+		<name xml:lang="ru">NAVER</name>
+		<name xml:lang="zh-TW">NAVER</name>
+		<name xml:lang="tr">NAVER</name>
+	</author>
 </module>

--- a/modules/document/conf/module.xml
+++ b/modules/document/conf/module.xml
@@ -2,69 +2,63 @@
 <module>
 	<grants />
 	<permissions>
-		<!-- member -->
-		<permission action="getDocumentCategories" target="member" />
-		<permission action="procDocumentTempSave" target="member" />
-
-		<!-- manager -->
-		<permission action="getDocumentCategoryTplInfo" target="manager" />
-		<permission action="procDocumentInsertCategory" target="manager" />
-		<permission action="procDocumentDeleteCategory" target="manager" />
-		<permission action="procDocumentMoveCategory" target="manager" />
-		<permission action="procDocumentMakeXmlFile" target="manager" />
-
-		<permission action="procDocumentAddCart" target="manager" />
-		<permission action="procDocumentGetList" target="manager" />
-		<permission action="dispDocumentManageDocument" target="manager" />
-		<permission action="procDocumentManageCheckedDocument" target="manager" />
-		<permission action="procDocumentAdminMoveToTrash" target="manager" />
+		<permission action="dispDocumentManageDocument" target="all-managers" />
 		
-		<permission action="dispDocumentAdminList" target="manager" />
-		<permission action="procDocumentInsertModuleConfig" target="manager" />
-		<permission action="procDocumentAdminInsertExtraVar" target="manager" />
-		<permission action="procDocumentAdminDeleteExtraVar" target="manager" />
+		<permission action="getDocumentCategories" target="member" />
+		<permission action="getDocumentCategoryTplInfo" target="manager" check_var="module_srl" />
+		
+		<permission action="procDocumentTempSave" target="member" />
+		<permission action="procDocumentInsertCategory" target="manager" check_var="module_srl" />
+		<permission action="procDocumentDeleteCategory" target="manager" check_var="module_srl" />
+		<permission action="procDocumentMoveCategory" target="manager" check_var="module_srl" />
+		<permission action="procDocumentMakeXmlFile" target="manager" check_var="module_srl" />
+		<permission action="procDocumentAddCart" target="manager" check_type="document" check_var="srls" />
+		<permission action="procDocumentGetList" target="manager" check_type="document" check_var="document_srls" />
+		<permission action="procDocumentManageCheckedDocument" target="manager" check_type="document" check_var="cart" />
+		<permission action="procDocumentInsertModuleConfig" target="manager" check_var="target_module_srl" />
+		
+		<permission action="procDocumentAdminMoveToTrash" target="manager" check_type="document" check_var="document_srl" />
+		<permission action="procDocumentAdminInsertExtraVar" target="manager" check_var="module_srl" />
+		<permission action="procDocumentAdminDeleteExtraVar" target="manager" check_var="module_srl" />
 	</permissions>
 	<actions>
 		<action name="dispDocumentPrint" type="view" />
 		<action name="dispDocumentPreview" type="view" />
 		<action name="dispTempSavedList" type="view" />
 		<action name="dispDocumentDeclare" type="view" />
-
-		<action name="getDocumentCategories" type="model" />
+		<action name="dispDocumentManageDocument" type="view" />
+		
 		<action name="getDocumentMenu" type="model" />
-
+		<action name="getDocumentCategories" type="model" />
+		<action name="getDocumentCategoryTplInfo" type="model" />
+		<action name="getDocumentVotedMemberList" type="model" />
+		
 		<action name="procDocumentVoteUp" type="controller" />
 		<action name="procDocumentVoteUpCancel" type="controller" />.
 		<action name="procDocumentVoteDown" type="controller" />
 		<action name="procDocumentVoteDownCancel" type="controller" />
 		<action name="procDocumentDeclare" type="controller" />
 		<action name="procDocumentAddCart" type="controller" />
-		<action name="dispDocumentManageDocument" type="view" />
 		<action name="procDocumentManageCheckedDocument" type="controller" />
 		<action name="procDocumentInsertModuleConfig" type="controller" />
-
-		<action name="dispDocumentAdminList" type="view" admin_index="true" menu_name="document" menu_index="true" />
-		<action name="dispDocumentAdminConfig" type="view" />
-		<action name="dispDocumentAdminAlias" type="view" menu_name="document" />
-		<action name="dispDocumentAdminDeclared" type="view" menu_name="document" />
-		<action name="dispDocumentAdminDeclaredLogByDocumentSrl" type="view" menu_name="document" />
-		<action name="dispDocumentAdminTrashList" type="view" menu_name="document" />
-
-		<action name="getDocumentCategoryTplInfo" type="model" />
-		<action name="getDocumentVotedMemberList" type="model" />
-
 		<action name="procDocumentInsertCategory" type="controller" ruleset="insertCategory" />
 		<action name="procDocumentDeleteCategory" type="controller" />
 		<action name="procDocumentMoveCategory" type="controller" />
 		<action name="procDocumentMakeXmlFile" type="controller" />
 		<action name="procDocumentTempSave" type="controller" />
 		<action name="procDocumentGetList" type="controller" />
-
+		
+		<action name="dispDocumentAdminList" type="view" admin_index="true" menu_name="document" menu_index="true" />
+		<action name="dispDocumentAdminConfig" type="view" />
+		<action name="dispDocumentAdminAlias" type="view" menu_name="document" />
+		<action name="dispDocumentAdminDeclared" type="view" menu_name="document" />
+		<action name="dispDocumentAdminDeclaredLogByDocumentSrl" type="view" menu_name="document" />
+		<action name="dispDocumentAdminTrashList" type="view" menu_name="document" />
+		
 		<action name="procDocumentAdminInsertAlias" type="controller" ruleset="insertAlias" />
 		<action name="procDocumentAdminDeleteAlias" type="controller" ruleset="deleteAlias" />
 		<action name="procDocumentAdminRestoreTrash" type="controller" />
 		<action name="procDocumentAdminMoveExtraVar" type="controller" />
-
 		<action name="procDocumentAdminInsertExtraVar" type="controller" ruleset="insertExtraVar" />
 		<action name="procDocumentAdminDeleteExtraVar" type="controller" />
 		<action name="procDocumentAdminDeleteChecked" type="controller" />

--- a/modules/document/conf/module.xml
+++ b/modules/document/conf/module.xml
@@ -2,24 +2,29 @@
 <module>
 	<grants />
 	<permissions>
+		<permission action="dispTempSavedList" target="member" />
+		<permission action="dispDocumentDeclare" target="member" />
 		<permission action="dispDocumentManageDocument" target="all-managers" />
 		
-		<permission action="getDocumentCategories" target="member" />
+		<permission action="getDocumentCategories" target="all-managers" />
 		<permission action="getDocumentCategoryTplInfo" target="manager" check_var="module_srl" />
+		<permission action="getDocumentVotedMemberList" target="root" />
 		
 		<permission action="procDocumentTempSave" target="member" />
+		<permission action="procDocumentDeclare" target="member" />
+		<permission action="procDocumentGetList" target="manager" check_type="document" check_var="document_srls" />
+		<permission action="procDocumentAddCart" target="manager" check_type="document" check_var="srls" />
+		<permission action="procDocumentManageCheckedDocument" target="manager" check_type="document" check_var="cart" />
+		<permission action="procDocumentInsertModuleConfig" target="manager" check_var="target_module_srl" />
 		<permission action="procDocumentInsertCategory" target="manager" check_var="module_srl" />
 		<permission action="procDocumentDeleteCategory" target="manager" check_var="module_srl" />
 		<permission action="procDocumentMoveCategory" target="manager" check_var="module_srl" />
 		<permission action="procDocumentMakeXmlFile" target="manager" check_var="module_srl" />
-		<permission action="procDocumentAddCart" target="manager" check_type="document" check_var="srls" />
-		<permission action="procDocumentGetList" target="manager" check_type="document" check_var="document_srls" />
-		<permission action="procDocumentManageCheckedDocument" target="manager" check_type="document" check_var="cart" />
-		<permission action="procDocumentInsertModuleConfig" target="manager" check_var="target_module_srl" />
 		
 		<permission action="procDocumentAdminMoveToTrash" target="manager" check_type="document" check_var="document_srl" />
 		<permission action="procDocumentAdminInsertExtraVar" target="manager" check_var="module_srl" />
 		<permission action="procDocumentAdminDeleteExtraVar" target="manager" check_var="module_srl" />
+		<permission action="procDocumentAdminMoveExtraVar" target="manager" check_var="module_srl" />
 	</permissions>
 	<actions>
 		<action name="dispDocumentPrint" type="view" />
@@ -37,7 +42,9 @@
 		<action name="procDocumentVoteUpCancel" type="controller" />.
 		<action name="procDocumentVoteDown" type="controller" />
 		<action name="procDocumentVoteDownCancel" type="controller" />
+		<action name="procDocumentTempSave" type="controller" />
 		<action name="procDocumentDeclare" type="controller" />
+		<action name="procDocumentGetList" type="controller" />
 		<action name="procDocumentAddCart" type="controller" />
 		<action name="procDocumentManageCheckedDocument" type="controller" />
 		<action name="procDocumentInsertModuleConfig" type="controller" />
@@ -45,27 +52,25 @@
 		<action name="procDocumentDeleteCategory" type="controller" />
 		<action name="procDocumentMoveCategory" type="controller" />
 		<action name="procDocumentMakeXmlFile" type="controller" />
-		<action name="procDocumentTempSave" type="controller" />
-		<action name="procDocumentGetList" type="controller" />
 		
 		<action name="dispDocumentAdminList" type="view" admin_index="true" menu_name="document" menu_index="true" />
-		<action name="dispDocumentAdminConfig" type="view" />
-		<action name="dispDocumentAdminAlias" type="view" menu_name="document" />
+		<action name="dispDocumentAdminConfig" type="view" menu_name="document" />
 		<action name="dispDocumentAdminDeclared" type="view" menu_name="document" />
 		<action name="dispDocumentAdminDeclaredLogByDocumentSrl" type="view" menu_name="document" />
+		<action name="dispDocumentAdminAlias" type="view" menu_name="document" />
 		<action name="dispDocumentAdminTrashList" type="view" menu_name="document" />
 		
-		<action name="procDocumentAdminInsertAlias" type="controller" ruleset="insertAlias" />
-		<action name="procDocumentAdminDeleteAlias" type="controller" ruleset="deleteAlias" />
-		<action name="procDocumentAdminRestoreTrash" type="controller" />
-		<action name="procDocumentAdminMoveExtraVar" type="controller" />
-		<action name="procDocumentAdminInsertExtraVar" type="controller" ruleset="insertExtraVar" />
-		<action name="procDocumentAdminDeleteExtraVar" type="controller" />
 		<action name="procDocumentAdminDeleteChecked" type="controller" />
 		<action name="procDocumentAdminInsertConfig" type="controller" />
 		<action name="procDocumentAdminDeleteAllThumbnail" type="controller" />
 		<action name="procDocumentAdminCancelDeclare" type="controller" />
+		<action name="procDocumentAdminInsertAlias" type="controller" ruleset="insertAlias" />
+		<action name="procDocumentAdminDeleteAlias" type="controller" ruleset="deleteAlias" />
 		<action name="procDocumentAdminMoveToTrash" type="controller" />
+		<action name="procDocumentAdminRestoreTrash" type="controller" />
+		<action name="procDocumentAdminInsertExtraVar" type="controller" ruleset="insertExtraVar" />
+		<action name="procDocumentAdminDeleteExtraVar" type="controller" />
+		<action name="procDocumentAdminMoveExtraVar" type="controller" />
 	</actions>
 	<menus>
 		<menu name="document">

--- a/modules/editor/conf/info.xml
+++ b/modules/editor/conf/info.xml
@@ -1,36 +1,36 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module version="0.2">
-    <title xml:lang="vi">WYSIWYG Editor</title>
-    <title xml:lang="ko">위지윅 에디터 </title>
-    <title xml:lang="en">WYSIWYG Editor</title>
-    <title xml:lang="es">Editor WYSIWYG</title>
-    <title xml:lang="zh-CN">网页编辑器</title>
-    <title xml:lang="jp">ウィジウィグエディター</title>
-    <title xml:lang="ru">WYSIWYG-редактор</title>
-    <title xml:lang="zh-TW">網頁編輯器</title>
-    <title xml:lang="tr">Editor WYSIWYG</title>
-    <description xml:lang="vi">Module hiển thị WYSIWYG Editor để quản lý những kiểu viết bài.</description>
-    <description xml:lang="ko">위지윅 에디터를 출력하거나 에디터 컴포넌트들을 관리/중계하는 합니다.</description>
-    <description xml:lang="en">Module for displaying WYSIWYG editor and managing/relaying editor components.</description>
-    <description xml:lang="es">Módulo para mostrar en la pantalla el editor de WYSIWYG y para el manejo/relato de los componentes del editor.</description>
-    <description xml:lang="zh-CN">显示网页编辑器或管理/传递编辑器组件的模块。</description>
-    <description xml:lang="jp">ウィジウィグエディターを出力したり、エディターのコンポーネントを管理・中継するモジュールです。</description>
-    <description xml:lang="ru">Модуль для отображения WYSIWYG-редактора и управления/смены записей редактора.</description>
-    <description xml:lang="zh-TW">顯示網頁編輯器或管理/傳遞編輯器組件的模組。</description>
-    <description xml:lang="tr">WYSIWYG editörünü görüntüleme ve editör bileşenlerini düzenleme/aktarma için kullanılan modüldür. </description>
-    <version>1.7</version>
-    <date>2013-11-27</date>
-    <category>utility</category>
+	<title xml:lang="vi">WYSIWYG Editor</title>
+	<title xml:lang="ko">위지윅 에디터 </title>
+	<title xml:lang="en">WYSIWYG Editor</title>
+	<title xml:lang="es">Editor WYSIWYG</title>
+	<title xml:lang="zh-CN">网页编辑器</title>
+	<title xml:lang="jp">ウィジウィグエディター</title>
+	<title xml:lang="ru">WYSIWYG-редактор</title>
+	<title xml:lang="zh-TW">網頁編輯器</title>
+	<title xml:lang="tr">Editor WYSIWYG</title>
+	<description xml:lang="vi">Module hiển thị WYSIWYG Editor để quản lý những kiểu viết bài.</description>
+	<description xml:lang="ko">위지윅 에디터를 출력하거나 에디터 컴포넌트들을 관리/중계하는 합니다.</description>
+	<description xml:lang="en">Module for displaying WYSIWYG editor and managing/relaying editor components.</description>
+	<description xml:lang="es">Módulo para mostrar en la pantalla el editor de WYSIWYG y para el manejo/relato de los componentes del editor.</description>
+	<description xml:lang="zh-CN">显示网页编辑器或管理/传递编辑器组件的模块。</description>
+	<description xml:lang="jp">ウィジウィグエディターを出力したり、エディターのコンポーネントを管理・中継するモジュールです。</description>
+	<description xml:lang="ru">Модуль для отображения WYSIWYG-редактора и управления/смены записей редактора.</description>
+	<description xml:lang="zh-TW">顯示網頁編輯器或管理/傳遞編輯器組件的模組。</description>
+	<description xml:lang="tr">WYSIWYG editörünü görüntüleme ve editör bileşenlerini düzenleme/aktarma için kullanılan modüldür. </description>
+	<version>1.7</version>
+	<date>2013-11-27</date>
+	<category>utility</category>
 
-    <author email_address="developers@xpressengine.com" link="http://xpressengine.com/">
-        <name xml:lang="vi">NAVER</name>
-        <name xml:lang="ko">NAVER</name>
-        <name xml:lang="en">NAVER</name>
-        <name xml:lang="es">NAVER</name>
-        <name xml:lang="zh-CN">NAVER</name>
-        <name xml:lang="jp">NAVER</name>
-        <name xml:lang="ru">NAVER</name>
-        <name xml:lang="zh-TW">NAVER</name>
-        <name xml:lang="tr">NAVER</name>
-    </author>
+	<author email_address="developers@xpressengine.com" link="http://xpressengine.com/">
+		<name xml:lang="vi">NAVER</name>
+		<name xml:lang="ko">NAVER</name>
+		<name xml:lang="en">NAVER</name>
+		<name xml:lang="es">NAVER</name>
+		<name xml:lang="zh-CN">NAVER</name>
+		<name xml:lang="jp">NAVER</name>
+		<name xml:lang="ru">NAVER</name>
+		<name xml:lang="zh-TW">NAVER</name>
+		<name xml:lang="tr">NAVER</name>
+	</author>
 </module>

--- a/modules/editor/conf/module.xml
+++ b/modules/editor/conf/module.xml
@@ -2,28 +2,30 @@
 <module>
 	<grants />
 	<permissions>
+		<permission action="dispEditorSkinColorset" target="root" />
+		<permission action="dispEditorConfigPreview" target="root" />
+		
 		<permission action="procEditorInsertModuleConfig" target="manager" check_var="target_module_srl" />
 	</permissions>
 	<actions>
-		<action name="dispEditorPopup" type="view" />
 		<action name="dispEditorComponentInfo" type="view" />
-		<action name="dispEditorConfigPreview" type="view" />
+		<action name="dispEditorPopup" type="view" />
 		<action name="dispEditorPreview" type="view" />
 		<action name="dispEditorSkinColorset" type="view" />
+		<action name="dispEditorConfigPreview" type="view" />
 		
+		<action name="procEditorCall" type="controller" />
 		<action name="procEditorSaveDoc" type="controller" />
 		<action name="procEditorRemoveSavedDoc" type="controller" />
-		<action name="procEditorCall" type="controller" />
-		<action name="procEditorInsertModuleConfig" type="controller" />
 		<action name="procEditorLoadSavedDocument" type="controller" />
+		<action name="procEditorInsertModuleConfig" type="controller" />
 		
 		<action name="dispEditorAdminIndex" type="view" menu_name="editor" menu_index="true" admin_index="true" />
 		<action name="dispEditorAdminSetupComponent" type="view" menu_name="editor" />
-		<action name="dispEditorAdminSkinColorset" type="view" />
 		
-		<action name="procEditorAdminSetupComponent" type="controller" ruleset="setupComponent" />
 		<action name="procEditorAdminGeneralConfig" type="controller" ruleset="generalConfig" />
 		<action name="procEditorAdminCheckUseListOrder" type="controller" ruleset="componentOrderAndUse" />
+		<action name="procEditorAdminSetupComponent" type="controller" ruleset="setupComponent" />
 	</actions>
 	<menus>
 		<menu name="editor">

--- a/modules/editor/conf/module.xml
+++ b/modules/editor/conf/module.xml
@@ -2,25 +2,28 @@
 <module>
 	<grants />
 	<permissions>
-		<permission action="procEditorInsertModuleConfig" target="manager" />
+		<permission action="procEditorInsertModuleConfig" target="manager" check_var="target_module_srl" />
 	</permissions>
 	<actions>
 		<action name="dispEditorPopup" type="view" />
 		<action name="dispEditorComponentInfo" type="view" />
-		<action name="dispEditorAdminIndex" type="view" menu_name="editor" menu_index="true" admin_index="true" />
-		<action name="dispEditorAdminSetupComponent" type="view" menu_name="editor" />
-		<action name="dispEditorAdminSkinColorset" type="view" />
 		<action name="dispEditorConfigPreview" type="view" />
 		<action name="dispEditorPreview" type="view" />
 		<action name="dispEditorSkinColorset" type="view" />
+		
 		<action name="procEditorSaveDoc" type="controller" />
 		<action name="procEditorRemoveSavedDoc" type="controller" />
 		<action name="procEditorCall" type="controller" />
 		<action name="procEditorInsertModuleConfig" type="controller" />
+		<action name="procEditorLoadSavedDocument" type="controller" />
+		
+		<action name="dispEditorAdminIndex" type="view" menu_name="editor" menu_index="true" admin_index="true" />
+		<action name="dispEditorAdminSetupComponent" type="view" menu_name="editor" />
+		<action name="dispEditorAdminSkinColorset" type="view" />
+		
 		<action name="procEditorAdminSetupComponent" type="controller" ruleset="setupComponent" />
 		<action name="procEditorAdminGeneralConfig" type="controller" ruleset="generalConfig" />
 		<action name="procEditorAdminCheckUseListOrder" type="controller" ruleset="componentOrderAndUse" />
-		<action name="procEditorLoadSavedDocument" type="controller" />
 	</actions>
 	<menus>
 		<menu name="editor">

--- a/modules/file/conf/info.xml
+++ b/modules/file/conf/info.xml
@@ -1,36 +1,36 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module version="0.2">
-    <title xml:lang="ko">첨부파일</title>
-    <title xml:lang="zh-CN">附件管理</title>
-    <title xml:lang="en">Attachment</title>
-    <title xml:lang="vi">Đính kèm</title>
-    <title xml:lang="es">Adjuntar archivos</title>
-    <title xml:lang="jp">添付ファイル</title>
-    <title xml:lang="ru">Вложения</title>
-    <title xml:lang="zh-TW">附加檔案</title>
-    <title xml:lang="tr">Ekler</title>
-    <description xml:lang="ko">첨부 파일을 관리합니다.</description>
-    <description xml:lang="zh-CN">管理附件的模块。</description>
-    <description xml:lang="en">Managing attachments.</description>
-    <description xml:lang="vi">Module quản lý File đính kèm.</description>
-    <description xml:lang="es">Módulo para manejar los archivos adjuntos.</description>
-    <description xml:lang="jp">添付ファイルを管理するモジュールです。</description>
-    <description xml:lang="ru">Модуль для управления вложениями.</description>
-    <description xml:lang="zh-TW">管理附加檔案的模組。</description>
-    <description xml:lang="tr">Ekleri yönetmek için kullanılan modüldür.</description>
-    <version>1.7</version>
-    <date>2013-11-27</date>
-    <category>content</category>
+	<title xml:lang="ko">첨부파일</title>
+	<title xml:lang="zh-CN">附件管理</title>
+	<title xml:lang="en">Attachment</title>
+	<title xml:lang="vi">Đính kèm</title>
+	<title xml:lang="es">Adjuntar archivos</title>
+	<title xml:lang="jp">添付ファイル</title>
+	<title xml:lang="ru">Вложения</title>
+	<title xml:lang="zh-TW">附加檔案</title>
+	<title xml:lang="tr">Ekler</title>
+	<description xml:lang="ko">첨부 파일을 관리합니다.</description>
+	<description xml:lang="zh-CN">管理附件的模块。</description>
+	<description xml:lang="en">Managing attachments.</description>
+	<description xml:lang="vi">Module quản lý File đính kèm.</description>
+	<description xml:lang="es">Módulo para manejar los archivos adjuntos.</description>
+	<description xml:lang="jp">添付ファイルを管理するモジュールです。</description>
+	<description xml:lang="ru">Модуль для управления вложениями.</description>
+	<description xml:lang="zh-TW">管理附加檔案的模組。</description>
+	<description xml:lang="tr">Ekleri yönetmek için kullanılan modüldür.</description>
+	<version>1.7</version>
+	<date>2013-11-27</date>
+	<category>content</category>
 
-    <author email_address="developers@xpressengine.com" link="http://xpressengine.com/">
-        <name xml:lang="ko">NAVER</name>
-        <name xml:lang="vi">NAVER</name>
-        <name xml:lang="zh-CN">NAVER</name>
-        <name xml:lang="en">NAVER</name>
-        <name xml:lang="es">NAVER</name>
-        <name xml:lang="jp">NAVER</name>
-        <name xml:lang="ru">NAVER</name>
-        <name xml:lang="zh-TW">NAVER</name>
-        <name xml:lang="tr">NAVER</name>
-    </author>
+	<author email_address="developers@xpressengine.com" link="http://xpressengine.com/">
+		<name xml:lang="ko">NAVER</name>
+		<name xml:lang="vi">NAVER</name>
+		<name xml:lang="zh-CN">NAVER</name>
+		<name xml:lang="en">NAVER</name>
+		<name xml:lang="es">NAVER</name>
+		<name xml:lang="jp">NAVER</name>
+		<name xml:lang="ru">NAVER</name>
+		<name xml:lang="zh-TW">NAVER</name>
+		<name xml:lang="tr">NAVER</name>
+	</author>
 </module>

--- a/modules/file/conf/module.xml
+++ b/modules/file/conf/module.xml
@@ -12,18 +12,18 @@
 		<action name="procFileIframeUpload" type="controller" />
 		<action name="procFileImageResize" type="controller" ruleset="imageResize" />
 		<action name="procFileDelete" type="controller" />
+		<action name="procFileSetCoverImage" type="controller" />
 		<action name="procFileDownload" type="controller" method="GET|POST" />
 		<action name="procFileOutput" type="controller" method="GET|POST" />
 		<action name="procFileGetList" type="controller" />
-		<action name="procFileSetCoverImage" type="controller" />
 		
 		<action name="dispFileAdminList" type="view" admin_index="true" menu_name="file" menu_index="true" />
 		<action name="dispFileAdminConfig" type="view" menu_name="fileUpload" menu_index="true" />
 		
+		<action name="procFileAdminAddCart" type="controller" />
 		<action name="procFileAdminDeleteChecked" type="controller" ruleset="deleteChecked" />
 		<action name="procFileAdminInsertConfig" type="controller" ruleset="insertConfig" />
 		<action name="procFileAdminInsertModuleConfig" type="controller" ruleset="fileModuleConfig" />
-		<action name="procFileAdminAddCart" type="controller" />
 	</actions>
 	<menus>
 		<menu name="file">

--- a/modules/file/conf/module.xml
+++ b/modules/file/conf/module.xml
@@ -1,27 +1,30 @@
 <?xml version="1.0" encoding="utf-8"?>
 <module>
-    <grants />
-    <permissions>
-		<permission action="procFileGetList" target="manager" />
-        <permission action="procFileAdminInsertModuleConfig" target="manager" />
-    </permissions>
-    <actions>
-        <action name="dispFileAdminList" type="view" admin_index="true" menu_name="file" menu_index="true" />
-        <action name="dispFileAdminConfig" type="view" menu_name="fileUpload" menu_index="true" />
-        <action name="getFileList" type="model" />
-        <action name="procFileUpload" type="controller" check_csrf="false" />
-        <action name="procFileIframeUpload" type="controller" />
-        <action name="procFileImageResize" type="controller" ruleset="imageResize" />
-        <action name="procFileDelete" type="controller" />
-        <action name="procFileDownload" type="controller" method="GET|POST" />
-        <action name="procFileOutput" type="controller" method="GET|POST" />
-        <action name="procFileAdminDeleteChecked" type="controller" ruleset="deleteChecked" />
-        <action name="procFileAdminInsertConfig" type="controller" ruleset="insertConfig" />
-        <action name="procFileAdminInsertModuleConfig" type="controller" ruleset="fileModuleConfig" />
-        <action name="procFileAdminAddCart" type="controller" />
-        <action name="procFileGetList" type="controller" />
-        <action name="procFileSetCoverImage" type="controller" />
-    </actions>
+	<grants />
+	<permissions>
+		<permission action="procFileGetList" target="root" />
+		<permission action="procFileAdminInsertModuleConfig" target="manager" check_var="target_module_srl" />
+	</permissions>
+	<actions>
+		<action name="getFileList" type="model" />
+		
+		<action name="procFileUpload" type="controller" check_csrf="false" />
+		<action name="procFileIframeUpload" type="controller" />
+		<action name="procFileImageResize" type="controller" ruleset="imageResize" />
+		<action name="procFileDelete" type="controller" />
+		<action name="procFileDownload" type="controller" method="GET|POST" />
+		<action name="procFileOutput" type="controller" method="GET|POST" />
+		<action name="procFileGetList" type="controller" />
+		<action name="procFileSetCoverImage" type="controller" />
+		
+		<action name="dispFileAdminList" type="view" admin_index="true" menu_name="file" menu_index="true" />
+		<action name="dispFileAdminConfig" type="view" menu_name="fileUpload" menu_index="true" />
+		
+		<action name="procFileAdminDeleteChecked" type="controller" ruleset="deleteChecked" />
+		<action name="procFileAdminInsertConfig" type="controller" ruleset="insertConfig" />
+		<action name="procFileAdminInsertModuleConfig" type="controller" ruleset="fileModuleConfig" />
+		<action name="procFileAdminAddCart" type="controller" />
+	</actions>
 	<menus>
 		<menu name="file">
 			<title xml:lang="en">File</title>

--- a/modules/importer/conf/info.xml
+++ b/modules/importer/conf/info.xml
@@ -1,36 +1,36 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module version="0.2">
-    <title xml:lang="ko">데이터 이전</title>
-    <title xml:lang="en">Data Importer</title>
-    <title xml:lang="vi">Chuyển đổi Data</title>
-    <title xml:lang="zh-CN">数据导入</title>
-    <title xml:lang="jp">データ移転</title>
-    <title xml:lang="es">Transferencia de los datos</title>
-    <title xml:lang="ru">Трансферинг</title>
-    <title xml:lang="zh-TW">資料匯入</title>
-    <title xml:lang="tr">Veri Alıcısı</title>
-    <description xml:lang="ko">XML파일을 이용하여 회원정보 또는 게시판등의 데이터를 입력합니다.</description>
-    <description xml:lang="en">This module imports data of members and articles from XML file.</description>
-    <description xml:lang="vi">Nhập thông tin thành viên hoặc Database sử dụng định dạng XML Data.</description>
-    <description xml:lang="zh-CN">利用XML文件导入会员信息或版面数据。</description>
-    <description xml:lang="jp">XMLファイルを用いて会員情報または掲示板などの情報を入力します。</description>
-    <description xml:lang="es">Ingresa la información del usuario o los datos del tablero utilizando el archivo XML.</description>
-    <description xml:lang="ru">Запись информации пользователей или форума, используя XML-файл.</description>
-    <description xml:lang="zh-TW">利用 XML 檔案匯入會員或討論板資料。</description>
-    <description xml:lang="tr">Bu modül, XML dosyasından üye ve makale verilerinin içeri aktarımı içindir.</description>
-    <version>1.7</version>
-    <date>2013-11-27</date>
-    <category>migration</category>
+	<title xml:lang="ko">데이터 이전</title>
+	<title xml:lang="en">Data Importer</title>
+	<title xml:lang="vi">Chuyển đổi Data</title>
+	<title xml:lang="zh-CN">数据导入</title>
+	<title xml:lang="jp">データ移転</title>
+	<title xml:lang="es">Transferencia de los datos</title>
+	<title xml:lang="ru">Трансферинг</title>
+	<title xml:lang="zh-TW">資料匯入</title>
+	<title xml:lang="tr">Veri Alıcısı</title>
+	<description xml:lang="ko">XML파일을 이용하여 회원정보 또는 게시판등의 데이터를 입력합니다.</description>
+	<description xml:lang="en">This module imports data of members and articles from XML file.</description>
+	<description xml:lang="vi">Nhập thông tin thành viên hoặc Database sử dụng định dạng XML Data.</description>
+	<description xml:lang="zh-CN">利用XML文件导入会员信息或版面数据。</description>
+	<description xml:lang="jp">XMLファイルを用いて会員情報または掲示板などの情報を入力します。</description>
+	<description xml:lang="es">Ingresa la información del usuario o los datos del tablero utilizando el archivo XML.</description>
+	<description xml:lang="ru">Запись информации пользователей или форума, используя XML-файл.</description>
+	<description xml:lang="zh-TW">利用 XML 檔案匯入會員或討論板資料。</description>
+	<description xml:lang="tr">Bu modül, XML dosyasından üye ve makale verilerinin içeri aktarımı içindir.</description>
+	<version>1.7</version>
+	<date>2013-11-27</date>
+	<category>migration</category>
 
-    <author email_address="developers@xpressengine.com" link="http://xpressengine.com/">
-        <name xml:lang="ko">NAVER</name>
-        <name xml:lang="en">NAVER</name>
-        <name xml:lang="vi">NAVER</name>
-        <name xml:lang="zh-CN">NAVER</name>
-        <name xml:lang="jp">NAVER</name>
-        <name xml:lang="es">NAVER</name>
-        <name xml:lang="ru">NAVER</name>
-        <name xml:lang="zh-TW">NAVER</name>
-        <name xml:lang="tr">NAVER</name>
-    </author>
+	<author email_address="developers@xpressengine.com" link="http://xpressengine.com/">
+		<name xml:lang="ko">NAVER</name>
+		<name xml:lang="en">NAVER</name>
+		<name xml:lang="vi">NAVER</name>
+		<name xml:lang="zh-CN">NAVER</name>
+		<name xml:lang="jp">NAVER</name>
+		<name xml:lang="es">NAVER</name>
+		<name xml:lang="ru">NAVER</name>
+		<name xml:lang="zh-TW">NAVER</name>
+		<name xml:lang="tr">NAVER</name>
+	</author>
 </module>

--- a/modules/importer/conf/module.xml
+++ b/modules/importer/conf/module.xml
@@ -8,10 +8,6 @@
 		<action name="procImporterAdminImport" type="controller" />
 		<action name="procImporterAdminPreProcessing" type="controller" />
 		<action name="procImporterAdminSync" type="controller" />
-		<action name="procImporterAdminMemberImport" type="controller" />
-		<action name="procImporterAdminMessageImport" type="controller" />
-		<action name="procImporterAdminModuleImport" type="controller" />
-		<action name="procImporterAdminTTXMLImport" type="controller" />
 		<action name="procImporterAdminCheckXmlFile" type="controller" />
 	</actions>
 	<menus>

--- a/modules/importer/conf/module.xml
+++ b/modules/importer/conf/module.xml
@@ -1,20 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <module>
-    <grants />
-    <permissions />
-    <actions>
-        <action name="dispImporterAdminImportForm" type="view" admin_index="true" menu_name="importer" menu_index="true" />
-
-        <action name="procImporterAdminImport" type="controller" />
-        <action name="procImporterAdminPreProcessing" type="controller" />
-
-        <action name="procImporterAdminSync" type="controller" />
-        <action name="procImporterAdminMemberImport" type="controller" />
-        <action name="procImporterAdminMessageImport" type="controller" />
-        <action name="procImporterAdminModuleImport" type="controller" />
-        <action name="procImporterAdminTTXMLImport" type="controller" />
-        <action name="procImporterAdminCheckXmlFile" type="controller" />
-    </actions>
+	<grants />
+	<permissions />
+	<actions>
+		<action name="dispImporterAdminImportForm" type="view" admin_index="true" menu_name="importer" menu_index="true" />
+		
+		<action name="procImporterAdminImport" type="controller" />
+		<action name="procImporterAdminPreProcessing" type="controller" />
+		<action name="procImporterAdminSync" type="controller" />
+		<action name="procImporterAdminMemberImport" type="controller" />
+		<action name="procImporterAdminMessageImport" type="controller" />
+		<action name="procImporterAdminModuleImport" type="controller" />
+		<action name="procImporterAdminTTXMLImport" type="controller" />
+		<action name="procImporterAdminCheckXmlFile" type="controller" />
+	</actions>
 	<menus>
 		<menu name="importer">
 			<title xml:lang="en">Data Migration</title>

--- a/modules/install/conf/info.xml
+++ b/modules/install/conf/info.xml
@@ -1,36 +1,36 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module version="0.2">
-    <title xml:lang="ko">설치관리</title>
-    <title xml:lang="en">Manage installation</title>
-    <title xml:lang="vi">Quản lý cài đặt</title>
-    <title xml:lang="zh-CN">安装管理</title>
-    <title xml:lang="jp">インストール管理</title>
-    <title xml:lang="es">Manajo de la Instalación</title>
-    <title xml:lang="ru">Управление установкой</title>
-    <title xml:lang="zh-TW">安裝管理</title>
-    <title xml:lang="tr">Kurulumu yönet</title>
-    <description xml:lang="ko">설치 관리 모듈</description>
-    <description xml:lang="en">Module for managing installations</description>
-    <description xml:lang="vi">Module quản lý cài đặt</description>
-    <description xml:lang="zh-CN">安装管理模块。</description>
-    <description xml:lang="jp">インストール管理モジュール</description>
-    <description xml:lang="es">Módulo para el manejo de la instalación</description>
-    <description xml:lang="ru">Модуль для управления установкой</description>
-    <description xml:lang="zh-TW">安裝管理模組</description>
-    <description xml:lang="tr">Kurulumu yönetmek için olan modüldür</description>
-    <version>1.7</version>
-    <date>2013-11-27</date>
-    <category>system</category>
+	<title xml:lang="ko">설치관리</title>
+	<title xml:lang="en">Manage installation</title>
+	<title xml:lang="vi">Quản lý cài đặt</title>
+	<title xml:lang="zh-CN">安装管理</title>
+	<title xml:lang="jp">インストール管理</title>
+	<title xml:lang="es">Manajo de la Instalación</title>
+	<title xml:lang="ru">Управление установкой</title>
+	<title xml:lang="zh-TW">安裝管理</title>
+	<title xml:lang="tr">Kurulumu yönet</title>
+	<description xml:lang="ko">설치 관리 모듈</description>
+	<description xml:lang="en">Module for managing installations</description>
+	<description xml:lang="vi">Module quản lý cài đặt</description>
+	<description xml:lang="zh-CN">安装管理模块。</description>
+	<description xml:lang="jp">インストール管理モジュール</description>
+	<description xml:lang="es">Módulo para el manejo de la instalación</description>
+	<description xml:lang="ru">Модуль для управления установкой</description>
+	<description xml:lang="zh-TW">安裝管理模組</description>
+	<description xml:lang="tr">Kurulumu yönetmek için olan modüldür</description>
+	<version>1.7</version>
+	<date>2013-11-27</date>
+	<category>system</category>
 
-    <author email_address="developers@xpressengine.com" link="http://xpressengine.com/">
-        <name xml:lang="ko">NAVER</name>
-        <name xml:lang="vi">NAVER</name>
-        <name xml:lang="en">NAVER</name>
-        <name xml:lang="zh-CN">NAVER</name>
-        <name xml:lang="jp">NAVER</name>
-        <name xml:lang="es">NAVER</name>
-        <name xml:lang="ru">NAVER</name>
-        <name xml:lang="zh-TW">NAVER</name>
-        <name xml:lang="tr">NAVER</name>
-    </author>
+	<author email_address="developers@xpressengine.com" link="http://xpressengine.com/">
+		<name xml:lang="ko">NAVER</name>
+		<name xml:lang="vi">NAVER</name>
+		<name xml:lang="en">NAVER</name>
+		<name xml:lang="zh-CN">NAVER</name>
+		<name xml:lang="jp">NAVER</name>
+		<name xml:lang="es">NAVER</name>
+		<name xml:lang="ru">NAVER</name>
+		<name xml:lang="zh-TW">NAVER</name>
+		<name xml:lang="tr">NAVER</name>
+	</author>
 </module>

--- a/modules/install/conf/module.xml
+++ b/modules/install/conf/module.xml
@@ -1,18 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <module>
-    <grants />
-    <permissions />
-    <actions>
-        <action name="dispInstallIndex" type="view" index="true" />
-        <action name="dispInstallCheckEnv" type="view" />
-        <action name="dispInstallDBConfig" type="view" />
-        <action name="dispInstallOtherConfig" type="view" />
-        <action name="procDBConfig" type="controller" />
-        <action name="procInstall" type="controller" ruleset="install" />
-        <action name="procInstallLicenseAgreement" type="controller" />
-        <action name="procInstallAdminInstall" type="controller" />
-        <action name="procInstallAdminUpdate" type="controller" />
+	<grants />
+	<permissions>
+		<permission action="getInstallFTPList" target="root" />
+	</permissions>
+	<actions>
+		<action name="dispInstallIndex" type="view" index="true" />
+		<action name="dispInstallCheckEnv" type="view" />
+		<action name="dispInstallDBConfig" type="view" />
+		<action name="dispInstallOtherConfig" type="view" />
+		
+		<action name="getInstallFTPList" type="model" />
+		
+		<action name="procDBConfig" type="controller" />
+		<action name="procInstall" type="controller" ruleset="install" />
+		<action name="procInstallLicenseAgreement" type="controller" />
+		
+		<action name="procInstallAdminInstall" type="controller" />
+		<action name="procInstallAdminUpdate" type="controller" />
 		<action name="procInstallAdminUpdateIndexModule" type="controller" />
-        <action name="getInstallFTPList" type="model" />
-    </actions>
+	</actions>
 </module>

--- a/modules/install/conf/module.xml
+++ b/modules/install/conf/module.xml
@@ -12,9 +12,9 @@
 		
 		<action name="getInstallFTPList" type="model" />
 		
+		<action name="procInstallLicenseAgreement" type="controller" />
 		<action name="procDBConfig" type="controller" />
 		<action name="procInstall" type="controller" ruleset="install" />
-		<action name="procInstallLicenseAgreement" type="controller" />
 		
 		<action name="procInstallAdminInstall" type="controller" />
 		<action name="procInstallAdminUpdate" type="controller" />

--- a/modules/integration_search/conf/info.xml
+++ b/modules/integration_search/conf/info.xml
@@ -1,63 +1,63 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module version="0.2">
-    <title xml:lang="ko">통합검색</title>
-    <title xml:lang="en">Integrated Search</title>
-    <title xml:lang="jp">統合検索</title>
+	<title xml:lang="ko">통합검색</title>
+	<title xml:lang="en">Integrated Search</title>
+	<title xml:lang="jp">統合検索</title>
 	<title xml:lang="zh-CN">集成搜索</title>
 	<title xml:lang="zh-TW">集成搜索</title>
-    <title xml:lang="vi">Tìm kiếm tích hợp</title>
-    <title xml:lang="es">Búsqueda Integrada</title>
-    <title xml:lang="ru">Интегрируемый поиск</title>
-    <title xml:lang="tr">Birleşik Arama</title>
-    <description xml:lang="ko">
-        선택한 페이지를 대상으로 통합검색을 지원합니다.
-        선택한 페이지의 글중 비밀글만 검색을 하지 않고 나머지는 모두 검색을 하기에 공개되지 않은 페이지는 대상에 포함하지 않도록 해야 합니다.
-    </description>
-    <description xml:lang="zh-CN">
-        把所选模块作为搜索对象。
-        所选模块当中只有密帖不会被搜索，因此请留意您不想搜索的模块。
-    </description>
-    <description xml:lang="jp">
-        選択されたモジュールを対象に統合検索を行う機能をサポートします。
-        選択されたモジュールのコンテンツ（書き込み）の中で、非公開コンテンツのみ検索から除外されますので、未公開のモジュールは対象にしないようにして下さい。
-    </description>
-    <description xml:lang="en">
-        It supports the integrated search for chosen modules.
-        All articles except secret articles will be searched, so you need to be careful not to include secret module to target.
-    </description>
-    <description xml:lang="vi">
-        Hỗ trợ tìm kiếm tích hợp cho những Module được chọn.
-        Mọi bài viết đều có thể được tìm kiếm (Trừ những bài đặt bí mật), vì vậy bạn hãy cẩn thận khi chọn những Module bí mật.
-    </description>
-    <description xml:lang="es">
-        Soporta la búsqueda integrada de los módulos elegidos.
-        Todo los documentos excepto los secretos serán buscados, y es necesario tener cuidado de no incluir módulo secreto como  objetivo.
-    </description>
-    <description xml:lang="ru">
-        Поддерживает интеграцию поиска в выбранные модули.
-        Все статьи, за исключением секретных, будут подлежать поиску, поэтому Вам нужно быть осторожным с тем, чтобы не включить модуль секретов в назначение.
-    </description>
-    <description xml:lang="tr">
-        Seçili modüller için toplu arama desteği sunar.
-        Gizli makaleler dışındaki tüm makaleler aranacaktır.Bu yüzden hedefin, gizli modülü içermemesine dikkat ediniz.
-    </description>
-    <description xml:lang="zh-TW">
-        將所選擇的模組當作搜尋對象進行搜尋。
-        所搜尋的模組中，如有私密文章時將不會被搜尋，因此請注意選擇。
-    </description>
-    <version>1.7</version>
-    <date>2013-11-27</date>
-    <category>service</category>
+	<title xml:lang="vi">Tìm kiếm tích hợp</title>
+	<title xml:lang="es">Búsqueda Integrada</title>
+	<title xml:lang="ru">Интегрируемый поиск</title>
+	<title xml:lang="tr">Birleşik Arama</title>
+	<description xml:lang="ko">
+		선택한 페이지를 대상으로 통합검색을 지원합니다.
+		선택한 페이지의 글중 비밀글만 검색을 하지 않고 나머지는 모두 검색을 하기에 공개되지 않은 페이지는 대상에 포함하지 않도록 해야 합니다.
+	</description>
+	<description xml:lang="zh-CN">
+		把所选模块作为搜索对象。
+		所选模块当中只有密帖不会被搜索，因此请留意您不想搜索的模块。
+	</description>
+	<description xml:lang="jp">
+		選択されたモジュールを対象に統合検索を行う機能をサポートします。
+		選択されたモジュールのコンテンツ（書き込み）の中で、非公開コンテンツのみ検索から除外されますので、未公開のモジュールは対象にしないようにして下さい。
+	</description>
+	<description xml:lang="en">
+		It supports the integrated search for chosen modules.
+		All articles except secret articles will be searched, so you need to be careful not to include secret module to target.
+	</description>
+	<description xml:lang="vi">
+		Hỗ trợ tìm kiếm tích hợp cho những Module được chọn.
+		Mọi bài viết đều có thể được tìm kiếm (Trừ những bài đặt bí mật), vì vậy bạn hãy cẩn thận khi chọn những Module bí mật.
+	</description>
+	<description xml:lang="es">
+		Soporta la búsqueda integrada de los módulos elegidos.
+		Todo los documentos excepto los secretos serán buscados, y es necesario tener cuidado de no incluir módulo secreto como  objetivo.
+	</description>
+	<description xml:lang="ru">
+		Поддерживает интеграцию поиска в выбранные модули.
+		Все статьи, за исключением секретных, будут подлежать поиску, поэтому Вам нужно быть осторожным с тем, чтобы не включить модуль секретов в назначение.
+	</description>
+	<description xml:lang="tr">
+		Seçili modüller için toplu arama desteği sunar.
+		Gizli makaleler dışındaki tüm makaleler aranacaktır.Bu yüzden hedefin, gizli modülü içermemesine dikkat ediniz.
+	</description>
+	<description xml:lang="zh-TW">
+		將所選擇的模組當作搜尋對象進行搜尋。
+		所搜尋的模組中，如有私密文章時將不會被搜尋，因此請注意選擇。
+	</description>
+	<version>1.7</version>
+	<date>2013-11-27</date>
+	<category>service</category>
 
-    <author email_address="developers@xpressengine.com" link="http://xpressengine.com/">
-        <name xml:lang="ko">NAVER</name>
-        <name xml:lang="vi">NAVER</name>
-        <name xml:lang="zh-CN">NAVER</name>
-        <name xml:lang="jp">NAVER</name>
-        <name xml:lang="en">NAVER</name>
-        <name xml:lang="es">NAVER</name>
-        <name xml:lang="ru">NAVER</name>
-        <name xml:lang="zh-TW">NAVER</name>
-        <name xml:lang="tr">NAVER</name>
-    </author>
+	<author email_address="developers@xpressengine.com" link="http://xpressengine.com/">
+		<name xml:lang="ko">NAVER</name>
+		<name xml:lang="vi">NAVER</name>
+		<name xml:lang="zh-CN">NAVER</name>
+		<name xml:lang="jp">NAVER</name>
+		<name xml:lang="en">NAVER</name>
+		<name xml:lang="es">NAVER</name>
+		<name xml:lang="ru">NAVER</name>
+		<name xml:lang="zh-TW">NAVER</name>
+		<name xml:lang="tr">NAVER</name>
+	</author>
 </module>

--- a/modules/integration_search/conf/module.xml
+++ b/modules/integration_search/conf/module.xml
@@ -1,14 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <module>
-    <grants />
-    <permissions />
-    <actions>
-        <action name="IS" type="view" />
-        <action name="dispIntegration_searchAdminContent" type="view" admin_index="true" />
-        <action name="dispIntegration_searchAdminGrantInfo" type="view" />
-        <action name="dispIntegration_searchAdminSkinInfo" type="view" />
-
-        <action name="procIntegration_searchAdminInsertConfig" type="controller" ruleset="insertConfig" />
-        <action name="procIntegration_searchAdminInsertSkin" type="controller" />
-    </actions>
+	<grants />
+	<permissions />
+	<actions>
+		<action name="IS" type="view" />
+		
+		<action name="dispIntegration_searchAdminContent" type="view" admin_index="true" />
+		<action name="dispIntegration_searchAdminGrantInfo" type="view" />
+		<action name="dispIntegration_searchAdminSkinInfo" type="view" />
+		
+		<action name="procIntegration_searchAdminInsertConfig" type="controller" ruleset="insertConfig" />
+		<action name="procIntegration_searchAdminInsertSkin" type="controller" />
+	</actions>
 </module>

--- a/modules/integration_search/conf/module.xml
+++ b/modules/integration_search/conf/module.xml
@@ -6,7 +6,6 @@
 		<action name="IS" type="view" />
 		
 		<action name="dispIntegration_searchAdminContent" type="view" admin_index="true" />
-		<action name="dispIntegration_searchAdminGrantInfo" type="view" />
 		<action name="dispIntegration_searchAdminSkinInfo" type="view" />
 		
 		<action name="procIntegration_searchAdminInsertConfig" type="controller" ruleset="insertConfig" />

--- a/modules/krzip/conf/info.xml
+++ b/modules/krzip/conf/info.xml
@@ -4,6 +4,7 @@
 	<description xml:lang="ko">공개 API를 이용해 우편번호 검색 서비스를 이용합니다.</description>
 	<version>1.8.0</version>
 	<date>2015-03-10</date>
+	
 	<author email_address="developers@xpressengine.com" link="http://www.xpressengine.com/">
 		<name xml:lang="ko">NAVER</name>
 	</author>

--- a/modules/krzip/conf/module.xml
+++ b/modules/krzip/conf/module.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module>
 	<actions>
-		<action name="dispKrzipAdminConfig" type="view" menu_name="krzip" menu_index="true" admin_index="true" />
-		<action name="procKrzipAdminInsertConfig" type="controller" ruleset="krzipConfig" />
 		<action name="dispKrzipSearchForm" type="view" />
 		<action name="getKrzipCodeList" type="model" />
+		
+		<action name="dispKrzipAdminConfig" type="view" menu_name="krzip" menu_index="true" admin_index="true" />
+		<action name="procKrzipAdminInsertConfig" type="controller" ruleset="krzipConfig" />
 	</actions>
 	<menus>
 		<menu name="krzip" type="all">

--- a/modules/krzip/conf/module.xml
+++ b/modules/krzip/conf/module.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module>
+	<grants />
+	<permissions />
 	<actions>
 		<action name="dispKrzipSearchForm" type="view" />
 		<action name="getKrzipCodeList" type="model" />

--- a/modules/layout/conf/info.xml
+++ b/modules/layout/conf/info.xml
@@ -1,36 +1,36 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module version="0.2">
-    <title xml:lang="ko">레이아웃</title>
-    <title xml:lang="zh-CN">布局管理</title>
-    <title xml:lang="jp">レイアウト</title>
-    <title xml:lang="en">Layout</title>
-    <title xml:lang="vi">Giao diện</title>
-    <title xml:lang="es">Diseño</title>
-    <title xml:lang="ru">Лейаут</title>
-    <title xml:lang="zh-TW">版面設計</title>
-    <title xml:lang="tr">Yerleşim Düzeni</title>
-    <description xml:lang="ko">레이아웃을 생성/관리합니다.</description>
-    <description xml:lang="zh-CN">生成/管理布局的模块。</description>
-    <description xml:lang="jp">レイアウトを生成・管理するモジュールです。</description>
-    <description xml:lang="en">This module is for creating/managing the layouts.</description>
-    <description xml:lang="vi">Chức năng của Module này dành cho việc tạo và quản lý giao diện.</description>
-    <description xml:lang="es">Este módulo es para crear y manejar el diseño.</description>
-    <description xml:lang="ru">Этот модуль служит для создания/управления лейаутами.</description>
-    <description xml:lang="zh-TW">建立/管理版面的模組。</description>
-    <description xml:lang="tr">Bu modül yerleşim düzenleri(layout) oluşturmak ve yönetmek içindir.</description>
-    <version>1.7</version>
-    <date>2013-11-27</date>
-    <category>construction</category>
+	<title xml:lang="ko">레이아웃</title>
+	<title xml:lang="zh-CN">布局管理</title>
+	<title xml:lang="jp">レイアウト</title>
+	<title xml:lang="en">Layout</title>
+	<title xml:lang="vi">Giao diện</title>
+	<title xml:lang="es">Diseño</title>
+	<title xml:lang="ru">Лейаут</title>
+	<title xml:lang="zh-TW">版面設計</title>
+	<title xml:lang="tr">Yerleşim Düzeni</title>
+	<description xml:lang="ko">레이아웃을 생성/관리합니다.</description>
+	<description xml:lang="zh-CN">生成/管理布局的模块。</description>
+	<description xml:lang="jp">レイアウトを生成・管理するモジュールです。</description>
+	<description xml:lang="en">This module is for creating/managing the layouts.</description>
+	<description xml:lang="vi">Chức năng của Module này dành cho việc tạo và quản lý giao diện.</description>
+	<description xml:lang="es">Este módulo es para crear y manejar el diseño.</description>
+	<description xml:lang="ru">Этот модуль служит для создания/управления лейаутами.</description>
+	<description xml:lang="zh-TW">建立/管理版面的模組。</description>
+	<description xml:lang="tr">Bu modül yerleşim düzenleri(layout) oluşturmak ve yönetmek içindir.</description>
+	<version>1.7</version>
+	<date>2013-11-27</date>
+	<category>construction</category>
 
-    <author email_address="developers@xpressengine.com" link="http://xpressengine.com/">
-        <name xml:lang="ko">NAVER</name>
-        <name xml:lang="vi">NAVER</name>
-        <name xml:lang="zh-CN">NAVER</name>
-        <name xml:lang="jp">NAVER</name>
-        <name xml:lang="en">NAVER</name>
-        <name xml:lang="es">NAVER</name>
-        <name xml:lang="ru">NAVER</name>
-        <name xml:lang="tr">NAVER</name>
-        <name xml:lang="zh-TW">NAVER</name>
-    </author>
+	<author email_address="developers@xpressengine.com" link="http://xpressengine.com/">
+		<name xml:lang="ko">NAVER</name>
+		<name xml:lang="vi">NAVER</name>
+		<name xml:lang="zh-CN">NAVER</name>
+		<name xml:lang="jp">NAVER</name>
+		<name xml:lang="en">NAVER</name>
+		<name xml:lang="es">NAVER</name>
+		<name xml:lang="ru">NAVER</name>
+		<name xml:lang="tr">NAVER</name>
+		<name xml:lang="zh-TW">NAVER</name>
+	</author>
 </module>

--- a/modules/layout/conf/module.xml
+++ b/modules/layout/conf/module.xml
@@ -2,23 +2,20 @@
 <module>
 	<grants />
 	<permissions>
-		<permission action="dispLayoutPreview" target="manager" />
-		<permission action="dispLayoutPreviewWithModule" target="manager" />
-		<permission action="getLayoutInstanceListForJSONP" target="manager" />
+		<permission action="dispLayoutPreview" target="root" />
+		<permission action="dispLayoutPreviewWithModule" target="root" />
+		<permission action="getLayoutInstanceListForJSONP" target="root" />
 	</permissions>
 	<actions>
-		<action name="dispLayoutInfo" type="view" />
 		<action name="dispLayoutPreview" type="view" />
 		<action name="dispLayoutPreviewWithModule" type="view" />
 		<action name="getLayoutInstanceListForJSONP" type="model" />
-
-		<!-- admin -->
+		
 		<action name="dispLayoutAdminContent" type="view" />
 		<action name="dispLayoutAdminInfo" type="view" />
 		<action name="dispLayoutAdminLayoutModify" type="view" />
 		<action name="dispLayoutAdminLayoutImageList" type="view" />
 		<action name="dispLayoutAdminMobileContent" type="view" />
-
 		<action name="dispLayoutAdminInstalledList" type="view" admin_index="true" menu_name="installedLayout" menu_index="true" />
 		<action name="dispLayoutAdminInstanceList" type="view" menu_name="installedLayout" />
 		<action name="dispLayoutAdminAllInstanceList" type="view" menu_name="installedLayout" />
@@ -26,11 +23,11 @@
 		<action name="dispLayoutAdminModify" type="view" menu_name="installedLayout" />
 		<action name="dispLayoutAdminEdit" type="view" menu_name="installedLayout" />
 		<action name="dispLayoutAdminCopyLayout" type="view" />
-
+		
 		<action name="getLayoutAdminSetInfoView" type="model" />
 		<action name="getLayoutAdminSetHTMLCSS" type="model" />
 		<action name="getLayoutAdminSiteDefaultLayout" type="model" />
-
+		
 		<action name="procLayoutAdminUpdate" type="controller" ruleset="updateLayout" />
 		<action name="procLayoutAdminCodeUpdate" type="controller" ruleset="codeUpdate" />
 		<action name="procLayoutAdminUserImageUpload" type="controller" ruleset="imageUpload" />
@@ -38,11 +35,8 @@
 		<action name="procLayoutAdminConfigImageUpload" type="controller" />
 		<action name="procLayoutAdminConfigImageDelete" type="controller" />
 		<action name="procLayoutAdminDelete" type="controller" ruleset="deleteLayout" />
-
 		<action name="procLayoutAdminInsert" type="controller" ruleset="insertLayout" />
-
 		<action name="procLayoutAdminCodeReset" type="controller" />
-
 		<action name="procLayoutAdminUserValueInsert" type="controller" />
 		<action name="procLayoutAdminUserLayoutExport" type="controller" />
 		<action name="procLayoutAdminUserLayoutImport" type="controller" ruleset="userLayoutImport" />

--- a/modules/layout/conf/module.xml
+++ b/modules/layout/conf/module.xml
@@ -11,36 +11,32 @@
 		<action name="dispLayoutPreviewWithModule" type="view" />
 		<action name="getLayoutInstanceListForJSONP" type="model" />
 		
-		<action name="dispLayoutAdminContent" type="view" />
-		<action name="dispLayoutAdminInfo" type="view" />
-		<action name="dispLayoutAdminLayoutModify" type="view" />
-		<action name="dispLayoutAdminLayoutImageList" type="view" />
-		<action name="dispLayoutAdminMobileContent" type="view" />
 		<action name="dispLayoutAdminInstalledList" type="view" admin_index="true" menu_name="installedLayout" menu_index="true" />
-		<action name="dispLayoutAdminInstanceList" type="view" menu_name="installedLayout" />
 		<action name="dispLayoutAdminAllInstanceList" type="view" menu_name="installedLayout" />
+		<action name="dispLayoutAdminInstanceList" type="view" menu_name="installedLayout" />
 		<action name="dispLayoutAdminInsert" type="view" menu_name="installedLayout" />
 		<action name="dispLayoutAdminModify" type="view" menu_name="installedLayout" />
 		<action name="dispLayoutAdminEdit" type="view" menu_name="installedLayout" />
 		<action name="dispLayoutAdminCopyLayout" type="view" />
+		<action name="dispLayoutAdminLayoutModify" type="view" />
 		
 		<action name="getLayoutAdminSetInfoView" type="model" />
 		<action name="getLayoutAdminSetHTMLCSS" type="model" />
 		<action name="getLayoutAdminSiteDefaultLayout" type="model" />
 		
+		<action name="procLayoutAdminInsert" type="controller" ruleset="insertLayout" />
 		<action name="procLayoutAdminUpdate" type="controller" ruleset="updateLayout" />
+		<action name="procLayoutAdminDelete" type="controller" ruleset="deleteLayout" />
+		<action name="procLayoutAdminCopyLayout" type="controller" />
 		<action name="procLayoutAdminCodeUpdate" type="controller" ruleset="codeUpdate" />
+		<action name="procLayoutAdminCodeReset" type="controller" />
 		<action name="procLayoutAdminUserImageUpload" type="controller" ruleset="imageUpload" />
 		<action name="procLayoutAdminUserImageDelete" type="controller" />
 		<action name="procLayoutAdminConfigImageUpload" type="controller" />
 		<action name="procLayoutAdminConfigImageDelete" type="controller" />
-		<action name="procLayoutAdminDelete" type="controller" ruleset="deleteLayout" />
-		<action name="procLayoutAdminInsert" type="controller" ruleset="insertLayout" />
-		<action name="procLayoutAdminCodeReset" type="controller" />
-		<action name="procLayoutAdminUserValueInsert" type="controller" />
-		<action name="procLayoutAdminUserLayoutExport" type="controller" />
 		<action name="procLayoutAdminUserLayoutImport" type="controller" ruleset="userLayoutImport" />
-		<action name="procLayoutAdminCopyLayout" type="controller" />
+		<action name="procLayoutAdminUserLayoutExport" type="controller" />
+		<action name="procLayoutAdminUserValueInsert" type="controller" />
 	</actions>
 	<menus>
 		<menu name="installedLayout">

--- a/modules/member/conf/info.xml
+++ b/modules/member/conf/info.xml
@@ -1,36 +1,36 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module version="0.2">
-    <title xml:lang="ko">회원</title>
-    <title xml:lang="zh-CN">会员</title>
-    <title xml:lang="jp">会員</title>
-    <title xml:lang="en">Member</title>
-    <title xml:lang="vi">Quản lý thành viên</title>
-    <title xml:lang="es">Usuario Gestión</title>
-    <title xml:lang="ru">Управление пользователями</title>
-    <title xml:lang="zh-TW">會員管理</title>
-    <title xml:lang="tr">Üye Yönetimi</title>
-    <description xml:lang="ko">회원 관리 및 설정을 합니다.</description>
-    <description xml:lang="zh-CN">对会员进行管理及相关设置的模块。</description>
-    <description xml:lang="jp">会員管理及び会員関連設定などを行うモジュールです。</description>
-    <description xml:lang="en">This module is for managing or configuring members.</description>
-    <description xml:lang="vi">Module này dành cho việc quản lý và tạo thành viên.</description>
-    <description xml:lang="es">Este módulo es para el manejo y la configuración de los usuarios.</description>
-    <description xml:lang="ru">Этот модуль служит для управления и конфигурирования пользователей.</description>
-    <description xml:lang="zh-TW">對會員進行管理與相關設置的模組。</description>
-    <description xml:lang="tr">Bu modül üyeleri yönetmek/yapılandırmak için kullanılır</description>
-    <version>1.7</version>
-    <date>2013-11-27</date>
-    <category>member</category>
+	<title xml:lang="ko">회원</title>
+	<title xml:lang="zh-CN">会员</title>
+	<title xml:lang="jp">会員</title>
+	<title xml:lang="en">Member</title>
+	<title xml:lang="vi">Quản lý thành viên</title>
+	<title xml:lang="es">Usuario Gestión</title>
+	<title xml:lang="ru">Управление пользователями</title>
+	<title xml:lang="zh-TW">會員管理</title>
+	<title xml:lang="tr">Üye Yönetimi</title>
+	<description xml:lang="ko">회원 관리 및 설정을 합니다.</description>
+	<description xml:lang="zh-CN">对会员进行管理及相关设置的模块。</description>
+	<description xml:lang="jp">会員管理及び会員関連設定などを行うモジュールです。</description>
+	<description xml:lang="en">This module is for managing or configuring members.</description>
+	<description xml:lang="vi">Module này dành cho việc quản lý và tạo thành viên.</description>
+	<description xml:lang="es">Este módulo es para el manejo y la configuración de los usuarios.</description>
+	<description xml:lang="ru">Этот модуль служит для управления и конфигурирования пользователей.</description>
+	<description xml:lang="zh-TW">對會員進行管理與相關設置的模組。</description>
+	<description xml:lang="tr">Bu modül üyeleri yönetmek/yapılandırmak için kullanılır</description>
+	<version>1.7</version>
+	<date>2013-11-27</date>
+	<category>member</category>
 
-    <author email_address="developers@xpressengine.com" link="http://xpressengine.com/">
-        <name xml:lang="ko">NAVER</name>
-        <name xml:lang="vi">NAVER</name>
-        <name xml:lang="zh-CN">NAVER</name>
-        <name xml:lang="jp">NAVER</name>
-        <name xml:lang="en">NAVER</name>
-        <name xml:lang="es">NAVER</name>
-        <name xml:lang="ru">NAVER</name>
-        <name xml:lang="zh-TW">NAVER</name>
-        <name xml:lang="tr">NAVER</name>
-    </author>
+	<author email_address="developers@xpressengine.com" link="http://xpressengine.com/">
+		<name xml:lang="ko">NAVER</name>
+		<name xml:lang="vi">NAVER</name>
+		<name xml:lang="zh-CN">NAVER</name>
+		<name xml:lang="jp">NAVER</name>
+		<name xml:lang="en">NAVER</name>
+		<name xml:lang="es">NAVER</name>
+		<name xml:lang="ru">NAVER</name>
+		<name xml:lang="zh-TW">NAVER</name>
+		<name xml:lang="tr">NAVER</name>
+	</author>
 </module>

--- a/modules/member/conf/module.xml
+++ b/modules/member/conf/module.xml
@@ -2,101 +2,107 @@
 <module>
 	<grants />
 	<permissions>
-		<permission action="dispMemberModifyEmailAddress" target="member" />
+		<permission action="dispMemberInfo" target="member" />
 		<permission action="dispMemberModifyInfo" target="member" />
 		<permission action="dispMemberModifyPassword" target="member" />
+		<permission action="dispMemberModifyEmailAddress" target="member" />
 		<permission action="dispMemberLeave" target="member" />
-		<permission action="dispMemberOwnDocument" target="member" />
 		<permission action="dispMemberScrappedDocument" target="member" />
 		<permission action="dispMemberSavedDocument" target="member" />
+		<permission action="dispMemberOwnDocument" target="member" />
+		<permission action="dispMemberOwnComment" target="member" />
+		<permission action="dispMemberActiveLogins" target="member" />
+		<permission action="dispMemberModifyNicknameLog" target="member" />
+		<permission action="dispMemberLogout" target="member" />
 		<permission action="dispMemberSpammer" target="manager" check_var="module_srl" />
 		
 		<permission action="getApiGroups" target="root" />
 		
-		<permission action="procMemberModifyEmailAddress" target="member" />
 		<permission action="procMemberModifyInfoBefore" target="member" />
 		<permission action="procMemberModifyInfo" target="member" />
 		<permission action="procMemberModifyPassword" target="member" />
+		<permission action="procMemberModifyEmailAddress" target="member" />
 		<permission action="procMemberLeave" target="member" />
 		<permission action="procMemberInsertProfileImage" target="member" />
-		<permission action="procMemberInsertImageName" target="member" />
-		<permission action="procMemberInsertImageMark" target="member" />
 		<permission action="procMemberDeleteProfileImage" target="member" />
+		<permission action="procMemberInsertImageName" target="member" />
 		<permission action="procMemberDeleteImageName" target="member" />
+		<permission action="procMemberInsertImageMark" target="member" />
 		<permission action="procMemberDeleteImageMark" target="member" />
-		<permission action="procMemberSiteSignUp" target="member" />
-		<permission action="procMemberSiteLeave" target="member" />
 		<permission action="procMemberScrapDocument" target="member" />
 		<permission action="procMemberDeleteScrap" target="member" />
 		<permission action="procMemberSaveDocument" target="member" />
 		<permission action="procMemberDeleteSavedDocument" target="member" />
+		<permission action="procMemberDeleteAutologin" target="member" />
+		<permission action="procMemberSiteSignUp" target="member" />
+		<permission action="procMemberSiteLeave" target="member" />
+		<permission action="procMemberLogout" target="member" />
 		<permission action="procMemberSpammerManage" target="manager" check_var="module_srl" />
 	</permissions>
 	<actions>
-		<action name="dispMemberInfo" type="view" standalone="true" />
-		<action name="dispMemberSignUpForm" type="view" standalone="true" />
-		<action name="dispMemberModifyEmailAddress" type="view" standalone="true" />
-		<action name="dispMemberModifyInfo" type="view" standalone="true" />
-		<action name="dispMemberModifyPassword" type="view" standalone="true" />
-		<action name="dispMemberLoginForm" type="view" standalone="true" />
-		<action name="dispMemberLogout" type="view" standalone="true" />
-		<action name="dispMemberLeave" type="view" standalone="true" />
-		<action name="dispMemberOwnDocument" type="view" standalone="true" />
-		<action name="dispMemberOwnComment" type="view" standalone="true" />
-		<action name="dispMemberScrappedDocument" type="view" standalone="true" />
-		<action name="dispMemberSavedDocument" type="view" standalone="true" />
-		<action name="dispMemberActiveLogins" type="view" standalone="true" />
-		<action name="dispMemberFindAccount" type="view" standalone="true" />
-		<action name="dispMemberGetTempPassword" type="view" standalone="true" />
-		<action name="dispMemberResendAuthMail" type="view" standalone="true" />
-		<action name="dispSavedDocumentList" type="view" standalone="true" />
-		<action name="dispMemberModifyNicknameLog" type="view" standalone="true" />
-		<action name="dispMemberSpammer" type="view" standalone="true" />
+		<action name="dispMemberSignUpForm" type="view" />
+		<action name="dispMemberLoginForm" type="view" />
+		<action name="dispMemberFindAccount" type="view" />
+		<action name="dispMemberResendAuthMail" type="view" />
+		<action name="dispMemberGetTempPassword" type="view" />
+		<action name="dispMemberInfo" type="view" />
+		<action name="dispMemberModifyInfo" type="view" />
+		<action name="dispMemberModifyPassword" type="view" />
+		<action name="dispMemberModifyEmailAddress" type="view" />
+		<action name="dispMemberLeave" type="view" />
+		<action name="dispMemberScrappedDocument" type="view" />
+		<action name="dispMemberSavedDocument" type="view" />
+		<action name="dispMemberOwnDocument" type="view" />
+		<action name="dispMemberOwnComment" type="view" />
+		<action name="dispMemberActiveLogins" type="view" />
+		<action name="dispMemberModifyNicknameLog" type="view" />
+		<action name="dispMemberLogout" type="view" />
+		<action name="dispMemberSpammer" type="view" />
 		
-		<action name="getApiGroups" type="model" standalone="true" />
-		<action name="getMemberMenu" type="model" standalone="true" />
+		<action name="getMemberMenu" type="model" />
+		<action name="getApiGroups" type="model" />
 		
-		<action name="procMemberLogin" type="controller" ruleset="@login" standalone="true" />
-		<action name="procMemberLogout" type="controller" standalone="true" />
-		<action name="procMemberCheckValue" type="controller" standalone="true" />
-		<action name="procMemberInsert" type="controller" ruleset="@insertMember" standalone="true" />
-		<action name="procMemberModifyEmailAddress" type="controller" ruleset="modifyEmailAddress" standalone="true" />
-		<action name="procMemberModifyInfoBefore" type="controller" ruleset="recheckedPassword" standalone="true" />
-		<action name="procMemberModifyInfo" type="controller" ruleset="@insertMember" standalone="true" />
-		<action name="procMemberModifyPassword" type="controller" ruleset="modifyPassword" standalone="true" />
-		<action name="procMemberLeave" type="controller" ruleset="leaveMember" standalone="true" />
-		<action name="procMemberInsertProfileImage" type="controller" ruleset="insertProfileImage" standalone="true" />
-		<action name="procMemberInsertImageName" type="controller" ruleset="insertImageName" standalone="true" />
-		<action name="procMemberInsertImageMark" type="controller" ruleset="insertImageMark" standalone="true" />
-		<action name="procMemberDeleteProfileImage" type="controller" standalone="true" />
-		<action name="procMemberDeleteImageName" type="controller" standalone="true" />
-		<action name="procMemberDeleteImageMark" type="controller" standalone="true" />
-		<action name="procMemberSiteSignUp" type="controller" standalone="true" />
-		<action name="procMemberSiteLeave" type="controller" standalone="true" />
-		<action name="procMemberScrapDocument" type="controller" standalone="true" />
-		<action name="procMemberDeleteScrap" type="controller" standalone="true" />
-		<action name="procMemberSaveDocument" type="controller" standalone="true" />
-		<action name="procMemberDeleteSavedDocument" type="controller" standalone="true" />
-		<action name="procMemberDeleteAutologin" type="controller" standalone="true" />
-		<action name="procMemberFindAccount" type="controller" method="GET|POST" ruleset="findAccount" standalone="true" />
-		<action name="procMemberFindAccountByQuestion" type="controller" method="GET|POST" standalone="true" />
-		<action name="procMemberAuthAccount" type="controller" method="GET|POST" standalone="true" />
-		<action name="procMemberAuthEmailAddress" type="controller" method="GET|POST" standalone="true" />
-		<action name="procMemberResendAuthMail" type="controller" ruleset="resendAuthMail" standalone="true" />
-		<action name="procMemberResetAuthMail" type="controller" ruleset="resetAuthMail" standalone="true" />
-		<action name="procMemberSpammerManage" type="controller" standalone="true" />
+		<action name="procMemberInsert" type="controller" ruleset="@insertMember" />
+		<action name="procMemberCheckValue" type="controller" />
+		<action name="procMemberLogin" type="controller" ruleset="@login" />
+		<action name="procMemberFindAccount" type="controller" method="GET|POST" ruleset="findAccount" />
+		<action name="procMemberFindAccountByQuestion" type="controller" method="GET|POST" />
+		<action name="procMemberAuthAccount" type="controller" method="GET|POST" />
+		<action name="procMemberAuthEmailAddress" type="controller" method="GET|POST" />
+		<action name="procMemberResendAuthMail" type="controller" ruleset="resendAuthMail" />
+		<action name="procMemberResetAuthMail" type="controller" ruleset="resetAuthMail" />
+		<action name="procMemberModifyInfoBefore" type="controller" ruleset="recheckedPassword" />
+		<action name="procMemberModifyInfo" type="controller" ruleset="@insertMember" />
+		<action name="procMemberModifyPassword" type="controller" ruleset="modifyPassword" />
+		<action name="procMemberModifyEmailAddress" type="controller" ruleset="modifyEmailAddress" />
+		<action name="procMemberLeave" type="controller" ruleset="leaveMember" />
+		<action name="procMemberInsertProfileImage" type="controller" ruleset="insertProfileImage" />
+		<action name="procMemberDeleteProfileImage" type="controller" />
+		<action name="procMemberInsertImageName" type="controller" ruleset="insertImageName" />
+		<action name="procMemberDeleteImageName" type="controller" />
+		<action name="procMemberInsertImageMark" type="controller" ruleset="insertImageMark" />
+		<action name="procMemberDeleteImageMark" type="controller" />
+		<action name="procMemberScrapDocument" type="controller" />
+		<action name="procMemberDeleteScrap" type="controller" />
+		<action name="procMemberSaveDocument" type="controller" />
+		<action name="procMemberDeleteSavedDocument" type="controller" />
+		<action name="procMemberDeleteAutologin" type="controller" />
+		<action name="procMemberSiteSignUp" type="controller" />
+		<action name="procMemberSiteLeave" type="controller" />
+		<action name="procMemberLogout" type="controller" />
+		<action name="procMemberSpammerManage" type="controller" />
 		
 		<action name="dispMemberAdminList" type="view" index="true" admin_index="true" menu_name="userList" menu_index="true"/>
+		<action name="dispMemberAdminInfo" type="view" menu_name="userList" />
+		<action name="dispMemberAdminInsert" type="view" menu_name="userList" />
 		<action name="dispMemberAdminConfig" type="view" menu_name="userSetting" menu_index="true" />
 		<action name="dispMemberAdminFeaturesConfig" type="view" menu_name="userSetting" />
 		<action name="dispMemberAdminSignUpConfig" type="view" menu_name="userSetting" />
 		<action name="dispMemberAdminLoginConfig" type="view" menu_name="userSetting" />
 		<action name="dispMemberAdminDesignConfig" type="view" menu_name="userSetting" />
-		<action name="dispMemberAdminInsert" type="view" menu_name="userList" />
-		<action name="dispMemberAdminGroupList" type="view" menu_name="userGroup" menu_index="true" />
-		<action name="dispMemberAdminInfo" type="view" menu_name="userList" />
-		<action name="dispMemberAdminInsertJoinForm" type="view" />
 		<action name="dispMemberAdminNickNameLog" type="view" menu_name="userSetting" />
+		<action name="dispMemberAdminGroupList" type="view" menu_name="userGroup" menu_index="true" />
+		<action name="dispMemberAdminInsertJoinForm" type="view" />
 		
 		<action name="getMemberAdminColorset" type="model" />
 		<action name="getMemberAdminInsertJoinForm" type="model" />
@@ -104,26 +110,26 @@
 		
 		<action name="procMemberAdminInsert" type="controller" ruleset="insertAdminMember" />
 		<action name="procMemberAdminDelete" type="controller" />
+		<action name="procMemberAdminSelectedMemberManage" type="controller" ruleset="updateSeletecdMemberInfo" />
 		<action name="procMemberAdminInsertDefaultConfig" type="controller" ruleset="insertDefaultConfig" />
 		<action name="procMemberAdminInsertFeaturesConfig" type="controller" />
 		<action name="procMemberAdminInsertSignupConfig" type="controller" />
 		<action name="procMemberAdminInsertLoginConfig" type="controller" />
 		<action name="procMemberAdminInsertDesignConfig" type="controller" />
-		<action name="procMemberAdminInsertGroup" type="controller" ruleset="insertGroup" />
-		<action name="procMemberAdminUpdateGroup" type="controller" ruleset="updateGroup" />
-		<action name="procMemberAdminDeleteGroup" type="controller" ruleset="deleteGroup" />
-		<action name="procMemberAdminUpdateMembersGroup" type="controller" ruleset="manageMemberGroup" />
-		<action name="procMemberAdminDeleteMembers" type="controller" />
-		<action name="procMemberAdminInsertJoinForm" type="controller" ruleset="insertJoinForm" />
-		<action name="procMemberAdminUpdateJoinForm" type="controller" />
 		<action name="procMemberAdminUpdateManagedEmailHosts" type="controller" />
-		<action name="procMemberAdminDeleteJoinForm" type="controller" />
 		<action name="procMemberAdminUpdateDeniedNickName" type="controller" />
 		<action name="procMemberAdminInsertDeniedID" type="controller" ruleset="insertDeniedId" />
 		<action name="procMemberAdminUpdateDeniedID" type="controller" />
-		<action name="procMemberAdminUpdateGroupOrder" type="controller" />
-		<action name="procMemberAdminSelectedMemberManage" type="controller" ruleset="updateSeletecdMemberInfo" />
+		<action name="procMemberAdminInsertJoinForm" type="controller" ruleset="insertJoinForm" />
+		<action name="procMemberAdminUpdateJoinForm" type="controller" />
+		<action name="procMemberAdminDeleteJoinForm" type="controller" />
 		<action name="procMemberAdminGroupConfig" type="controller" />
+		<action name="procMemberAdminInsertGroup" type="controller" ruleset="insertGroup" />
+		<action name="procMemberAdminUpdateGroup" type="controller" ruleset="updateGroup" />
+		<action name="procMemberAdminDeleteGroup" type="controller" ruleset="deleteGroup" />
+		<action name="procMemberAdminUpdateGroupOrder" type="controller" />
+		<action name="procMemberAdminUpdateMembersGroup" type="controller" ruleset="manageMemberGroup" />
+		<action name="procMemberAdminDeleteMembers" type="controller" />
 	</actions>
 	<menus>
 		<menu name="userList">

--- a/modules/member/conf/module.xml
+++ b/modules/member/conf/module.xml
@@ -9,13 +9,15 @@
 		<permission action="dispMemberOwnDocument" target="member" />
 		<permission action="dispMemberScrappedDocument" target="member" />
 		<permission action="dispMemberSavedDocument" target="member" />
-
+		<permission action="dispMemberSpammer" target="manager" check_var="module_srl" />
+		
+		<permission action="getApiGroups" target="root" />
+		
 		<permission action="procMemberModifyEmailAddress" target="member" />
 		<permission action="procMemberModifyInfoBefore" target="member" />
 		<permission action="procMemberModifyInfo" target="member" />
 		<permission action="procMemberModifyPassword" target="member" />
 		<permission action="procMemberLeave" target="member" />
-
 		<permission action="procMemberInsertProfileImage" target="member" />
 		<permission action="procMemberInsertImageName" target="member" />
 		<permission action="procMemberInsertImageMark" target="member" />
@@ -24,15 +26,11 @@
 		<permission action="procMemberDeleteImageMark" target="member" />
 		<permission action="procMemberSiteSignUp" target="member" />
 		<permission action="procMemberSiteLeave" target="member" />
-
 		<permission action="procMemberScrapDocument" target="member" />
 		<permission action="procMemberDeleteScrap" target="member" />
 		<permission action="procMemberSaveDocument" target="member" />
 		<permission action="procMemberDeleteSavedDocument" target="member" />
-
-		<permission action="dispMemberSpammer" target="manager" />
-		<permission action="procMemberSpammerManage" target="manager" />
-		<permission action="getApiGroups" target="manager" />
+		<permission action="procMemberSpammerManage" target="manager" check_var="module_srl" />
 	</permissions>
 	<actions>
 		<action name="dispMemberInfo" type="view" standalone="true" />
@@ -53,21 +51,11 @@
 		<action name="dispMemberResendAuthMail" type="view" standalone="true" />
 		<action name="dispSavedDocumentList" type="view" standalone="true" />
 		<action name="dispMemberModifyNicknameLog" type="view" standalone="true" />
-
-		<action name="dispMemberAdminList" type="view" index="true" admin_index="true" menu_name="userList" menu_index="true"/>
-		<action name="dispMemberAdminConfig" type="view" menu_name="userSetting" menu_index="true" />
-		<action name="dispMemberAdminFeaturesConfig" type="view" menu_name="userSetting" />
-		<action name="dispMemberAdminSignUpConfig" type="view" menu_name="userSetting" />
-		<action name="dispMemberAdminLoginConfig" type="view" menu_name="userSetting" />
-		<action name="dispMemberAdminDesignConfig" type="view" menu_name="userSetting" />
-		<action name="dispMemberAdminInsert" type="view" menu_name="userList" />
-		<action name="dispMemberAdminGroupList" type="view" menu_name="userGroup" menu_index="true" />
-		<action name="dispMemberAdminInfo" type="view" menu_name="userList" />
-		<action name="dispMemberAdminInsertJoinForm" type="view" />
-		<action name="dispMemberAdminNickNameLog" type="view" menu_name="userSetting" />
+		<action name="dispMemberSpammer" type="view" standalone="true" />
 		
+		<action name="getApiGroups" type="model" standalone="true" />
 		<action name="getMemberMenu" type="model" standalone="true" />
-
+		
 		<action name="procMemberLogin" type="controller" ruleset="@login" standalone="true" />
 		<action name="procMemberLogout" type="controller" standalone="true" />
 		<action name="procMemberCheckValue" type="controller" standalone="true" />
@@ -85,28 +73,22 @@
 		<action name="procMemberDeleteImageMark" type="controller" standalone="true" />
 		<action name="procMemberSiteSignUp" type="controller" standalone="true" />
 		<action name="procMemberSiteLeave" type="controller" standalone="true" />
-
 		<action name="procMemberScrapDocument" type="controller" standalone="true" />
 		<action name="procMemberDeleteScrap" type="controller" standalone="true" />
 		<action name="procMemberSaveDocument" type="controller" standalone="true" />
 		<action name="procMemberDeleteSavedDocument" type="controller" standalone="true" />
 		<action name="procMemberDeleteAutologin" type="controller" standalone="true" />
-
 		<action name="procMemberFindAccount" type="controller" method="GET|POST" ruleset="findAccount" standalone="true" />
 		<action name="procMemberFindAccountByQuestion" type="controller" method="GET|POST" standalone="true" />
 		<action name="procMemberAuthAccount" type="controller" method="GET|POST" standalone="true" />
 		<action name="procMemberAuthEmailAddress" type="controller" method="GET|POST" standalone="true" />
 		<action name="procMemberResendAuthMail" type="controller" ruleset="resendAuthMail" standalone="true" />
 		<action name="procMemberResetAuthMail" type="controller" ruleset="resetAuthMail" standalone="true" />
-
-		<!-- manager -->
-		<action name="dispMemberSpammer" type="view" standalone="true" />
 		<action name="procMemberSpammerManage" type="controller" standalone="true" />
-		<action name="getApiGroups" type="model" standalone="true" />
-
-		<!-- admin -->
+		
 		<action name="dispMemberAdminList" type="view" index="true" admin_index="true" menu_name="userList" menu_index="true"/>
 		<action name="dispMemberAdminConfig" type="view" menu_name="userSetting" menu_index="true" />
+		<action name="dispMemberAdminFeaturesConfig" type="view" menu_name="userSetting" />
 		<action name="dispMemberAdminSignUpConfig" type="view" menu_name="userSetting" />
 		<action name="dispMemberAdminLoginConfig" type="view" menu_name="userSetting" />
 		<action name="dispMemberAdminDesignConfig" type="view" menu_name="userSetting" />
@@ -114,11 +96,12 @@
 		<action name="dispMemberAdminGroupList" type="view" menu_name="userGroup" menu_index="true" />
 		<action name="dispMemberAdminInfo" type="view" menu_name="userList" />
 		<action name="dispMemberAdminInsertJoinForm" type="view" />
-
+		<action name="dispMemberAdminNickNameLog" type="view" menu_name="userSetting" />
+		
 		<action name="getMemberAdminColorset" type="model" />
 		<action name="getMemberAdminInsertJoinForm" type="model" />
 		<action name="getMemberAdminIPCheck" type="model" />
-
+		
 		<action name="procMemberAdminInsert" type="controller" ruleset="insertAdminMember" />
 		<action name="procMemberAdminDelete" type="controller" />
 		<action name="procMemberAdminInsertDefaultConfig" type="controller" ruleset="insertDefaultConfig" />
@@ -139,7 +122,6 @@
 		<action name="procMemberAdminInsertDeniedID" type="controller" ruleset="insertDeniedId" />
 		<action name="procMemberAdminUpdateDeniedID" type="controller" />
 		<action name="procMemberAdminUpdateGroupOrder" type="controller" />
-
 		<action name="procMemberAdminSelectedMemberManage" type="controller" ruleset="updateSeletecdMemberInfo" />
 		<action name="procMemberAdminGroupConfig" type="controller" />
 	</actions>

--- a/modules/menu/conf/info.xml
+++ b/modules/menu/conf/info.xml
@@ -1,36 +1,36 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module version="0.2">
-    <title xml:lang="ko">메뉴</title>
-    <title xml:lang="zh-CN">菜单管理</title>
-    <title xml:lang="jp">メニュー</title>
-    <title xml:lang="en">Menu</title>
-    <title xml:lang="vi">Menu</title>
-    <title xml:lang="es">Menú</title>
-    <title xml:lang="ru">Меню</title>
-    <title xml:lang="zh-TW">選單</title>
-    <title xml:lang="tr">Menü</title>
-    <description xml:lang="ko">레이아웃과 페이지를 연결하고 메뉴를 생성/관리합니다.</description>
-    <description xml:lang="zh-CN">此模块将生成并管理连接布局，模块的菜单。</description>
-    <description xml:lang="jp">レイアウト、モジュールを連動させるメニューを作成・管理するモジュールです。</description>
-    <description xml:lang="en">This is for creating/managing menus which link to layouts or modules.</description>
-    <description xml:lang="vi">Module này dành cho việc tạo và quản lý Menu sẽ liên kết với giao diện hoặc Mudule.</description>
-    <description xml:lang="es">Este módulo es para crear/manejar los menús que que son conectados con los diseños o módulos.</description>
-    <description xml:lang="ru">Этот модуль служит для создания/управления меню, соединяюще лейауты и модули.</description>
-    <description xml:lang="zh-TW">可建立並管理連結版面和模組的選單。</description>
-    <description xml:lang="tr">Bu modül, yerleşim düzenlerine ya da modüllere bağlı menüleri oluşturmak/yönetmek içindir.</description>
-    <version>1.7</version>
-    <date>2013-11-27</date>
-    <category>construction</category>
+	<title xml:lang="ko">메뉴</title>
+	<title xml:lang="zh-CN">菜单管理</title>
+	<title xml:lang="jp">メニュー</title>
+	<title xml:lang="en">Menu</title>
+	<title xml:lang="vi">Menu</title>
+	<title xml:lang="es">Menú</title>
+	<title xml:lang="ru">Меню</title>
+	<title xml:lang="zh-TW">選單</title>
+	<title xml:lang="tr">Menü</title>
+	<description xml:lang="ko">레이아웃과 페이지를 연결하고 메뉴를 생성/관리합니다.</description>
+	<description xml:lang="zh-CN">此模块将生成并管理连接布局，模块的菜单。</description>
+	<description xml:lang="jp">レイアウト、モジュールを連動させるメニューを作成・管理するモジュールです。</description>
+	<description xml:lang="en">This is for creating/managing menus which link to layouts or modules.</description>
+	<description xml:lang="vi">Module này dành cho việc tạo và quản lý Menu sẽ liên kết với giao diện hoặc Mudule.</description>
+	<description xml:lang="es">Este módulo es para crear/manejar los menús que que son conectados con los diseños o módulos.</description>
+	<description xml:lang="ru">Этот модуль служит для создания/управления меню, соединяюще лейауты и модули.</description>
+	<description xml:lang="zh-TW">可建立並管理連結版面和模組的選單。</description>
+	<description xml:lang="tr">Bu modül, yerleşim düzenlerine ya da modüllere bağlı menüleri oluşturmak/yönetmek içindir.</description>
+	<version>1.7</version>
+	<date>2013-11-27</date>
+	<category>construction</category>
 
-    <author email_address="developers@xpressengine.com" link="http://xpressengine.com/">
-        <name xml:lang="ko">NAVER</name>
-        <name xml:lang="vi">NAVER</name>
-        <name xml:lang="zh-CN">NAVER</name>
-        <name xml:lang="jp">NAVER</name>
-        <name xml:lang="en">NAVER</name>
-        <name xml:lang="es">NAVER</name>
-        <name xml:lang="ru">NAVER</name>
-        <name xml:lang="zh-TW">NAVER</name>
-        <name xml:lang="tr">NAVER</name>
-    </author>
+	<author email_address="developers@xpressengine.com" link="http://xpressengine.com/">
+		<name xml:lang="ko">NAVER</name>
+		<name xml:lang="vi">NAVER</name>
+		<name xml:lang="zh-CN">NAVER</name>
+		<name xml:lang="jp">NAVER</name>
+		<name xml:lang="en">NAVER</name>
+		<name xml:lang="es">NAVER</name>
+		<name xml:lang="ru">NAVER</name>
+		<name xml:lang="zh-TW">NAVER</name>
+		<name xml:lang="tr">NAVER</name>
+	</author>
 </module>

--- a/modules/menu/conf/module.xml
+++ b/modules/menu/conf/module.xml
@@ -1,24 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <module>
 	<grants />
-	<permissions>
-		<permission action="getMenuAdminSiteMap" target="manager" />
-		<permission action="procMenuAdminUpdateAuth" target="manager" />
-	</permissions>
+	<permissions />
 	<actions>
 		<action name="dispMenuMenu" type="mobile" />
-
-		<!-- admin -->
+		
 		<action name="dispMenuAdminMidList" type="view" />
 		<action name="dispMenuAdminSiteMap" type="view" admin_index="true" menu_name="siteMap" menu_index="true" />
 		<action name="dispMenuAdminSiteDesign" type="view" menu_name="siteDesign" menu_index="true" />
-
+		
 		<action name="getMenuAdminTplInfo" type="model" />
 		<action name="getMenuAdminItemInfo" type="model" />
 		<action name="getMenuAdminSiteMap" type="model" />
 		<action name="getMenuAdminInstalledMenuType" type="model" />
 		<action name="getMenuAdminDetailSetup" type="model" />
-
+		
 		<action name="procMenuAdminInsert" type="controller" ruleset="insertMenu" />
 		<action name="procMenuAdminUpdate" type="controller" ruleset="updateMenuTitle" />
 		<action name="procMenuAdminDelete" type="controller" />
@@ -31,7 +27,6 @@
 		<action name="procMenuAdminMoveItem" type="controller" />
 		<action name="procMenuAdminCopyItem" type="controller" />
 		<action name="procMenuAdminArrangeItem" type="controller" />
-
 		<action name="procMenuAdminUploadButton" type="controller" />
 		<action name="procMenuAdminDeleteButton" type="controller" />
 		<action name="procMenuAdminAllActList" type="controller" />

--- a/modules/menu/conf/module.xml
+++ b/modules/menu/conf/module.xml
@@ -5,13 +5,12 @@
 	<actions>
 		<action name="dispMenuMenu" type="mobile" />
 		
-		<action name="dispMenuAdminMidList" type="view" />
 		<action name="dispMenuAdminSiteMap" type="view" admin_index="true" menu_name="siteMap" menu_index="true" />
 		<action name="dispMenuAdminSiteDesign" type="view" menu_name="siteDesign" menu_index="true" />
 		
-		<action name="getMenuAdminTplInfo" type="model" />
-		<action name="getMenuAdminItemInfo" type="model" />
 		<action name="getMenuAdminSiteMap" type="model" />
+		<action name="getMenuAdminItemInfo" type="model" />
+		<action name="getMenuAdminTplInfo" type="model" />
 		<action name="getMenuAdminInstalledMenuType" type="model" />
 		<action name="getMenuAdminDetailSetup" type="model" />
 		
@@ -20,17 +19,17 @@
 		<action name="procMenuAdminDelete" type="controller" />
 		<action name="procMenuAdminInsertItem" type="controller" ruleset="insertMenuItem" />
 		<action name="procMenuAdminUpdateItem" type="controller" ruleset="updateMenuItem" />
-		<action name="procMenuAdminButtonUpload" type="controller" />
-		<action name="procMenuAdminInsertItemForAdminMenu" type="controller" />
 		<action name="procMenuAdminDeleteItem" type="controller" />
-		<action name="procMenuAdminMakeXmlFile" type="controller" />
 		<action name="procMenuAdminMoveItem" type="controller" />
 		<action name="procMenuAdminCopyItem" type="controller" />
-		<action name="procMenuAdminArrangeItem" type="controller" />
+		<action name="procMenuAdminUpdateAuth" type="controller" />
+		<action name="procMenuAdminButtonUpload" type="controller" />
 		<action name="procMenuAdminUploadButton" type="controller" />
 		<action name="procMenuAdminDeleteButton" type="controller" />
+		<action name="procMenuAdminInsertItemForAdminMenu" type="controller" />
+		<action name="procMenuAdminMakeXmlFile" type="controller" />
+		<action name="procMenuAdminArrangeItem" type="controller" />
 		<action name="procMenuAdminAllActList" type="controller" />
-		<action name="procMenuAdminUpdateAuth" type="controller" />
 	</actions>
 	<menus>
 		<menu name="siteMap">

--- a/modules/message/conf/info.xml
+++ b/modules/message/conf/info.xml
@@ -1,36 +1,36 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module version="0.2">
-    <title xml:lang="ko">오류 표시</title>
-    <title xml:lang="jp">エラー表示</title>
-    <title xml:lang="zh-CN">错误信息</title>
-    <title xml:lang="en">Display Errors</title>
-    <title xml:lang="vi">Hiển thị lỗi</title>
-    <title xml:lang="es">Mostrar el error</title>
-    <title xml:lang="ru">Отображение ошибок</title>
-    <title xml:lang="zh-TW">錯誤訊息</title>
-    <title xml:lang="tr">Hata Görüntüleme</title>
-    <description xml:lang="ko">오류 및 각종 시스템 메세지를 관리합니다.</description>
-    <description xml:lang="jp">エラー及びシステムメッセージ管理モジュール</description>
-    <description xml:lang="zh-CN">管理错误信息及各种系统信息的模块。</description>
-    <description xml:lang="en">Erros and system messages manager.</description>
-    <description xml:lang="vi">Module này quản lý những thông báo lỗi của hệ thống.</description>
-    <description xml:lang="es">Este módulo es para manejar los errores y mensajes del sistema.</description>
-    <description xml:lang="ru">Этот модуль управляет ошибками и системными сообщениями.</description>
-    <description xml:lang="zh-TW">管理錯誤訊息及各種系統訊息的模組。</description>
-    <description xml:lang="tr">Bu modül, hataları ve sistem mesajlarını yönetir.</description>
-    <version>1.7</version>
-    <date>2013-11-27</date>
-    <category>system</category>
+	<title xml:lang="ko">오류 표시</title>
+	<title xml:lang="jp">エラー表示</title>
+	<title xml:lang="zh-CN">错误信息</title>
+	<title xml:lang="en">Display Errors</title>
+	<title xml:lang="vi">Hiển thị lỗi</title>
+	<title xml:lang="es">Mostrar el error</title>
+	<title xml:lang="ru">Отображение ошибок</title>
+	<title xml:lang="zh-TW">錯誤訊息</title>
+	<title xml:lang="tr">Hata Görüntüleme</title>
+	<description xml:lang="ko">오류 및 각종 시스템 메세지를 관리합니다.</description>
+	<description xml:lang="jp">エラー及びシステムメッセージ管理モジュール</description>
+	<description xml:lang="zh-CN">管理错误信息及各种系统信息的模块。</description>
+	<description xml:lang="en">Erros and system messages manager.</description>
+	<description xml:lang="vi">Module này quản lý những thông báo lỗi của hệ thống.</description>
+	<description xml:lang="es">Este módulo es para manejar los errores y mensajes del sistema.</description>
+	<description xml:lang="ru">Этот модуль управляет ошибками и системными сообщениями.</description>
+	<description xml:lang="zh-TW">管理錯誤訊息及各種系統訊息的模組。</description>
+	<description xml:lang="tr">Bu modül, hataları ve sistem mesajlarını yönetir.</description>
+	<version>1.7</version>
+	<date>2013-11-27</date>
+	<category>system</category>
 
-    <author email_address="developers@xpressengine.com" link="http://xpressengine.com/">
-        <name xml:lang="ko">NAVER</name>
-        <name xml:lang="vi">NAVER</name>
-        <name xml:lang="jp">NAVER</name>
-        <name xml:lang="zh-CN">NAVER</name>
-        <name xml:lang="en">NAVER</name>
-        <name xml:lang="es">NAVER</name>
-        <name xml:lang="ru">NAVER</name>
-        <name xml:lang="zh-TW">NAVER</name>
-        <name xml:lang="tr">NAVER</name>
-    </author>
+	<author email_address="developers@xpressengine.com" link="http://xpressengine.com/">
+		<name xml:lang="ko">NAVER</name>
+		<name xml:lang="vi">NAVER</name>
+		<name xml:lang="jp">NAVER</name>
+		<name xml:lang="zh-CN">NAVER</name>
+		<name xml:lang="en">NAVER</name>
+		<name xml:lang="es">NAVER</name>
+		<name xml:lang="ru">NAVER</name>
+		<name xml:lang="zh-TW">NAVER</name>
+		<name xml:lang="tr">NAVER</name>
+	</author>
 </module>

--- a/modules/message/conf/module.xml
+++ b/modules/message/conf/module.xml
@@ -4,8 +4,7 @@
 	<permissions />
 	<actions>
 		<action name="dispMessage" type="view" index="true" />
-
-		<!-- admin -->
+		
 		<action name="dispMessageAdminConfig" type="view" admin_index="true" />
 		<action name="procMessageAdminInsertConfig" type="controller" />
 		<action name="getMessageAdminColorset" type="model" />

--- a/modules/module/conf/info.xml
+++ b/modules/module/conf/info.xml
@@ -1,36 +1,36 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module version="0.2">
-    <title xml:lang="ko">모듈</title>
-    <title xml:lang="zh-CN">模块列表</title>
-    <title xml:lang="jp">モジュール</title>
-    <title xml:lang="en">Module</title>
-    <title xml:lang="vi">Module</title>
-    <title xml:lang="es">Módulo</title>
-    <title xml:lang="ru">Модули</title>
-    <title xml:lang="zh-TW">模組</title>
-    <title xml:lang="tr">Modül</title>
-    <description xml:lang="ko">모듈을 생성하고 관리합니다.</description>
-    <description xml:lang="zh-CN">生成及管理模块的模块。</description>
-    <description xml:lang="jp">モジュールの生成、管理するモジュールです。</description>
-    <description xml:lang="en">Creating/managering the other modules.</description>
-    <description xml:lang="vi">Module cho phép tạo và quản lý những Module khác.</description>
-    <description xml:lang="es">Este módulo is para crear y manejar los otros módulos.</description>
-    <description xml:lang="ru">Этот модуль служит для создания/управления другими модулями.</description>
-    <description xml:lang="zh-TW">用於建立與管理其他模組。</description>
-    <description xml:lang="tr">Bu modül, başka modüller oluşturmak ve yönetmek içindir.</description>
-    <version>1.7</version>
-    <date>2013-11-27</date>
-    <category>system</category>
+	<title xml:lang="ko">모듈</title>
+	<title xml:lang="zh-CN">模块列表</title>
+	<title xml:lang="jp">モジュール</title>
+	<title xml:lang="en">Module</title>
+	<title xml:lang="vi">Module</title>
+	<title xml:lang="es">Módulo</title>
+	<title xml:lang="ru">Модули</title>
+	<title xml:lang="zh-TW">模組</title>
+	<title xml:lang="tr">Modül</title>
+	<description xml:lang="ko">모듈을 생성하고 관리합니다.</description>
+	<description xml:lang="zh-CN">生成及管理模块的模块。</description>
+	<description xml:lang="jp">モジュールの生成、管理するモジュールです。</description>
+	<description xml:lang="en">Creating/managering the other modules.</description>
+	<description xml:lang="vi">Module cho phép tạo và quản lý những Module khác.</description>
+	<description xml:lang="es">Este módulo is para crear y manejar los otros módulos.</description>
+	<description xml:lang="ru">Этот модуль служит для создания/управления другими модулями.</description>
+	<description xml:lang="zh-TW">用於建立與管理其他模組。</description>
+	<description xml:lang="tr">Bu modül, başka modüller oluşturmak ve yönetmek içindir.</description>
+	<version>1.7</version>
+	<date>2013-11-27</date>
+	<category>system</category>
 
-    <author email_address="developers@xpressengine.com" link="http://xpressengine.com/">
-        <name xml:lang="ko">NAVER</name>
-        <name xml:lang="vi">NAVER</name>
-        <name xml:lang="zh-CN">NAVER</name>
-        <name xml:lang="jp">NAVER</name>
-        <name xml:lang="en">NAVER</name>
-        <name xml:lang="es">NAVER</name>
-        <name xml:lang="ru">NAVER</name>
-        <name xml:lang="zh-TW">NAVER</name>
-        <name xml:lang="tr">NAVER</name>
-    </author>
+	<author email_address="developers@xpressengine.com" link="http://xpressengine.com/">
+		<name xml:lang="ko">NAVER</name>
+		<name xml:lang="vi">NAVER</name>
+		<name xml:lang="zh-CN">NAVER</name>
+		<name xml:lang="jp">NAVER</name>
+		<name xml:lang="en">NAVER</name>
+		<name xml:lang="es">NAVER</name>
+		<name xml:lang="ru">NAVER</name>
+		<name xml:lang="zh-TW">NAVER</name>
+		<name xml:lang="tr">NAVER</name>
+	</author>
 </module>

--- a/modules/module/conf/module.xml
+++ b/modules/module/conf/module.xml
@@ -3,20 +3,27 @@
 	<grants />
 	<permissions>
 		<permission action="dispModuleSelectList" target="root" />
+		<permission action="dispModuleSkinInfo" target="all-managers" />
+		<permission action="dispModuleFileBox" target="root" />
+		<permission action="dispModuleFileBoxAdd" target="root" />
 		
-		<permission action="getLangByLangcode" target="manager" />
+		<permission action="getModuleSkinInfoList" target="root" />
+		<permission action="getFileBoxListHtml" target="root" />
+		<permission action="getModuleInfoByMenuItemSrl" target="root" />
 		<permission action="getLangListByLangcodeForAutoComplete" target="manager" />
 		
-		<permission action="getModuleAdminGrant" target="manager" />
+		<permission action="procModuleFileBoxAdd" target="root" />
+		<permission action="procModuleFileBoxDelete" target="root" />
+		
 		<permission action="getModuleAdminLangCode" target="manager" />
-		<permission action="getModuleAdminLangListHtml" target="manager" />
 		<permission action="getModuleAdminLangListByName" target="manager" />
 		<permission action="getModuleAdminLangListByValue" target="manager" />
 		<permission action="getModuleAdminMultilingualHtml" target="manager" />
+		<permission action="getModuleAdminLangListHtml" target="manager" />
 		
-		<permission action="procModuleAdminInsertGrant" target="manager" />
+		<permission action="procModuleAdminInsertGrant" target="manager" check_var="module_srl" />
+		<permission action="procModuleAdminUpdateSkinInfo" target="manager" check_var="module_srl" />
 		<permission action="procModuleAdminInsertLang" target="manager" />
-		<permission action="procModuleAdminUpdateSkinInfo" target="manager" />
 	</permissions>
 	<actions>
 		<action name="dispModuleSelectList" type="view" />
@@ -26,44 +33,42 @@
 		<action name="dispModuleChangeLang" type="mobile" />
 		
 		<action name="getModuleSkinInfoList" type="model" />
-		<action name="getModuleAdminModuleList" type="model" />
-		<action name="getModuleAdminLangCode" type="model" />
-		<action name="getModuleAdminLangListByName" type="model" />
-		<action name="getModuleAdminLangListByValue" type="model" />
-		<action name="getLangListByLangcodeForAutoComplete" type="model" />
 		<action name="getFileBoxListHtml" type="model" />
-		<action name="getLangByLangcode" type="model" />
 		<action name="getModuleInfoByMenuItemSrl" type="model" />
+		<action name="getLangListByLangcodeForAutoComplete" type="model" />
+		<action name="getLangByLangcode" type="model" />
 		
-		<action name="procModuleFileBoxAdd" type="controller" />
 		<action name="procModuleFileBoxAdd" type="controller" />
 		<action name="procModuleFileBoxDelete" type="controller" />
 		
-		<action name="dispModuleAdminContent" type="view"  menu_name="installedModule" menu_index="true" admin_index="true" />
-		<action name="dispModuleAdminList" type="view" />
+		<action name="dispModuleAdminContent" type="view" menu_name="installedModule" menu_index="true" admin_index="true" />
 		<action name="dispModuleAdminCategory" type="view" menu_name="installedModule" />
 		<action name="dispModuleAdminInfo" type="view" />
 		<action name="dispModuleAdminModuleSetup" type="view" />
 		<action name="dispModuleAdminModuleAdditionSetup" type="view" />
 		<action name="dispModuleAdminModuleGrantSetup" type="view" />
 		<action name="dispModuleAdminCopyModule" type="view" />
-		<action name="dispModuleAdminLangcode" type="view" menu_name="multilingual" menu_index="true" />
 		<action name="dispModuleAdminFileBox" type="view" menu_name="filebox" menu_index="true" />
+		<action name="dispModuleAdminLangcode" type="view" menu_name="multilingual" menu_index="true" />
 		
+		<action name="getModuleAdminModuleList" type="model" />
+		<action name="getModuleAdminModuleInfo" type="model" />
 		<action name="getModuleAdminGrant" type="model" />
+		<action name="getModuleAdminLangCode" type="model" />
+		<action name="getModuleAdminLangListByName" type="model" />
+		<action name="getModuleAdminLangListByValue" type="model" />
+		<action name="getModuleAdminModuleSearcherHtml" type="model" />
 		<action name="getModuleAdminMultilingualHtml" type="model" />
 		<action name="getModuleAdminLangListHtml" type="model" />
-		<action name="getModuleAdminModuleSearcherHtml" type="model" />
-		<action name="getModuleAdminModuleInfo" type="model" />
 		
 		<action name="procModuleAdminInsertCategory" type="controller" ruleset="insertCategory" />
 		<action name="procModuleAdminUpdateCategory" type="controller" ruleset="updateCategory" />
 		<action name="procModuleAdminDeleteCategory" type="controller" ruleset="deleteCategory" />
+		<action name="procModuleAdminModuleSetup" type="controller" ruleset="insertModuleSetup" />
+		<action name="procModuleAdminModuleGrantSetup" type="controller" ruleset="insertModulesGrant" />		
 		<action name="procModuleAdminCopyModule" type="controller" ruleset="copyModule" />
 		<action name="procModuleAdminInsertGrant" type="controller" />
 		<action name="procModuleAdminUpdateSkinInfo" type="controller" />
-		<action name="procModuleAdminModuleSetup" type="controller" ruleset="insertModuleSetup" />
-		<action name="procModuleAdminModuleGrantSetup" type="controller" ruleset="insertModulesGrant" />
 		<action name="procModuleAdminInsertLang" type="controller" />
 		<action name="procModuleAdminDeleteLang" type="controller" />
 		<action name="procModuleAdminGetList" type="controller" />

--- a/modules/module/conf/module.xml
+++ b/modules/module/conf/module.xml
@@ -2,34 +2,29 @@
 <module>
 	<grants />
 	<permissions>
-		<permission action="dispModuleSelectList" target="member" />
-
-
-		<permission action="getLangListByLangcodeForAutoComplete" target="manager" />
+		<permission action="dispModuleSelectList" target="root" />
+		
 		<permission action="getLangByLangcode" target="manager" />
-		<permission action="getModuleAdminMultilingualHtml" target="manager" />
-
+		<permission action="getLangListByLangcodeForAutoComplete" target="manager" />
+		
 		<permission action="getModuleAdminGrant" target="manager" />
-		<permission action="procModuleAdminInsertGrant" target="manager" />
-
 		<permission action="getModuleAdminLangCode" target="manager" />
 		<permission action="getModuleAdminLangListHtml" target="manager" />
 		<permission action="getModuleAdminLangListByName" target="manager" />
 		<permission action="getModuleAdminLangListByValue" target="manager" />
+		<permission action="getModuleAdminMultilingualHtml" target="manager" />
+		
+		<permission action="procModuleAdminInsertGrant" target="manager" />
 		<permission action="procModuleAdminInsertLang" target="manager" />
 		<permission action="procModuleAdminUpdateSkinInfo" target="manager" />
 	</permissions>
 	<actions>
 		<action name="dispModuleSelectList" type="view" />
 		<action name="dispModuleSkinInfo" type="view" />
-
 		<action name="dispModuleFileBox" type="view" />
 		<action name="dispModuleFileBoxAdd" type="view" />
-
-		<action name="procModuleFileBoxAdd" type="controller" />
-		<action name="procModuleFileBoxAdd" type="controller" />
-		<action name="procModuleFileBoxDelete" type="controller" />
-
+		<action name="dispModuleChangeLang" type="mobile" />
+		
 		<action name="getModuleSkinInfoList" type="model" />
 		<action name="getModuleAdminModuleList" type="model" />
 		<action name="getModuleAdminLangCode" type="model" />
@@ -39,9 +34,11 @@
 		<action name="getFileBoxListHtml" type="model" />
 		<action name="getLangByLangcode" type="model" />
 		<action name="getModuleInfoByMenuItemSrl" type="model" />
-		<action name="dispModuleChangeLang" type="mobile" />
-
-		<!-- admin -->
+		
+		<action name="procModuleFileBoxAdd" type="controller" />
+		<action name="procModuleFileBoxAdd" type="controller" />
+		<action name="procModuleFileBoxDelete" type="controller" />
+		
 		<action name="dispModuleAdminContent" type="view"  menu_name="installedModule" menu_index="true" admin_index="true" />
 		<action name="dispModuleAdminList" type="view" />
 		<action name="dispModuleAdminCategory" type="view" menu_name="installedModule" />
@@ -52,13 +49,13 @@
 		<action name="dispModuleAdminCopyModule" type="view" />
 		<action name="dispModuleAdminLangcode" type="view" menu_name="multilingual" menu_index="true" />
 		<action name="dispModuleAdminFileBox" type="view" menu_name="filebox" menu_index="true" />
-
+		
 		<action name="getModuleAdminGrant" type="model" />
 		<action name="getModuleAdminMultilingualHtml" type="model" />
 		<action name="getModuleAdminLangListHtml" type="model" />
 		<action name="getModuleAdminModuleSearcherHtml" type="model" />
 		<action name="getModuleAdminModuleInfo" type="model" />
-
+		
 		<action name="procModuleAdminInsertCategory" type="controller" ruleset="insertCategory" />
 		<action name="procModuleAdminUpdateCategory" type="controller" ruleset="updateCategory" />
 		<action name="procModuleAdminDeleteCategory" type="controller" ruleset="deleteCategory" />

--- a/modules/module/module.model.php
+++ b/modules/module/module.model.php
@@ -1931,7 +1931,7 @@ class moduleModel extends module
 		$is_module_admin = $this->isModuleAdmin($member_info, $module_info->module_srl);
 		
 		// Get module grant
-		$module_grant = is_array($xml_info->grant) ? array_keys($xml_info->grant) : array();
+		$module_grant = array_keys((array) $xml_info->grant);
 		
 		// Prepend default grant
 		array_unshift($module_grant, 'access', 'is_admin', 'manager', 'is_site_admin');

--- a/modules/module/module.model.php
+++ b/modules/module/module.model.php
@@ -845,15 +845,10 @@ class moduleModel extends module
 				{
 					$action = $permission->attrs->action;
 					$target = $permission->attrs->target;
-					$check = $permission->attrs->check ?: 'module_srl';
 
 					$info->permission->{$action} = $target;
-					$info->permission_check->{$action}->key = $check;
-					
-					if(strpos($check, '.') !== false)
-					{
-						list($info->permission_check->{$action}->type, $info->permission_check->{$action}->key) = explode('.', $check);
-					}
+					$info->permission_check->{$action}->key = $permission->attrs->check_var ?: 'module_srl';
+					$info->permission_check->{$action}->type = $permission->attrs->check_type ?: '';
 					
 					$buff[] = sprintf('$info->permission->%s = \'%s\';', $action, $target);
 					$buff[] = sprintf('$info->permission_check->%s->key = \'%s\';', $action, $info->permission_check->{$action}->key);

--- a/modules/module/module.model.php
+++ b/modules/module/module.model.php
@@ -1943,7 +1943,8 @@ class moduleModel extends module
 		$module_grant = array_keys((array) $xml_info->grant);
 		
 		// Prepend default grant
-		array_unshift($module_grant, 'access', 'is_admin', 'manager', 'is_site_admin');
+		// is_admin, manager, is_site_admin not distinguish because of compatibility.
+		array_unshift($module_grant, 'access', 'is_admin', 'manager', 'is_site_admin', 'root');
 		
 		// unique
 		$module_grant = array_unique($module_grant, SORT_STRING);
@@ -1951,15 +1952,22 @@ class moduleModel extends module
 		// Set grant
 		foreach($module_grant as $val)
 		{
-			// Set true if an administrator or a module manager
-			if($member_info->is_admin == 'Y' || $is_module_admin)
+			// If an administrator, set all true.
+			if($member_info->is_admin == 'Y')
 			{
 				$grant->{$val} = true;
 			}
-			else if($val == 'access' && !$module_info->module_srl)
+			// If a module manager, except 'root'
+			else if($is_module_admin === true && $val !== 'root')
 			{
 				$grant->{$val} = true;
 			}
+			// If module_srl doesn't exist, access true
+			else if(!$module_info->module_srl && $val === 'access')
+			{
+				$grant->{$val} = true;
+			}
+			// default permission false
 			else
 			{
 				$grant->{$val} = false;

--- a/modules/module/module.model.php
+++ b/modules/module/module.model.php
@@ -1928,6 +1928,8 @@ class moduleModel extends module
 			$member_group = array();
 		}
 		
+		$is_module_admin = $this->isModuleAdmin($member_info, $module_info->module_srl);
+		
 		// Get module grant
 		$module_grant = is_array($xml_info->grant) ? array_keys($xml_info->grant) : array();
 		
@@ -1941,7 +1943,7 @@ class moduleModel extends module
 		foreach($module_grant as $val)
 		{
 			// Set true if an administrator or a module manager
-			if($member_info->is_admin == 'Y' || $this->isModuleAdmin($member_info, $module_info->module_srl))
+			if($member_info->is_admin == 'Y' || $is_module_admin)
 			{
 				$grant->{$val} = true;
 			}

--- a/modules/module/module.model.php
+++ b/modules/module/module.model.php
@@ -845,10 +845,16 @@ class moduleModel extends module
 				{
 					$action = $permission->attrs->action;
 					$target = $permission->attrs->target;
+					$check = $permission->attrs->check ?: 'module_srl';
+					$check_array = isset($permission->attrs->check_array) ? $permission->attrs->check_array : '';
 
 					$info->permission->{$action} = $target;
+					$info->permission_check->{$action}->key = $check;
+					$info->permission_check->{$action}->array = $check_array;
 
 					$buff[] = sprintf('$info->permission->%s = \'%s\';', $action, $target);
+					$buff[] = sprintf('$info->permission_check->%s->key = \'%s\';', $action, $check);
+					$buff[] = sprintf('$info->permission_check->%s->array = \'%s\';', $action, $check_array);
 				}
 			}
 			// for admin menus

--- a/modules/module/module.model.php
+++ b/modules/module/module.model.php
@@ -846,15 +846,18 @@ class moduleModel extends module
 					$action = $permission->attrs->action;
 					$target = $permission->attrs->target;
 					$check = $permission->attrs->check ?: 'module_srl';
-					$check_array = isset($permission->attrs->check_array) ? $permission->attrs->check_array : '';
 
 					$info->permission->{$action} = $target;
 					$info->permission_check->{$action}->key = $check;
-					$info->permission_check->{$action}->array = $check_array;
-
+					
+					if(strpos($check, '.') !== false)
+					{
+						list($info->permission_check->{$action}->type, $info->permission_check->{$action}->key) = explode('.', $check);
+					}
+					
 					$buff[] = sprintf('$info->permission->%s = \'%s\';', $action, $target);
-					$buff[] = sprintf('$info->permission_check->%s->key = \'%s\';', $action, $check);
-					$buff[] = sprintf('$info->permission_check->%s->array = \'%s\';', $action, $check_array);
+					$buff[] = sprintf('$info->permission_check->%s->key = \'%s\';', $action, $info->permission_check->{$action}->key);
+					$buff[] = sprintf('$info->permission_check->%s->type = \'%s\';', $action, $info->permission_check->{$action}->type);
 				}
 			}
 			// for admin menus

--- a/modules/ncenterlite/conf/module.xml
+++ b/modules/ncenterlite/conf/module.xml
@@ -3,25 +3,28 @@
 	<grants />
 	<permissions />
 	<actions>
+		<action name="dispNcenterliteNotifyList" type="view" />
+		<action name="dispNcenterliteUserConfig" type="view" />
+		
+		<action name="getColorsetList" type="model" />
+		<action name="getMyNotifyListTpl" type="model" />
+		
+		<action name="procNcenterliteUserConfig" type="controller" />
+		<action name="procNcenterliteNotifyReadAll" type="controller" />
+		<action name="procNcenterliteRedirect" type="controller" method="GET|POST" />
+		
 		<action name="dispNcenterliteAdminConfig" type="view" admin_index="true" menu_name="ncenterlite" menu_index="true" />
 		<action name="dispNcenterliteAdminSeletedmid" type="view" />
 		<action name="dispNcenterliteAdminTest" type="view" />
 		<action name="dispNcenterliteAdminSkinsetting" type="view" />
 		<action name="dispNcenterliteAdminAdvancedconfig" type="view" />
-		<action name="dispNcenterliteNotifyList" type="view" />
 		<action name="dispNcenterliteAdminList" type="view" />
-		<action name="dispNcenterliteUserConfig" type="view" />
-		<action name="procNcenterliteUserConfig" type="controller" />
+		
 		<action name="procNcenterliteAdminInsertConfig" type="controller" ruleset="insertConfig" />
 		<action name="procNcenterliteAdminDeleteNofity" type="controller" />
 		<action name="procNcenterliteAdminInsertDummyData" type="controller" />
 		<action name="procNcenterliteAdminInsertPushData" type="controller" />
 		<action name="procNcenterliteAdminEnviromentGatheringAgreement" type="controller" />
-		<action name="procNcenterliteNotifyReadAll" type="controller" />
-		<action name="procNcenterliteRedirect" type="controller" method="GET|POST" />
-
-		<action name="getColorsetList" type="model" />
-		<action name="getMyNotifyListTpl" type="model" />
 	</actions>
 	<menus>
 		<menu name="ncenterlite" type="all">

--- a/modules/ncenterlite/conf/module.xml
+++ b/modules/ncenterlite/conf/module.xml
@@ -1,7 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module>
 	<grants />
-	<permissions />
+	<permissions>
+		<permission action="dispNcenterliteNotifyList" target="member" />
+		<permission action="dispNcenterliteUserConfig" target="member" />
+		
+		<permission action="getColorsetList" target="root" />
+		<permission action="getMyNotifyListTpl" target="member" />
+		
+		<permission action="procNcenterliteUserConfig" target="member" />
+		<permission action="procNcenterliteNotifyReadAll" target="member" />
+		<permission action="procNcenterliteRedirect" target="member" />
+	</permissions>
 	<actions>
 		<action name="dispNcenterliteNotifyList" type="view" />
 		<action name="dispNcenterliteUserConfig" type="view" />
@@ -14,17 +24,16 @@
 		<action name="procNcenterliteRedirect" type="controller" method="GET|POST" />
 		
 		<action name="dispNcenterliteAdminConfig" type="view" admin_index="true" menu_name="ncenterlite" menu_index="true" />
-		<action name="dispNcenterliteAdminSeletedmid" type="view" />
-		<action name="dispNcenterliteAdminTest" type="view" />
-		<action name="dispNcenterliteAdminSkinsetting" type="view" />
-		<action name="dispNcenterliteAdminAdvancedconfig" type="view" />
-		<action name="dispNcenterliteAdminList" type="view" />
+		<action name="dispNcenterliteAdminAdvancedconfig" type="view" menu_name="ncenterlite" />
+		<action name="dispNcenterliteAdminSeletedmid" type="view" menu_name="ncenterlite" />
+		<action name="dispNcenterliteAdminSkinsetting" type="view" menu_name="ncenterlite" />
+		<action name="dispNcenterliteAdminTest" type="view"  menu_name="ncenterlite" />
+		<action name="dispNcenterliteAdminList" type="view" menu_name="ncenterlite" />
 		
 		<action name="procNcenterliteAdminInsertConfig" type="controller" ruleset="insertConfig" />
-		<action name="procNcenterliteAdminDeleteNofity" type="controller" />
 		<action name="procNcenterliteAdminInsertDummyData" type="controller" />
 		<action name="procNcenterliteAdminInsertPushData" type="controller" />
-		<action name="procNcenterliteAdminEnviromentGatheringAgreement" type="controller" />
+		<action name="procNcenterliteAdminDeleteNofity" type="controller" />
 	</actions>
 	<menus>
 		<menu name="ncenterlite" type="all">

--- a/modules/page/conf/info.xml
+++ b/modules/page/conf/info.xml
@@ -1,36 +1,36 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module version="0.2">
-    <title xml:lang="ko">페이지</title>
-    <title xml:lang="zh-CN">页面管理</title>
-    <title xml:lang="jp">ページ</title>
-    <title xml:lang="en">Page</title>
-    <title xml:lang="vi">Trang</title>
-    <title xml:lang="es">Página</title>
-    <title xml:lang="ru">Страницы</title>
-    <title xml:lang="zh-TW">頁面</title>
-    <title xml:lang="tr">Sayfa</title>
-    <description xml:lang="ko">페이지를 제작할 수 있습니다.</description>
-    <description xml:lang="zh-CN">制作页面并能连接到内容区的模块。</description>
-    <description xml:lang="jp">ページを作成してコンテンツとしてリンク出来るようにするモジュールです。</description>
-    <description xml:lang="en">This module is for creating pages to link with contents.</description>
-    <description xml:lang="vi">Module này dành cho việc tạo trang cho liên kết với nội dung.</description>
-    <description xml:lang="es">Este módulo is para crear página para enlazar con contenidos.</description>
-    <description xml:lang="ru">Этот модуль служит для создания страниц, чтобы связать их с содержимым.</description>
-    <description xml:lang="zh-TW">製作頁面並連結內容的模組。</description>
-    <description xml:lang="tr">Bu modül içeriklere bağlanacak sayfaları oluşturmak içindir.</description>
-    <version>1.7</version>
-    <date>2013-11-27</date>
-    <category>service</category>
+	<title xml:lang="ko">페이지</title>
+	<title xml:lang="zh-CN">页面管理</title>
+	<title xml:lang="jp">ページ</title>
+	<title xml:lang="en">Page</title>
+	<title xml:lang="vi">Trang</title>
+	<title xml:lang="es">Página</title>
+	<title xml:lang="ru">Страницы</title>
+	<title xml:lang="zh-TW">頁面</title>
+	<title xml:lang="tr">Sayfa</title>
+	<description xml:lang="ko">페이지를 제작할 수 있습니다.</description>
+	<description xml:lang="zh-CN">制作页面并能连接到内容区的模块。</description>
+	<description xml:lang="jp">ページを作成してコンテンツとしてリンク出来るようにするモジュールです。</description>
+	<description xml:lang="en">This module is for creating pages to link with contents.</description>
+	<description xml:lang="vi">Module này dành cho việc tạo trang cho liên kết với nội dung.</description>
+	<description xml:lang="es">Este módulo is para crear página para enlazar con contenidos.</description>
+	<description xml:lang="ru">Этот модуль служит для создания страниц, чтобы связать их с содержимым.</description>
+	<description xml:lang="zh-TW">製作頁面並連結內容的模組。</description>
+	<description xml:lang="tr">Bu modül içeriklere bağlanacak sayfaları oluşturmak içindir.</description>
+	<version>1.7</version>
+	<date>2013-11-27</date>
+	<category>service</category>
 
-    <author email_address="developers@xpressengine.com" link="http://xpressengine.com/">
-        <name xml:lang="ko">NAVER</name>
-        <name xml:lang="vi">NAVER</name>
-        <name xml:lang="zh-CN">NAVER</name>
-        <name xml:lang="jp">NAVER</name>
-        <name xml:lang="en">NAVER</name>
-        <name xml:lang="es">NAVER</name>
-        <name xml:lang="ru">NAVER</name>
-        <name xml:lang="zh-TW">NAVER</name>
-        <name xml:lang="tr">NAVER</name>
-    </author>
+	<author email_address="developers@xpressengine.com" link="http://xpressengine.com/">
+		<name xml:lang="ko">NAVER</name>
+		<name xml:lang="vi">NAVER</name>
+		<name xml:lang="zh-CN">NAVER</name>
+		<name xml:lang="jp">NAVER</name>
+		<name xml:lang="en">NAVER</name>
+		<name xml:lang="es">NAVER</name>
+		<name xml:lang="ru">NAVER</name>
+		<name xml:lang="zh-TW">NAVER</name>
+		<name xml:lang="tr">NAVER</name>
+	</author>
 </module>

--- a/modules/page/conf/module.xml
+++ b/modules/page/conf/module.xml
@@ -2,33 +2,41 @@
 <module>
 	<grants />
 	<permissions>
+		<permission action="dispPageAdminInfo" target="manager" check_var="module_srl" />
+		<permission action="dispPageAdminPageAdditionSetup" target="manager" check_var="module_srl" />
+		<permission action="dispPageAdminGrantInfo" target="manager" check_var="module_srl" />
+		<permission action="dispPageAdminSkinInfo" target="manager" check_var="module_srl" />
+		<permission action="dispPageAdminMobileSkinInfo" target="manager" check_var="module_srl" />
 		<permission action="dispPageAdminContentModify" target="manager" />
-		<permission action="procPageAdminRemoveWidgetCache" target="manager" check_var="module_srl" />
+		<permission action="dispPageAdminMobileContent" target="manager" />
+		<permission action="dispPageAdminMobileContentModify" target="manager" />
+		
+		<permission action="procPageAdminUpdate" target="manager" check_var="module_srl" />
 		<permission action="procPageAdminInsertContent" target="manager" check_var="module_srl" />
+		<permission action="procPageAdminArticleDocumentInsert" target="manager" />
+		<permission action="procPageAdminRemoveWidgetCache" target="manager" check_var="module_srl" />
 	</permissions>
 	<actions>
 		<action name="dispPageIndex" type="view" index="true" />
 		
 		<action name="dispPageAdminContent" type="view" admin_index="true" menu_name="page" menu_index="true" />
-		<action name="dispPageAdminGrantInfo" type="view" menu_name="page" />
+		<action name="dispPageAdminDelete" type="view" menu_name="page" />
 		<action name="dispPageAdminInfo" type="view" setup_index="true" menu_name="page" />
 		<action name="dispPageAdminPageAdditionSetup" type="view" menu_name="page" />
-		<action name="dispPageAdminDelete" type="view" />
+		<action name="dispPageAdminGrantInfo" type="view" menu_name="page" />
+		<action name="dispPageAdminSkinInfo" type="view" menu_name="page" />
+		<action name="dispPageAdminMobileSkinInfo" type="view" menu_name="page" />
 		<action name="dispPageAdminContentModify" type="view" />
-		<action name="dispPageAdminAddContent" type="view" />
-		<action name="dispPageAdminMobileContentModify" type="view" />
 		<action name="dispPageAdminMobileContent" type="view" />
-		<action name="dispPageAdminSkinInfo" type="view" />
-		<action name="dispPageAdminMobileSkinInfo" type="view" />
+		<action name="dispPageAdminMobileContentModify" type="view" />
 		
-		<action name="procPageAdminRemoveWidgetCache" type="controller" />
 		<action name="procPageAdminInsert" type="controller" ruleset="insertPage" />
 		<action name="procPageAdminUpdate" type="controller" ruleset="updatePage" />
-		<action name="procPageAdminInsertContent" type="controller" />
 		<action name="procPageAdminDelete" type="controller" ruleset="deletePage" />
 		<action name="procPageAdminInsertConfig" type="controller" />
-		<action name="procPageAdminAddContent" type="controller" />
+		<action name="procPageAdminInsertContent" type="controller" />
 		<action name="procPageAdminArticleDocumentInsert" type="controller" />
+		<action name="procPageAdminRemoveWidgetCache" type="controller" />
 	</actions>
 	<menus>
 		<menu name="page" type="all">

--- a/modules/page/conf/module.xml
+++ b/modules/page/conf/module.xml
@@ -17,7 +17,7 @@
 		<permission action="procPageAdminRemoveWidgetCache" target="manager" check_var="module_srl" />
 	</permissions>
 	<actions>
-		<action name="dispPageIndex" type="view" index="true" />
+		<action name="dispPageIndex" type="view" standalone="false" index="true" />
 		
 		<action name="dispPageAdminContent" type="view" admin_index="true" menu_name="page" menu_index="true" />
 		<action name="dispPageAdminDelete" type="view" menu_name="page" />

--- a/modules/page/conf/module.xml
+++ b/modules/page/conf/module.xml
@@ -2,15 +2,13 @@
 <module>
 	<grants />
 	<permissions>
-		<permission action="procPageAdminRemoveWidgetCache" target="manager" />
 		<permission action="dispPageAdminContentModify" target="manager" />
-		<permission action="procPageAdminInsert" target="manager" />
-		<permission action="procPageAdminInsertContent" target="manager" />
+		<permission action="procPageAdminRemoveWidgetCache" target="manager" check_var="module_srl" />
+		<permission action="procPageAdminInsertContent" target="manager" check_var="module_srl" />
 	</permissions>
 	<actions>
 		<action name="dispPageIndex" type="view" index="true" />
-
-		<!-- admin -->
+		
 		<action name="dispPageAdminContent" type="view" admin_index="true" menu_name="page" menu_index="true" />
 		<action name="dispPageAdminGrantInfo" type="view" menu_name="page" />
 		<action name="dispPageAdminInfo" type="view" setup_index="true" menu_name="page" />
@@ -22,6 +20,7 @@
 		<action name="dispPageAdminMobileContent" type="view" />
 		<action name="dispPageAdminSkinInfo" type="view" />
 		<action name="dispPageAdminMobileSkinInfo" type="view" />
+		
 		<action name="procPageAdminRemoveWidgetCache" type="controller" />
 		<action name="procPageAdminInsert" type="controller" ruleset="insertPage" />
 		<action name="procPageAdminUpdate" type="controller" ruleset="updatePage" />

--- a/modules/point/conf/info.xml
+++ b/modules/point/conf/info.xml
@@ -1,72 +1,72 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module version="0.2">
-    <title xml:lang="ko">포인트 시스템</title>
-    <title xml:lang="zh-CN">积分系统</title>
-    <title xml:lang="jp">ポイントシステム</title>
-    <title xml:lang="en">Point System</title>
-    <title xml:lang="vi">Hệ thống điểm</title>
-    <title xml:lang="es">Sistema de Punto</title>
-    <title xml:lang="ru">Система поитов</title>
-    <title xml:lang="zh-TW">點數系統</title>
-    <title xml:lang="tr">Puanlama Sistemi</title>
-    <description xml:lang="ko">
-        글작성/삭제/댓글작성/삭제시에 포인트를 부여할 수 있습니다.
-        포인트마다 레벨을 지정하여 사용자 이름 앞에 아이콘을 표시할 수도 있습니다.
-        단 포인트 관련 애드온을 활성화 시켜야 됩니다.
-    </description>
-    <description xml:lang="zh-CN">
-        可以在发表/删除新帖，发表/删除评论时，付与相应积分。
-        也可以以积分设置级别，并在用户名前显示级别图标。
-        必须是先激活积分系统才可以使用。
-    </description>
-    <description xml:lang="jp">
-        書き込み作成・削除/コメント作成・削除の活動に対するポイントを計算するシステムです。
-        ポイントごとレベルを指定してユーザ名の前にアイコンを表示させることが出来ます。
-        但し、ポイントシステムアドオンを「使用」に設定しないと作動しません。
-    </description>
-    <description xml:lang="en">
-        You can grant points for writing/deleting/adding contents or comments.
-        You can also display point icon in front of a user name by selecting level for each point.
-        But to enable these functions, you need to activate point related addons.
-    </description>
-    <description xml:lang="tr">
-        Yazmaya/silmeye, yorum eklemeye/yorum silmeye puan atayabilirsiniz.
-        Her puanın seviyesini seçerek, kullanıcı isimlerinin başında puan simgesi gösterebilirsiniz.
-        Bu özellikleri mümkün kılmak için, puanlamayla alakalı eklentileri etkinleştirmeniz gerekmektedir.
-    </description>
-    <description xml:lang="vi">
-        Bạn có thể cho hay trừ điểm của các thành viên khi Gửi bài, Xóa bài, Thêm bình luận, Xóa bình luận.
-        bạn cũng có thể cho phép hiển thị Icon của cấp độ điểm trước tên sử dụng bằng việc lụa chọn Icon cấp độ điểm.
-        Để kích hoạt chức năng này, bạn phải kích hoạt Addon Hệ thống điểm.
-    </description>
-    <description xml:lang="es">
-        Usted puede entregar puntos a las acciones de escribir/eliminar/agregar comentarios/eliminar comentarios.
-        Usted también puede mostrar el ícono de punto delande del nombre del usuario seleccionando el nivel sobre cada puntos.
-        Pero para activar esas funciones, Usted necesita activar addon relacionado a los puntos.
-    </description>
-    <description xml:lang="ru">
-        Вы можете назначать поинты за написание/удаление/добавление комментариев/удаление комментариев.
-        Вы также можете отображать икнку поинтов напротив имени пользователя, установив уровени для поинтов.
-        Но чтобы включить эти функции, Вам надо активировать аддоны, относящиеся к поинтам.
-    </description>
-    <description xml:lang="zh-TW">
-        可在發表、刪除文章及回覆時，付出相對應的點數。
-        也能以點數設置等級，並在用戶名稱前顯示等級圖示。
-        但是必須先啟用點數系統才能使用。
-    </description>
-    <version>1.7</version>
-    <date>2013-11-27</date>
-    <category>member</category>
+	<title xml:lang="ko">포인트 시스템</title>
+	<title xml:lang="zh-CN">积分系统</title>
+	<title xml:lang="jp">ポイントシステム</title>
+	<title xml:lang="en">Point System</title>
+	<title xml:lang="vi">Hệ thống điểm</title>
+	<title xml:lang="es">Sistema de Punto</title>
+	<title xml:lang="ru">Система поитов</title>
+	<title xml:lang="zh-TW">點數系統</title>
+	<title xml:lang="tr">Puanlama Sistemi</title>
+	<description xml:lang="ko">
+		글작성/삭제/댓글작성/삭제시에 포인트를 부여할 수 있습니다.
+		포인트마다 레벨을 지정하여 사용자 이름 앞에 아이콘을 표시할 수도 있습니다.
+		단 포인트 관련 애드온을 활성화 시켜야 됩니다.
+	</description>
+	<description xml:lang="zh-CN">
+		可以在发表/删除新帖，发表/删除评论时，付与相应积分。
+		也可以以积分设置级别，并在用户名前显示级别图标。
+		必须是先激活积分系统才可以使用。
+	</description>
+	<description xml:lang="jp">
+		書き込み作成・削除/コメント作成・削除の活動に対するポイントを計算するシステムです。
+		ポイントごとレベルを指定してユーザ名の前にアイコンを表示させることが出来ます。
+		但し、ポイントシステムアドオンを「使用」に設定しないと作動しません。
+	</description>
+	<description xml:lang="en">
+		You can grant points for writing/deleting/adding contents or comments.
+		You can also display point icon in front of a user name by selecting level for each point.
+		But to enable these functions, you need to activate point related addons.
+	</description>
+	<description xml:lang="tr">
+		Yazmaya/silmeye, yorum eklemeye/yorum silmeye puan atayabilirsiniz.
+		Her puanın seviyesini seçerek, kullanıcı isimlerinin başında puan simgesi gösterebilirsiniz.
+		Bu özellikleri mümkün kılmak için, puanlamayla alakalı eklentileri etkinleştirmeniz gerekmektedir.
+	</description>
+	<description xml:lang="vi">
+		Bạn có thể cho hay trừ điểm của các thành viên khi Gửi bài, Xóa bài, Thêm bình luận, Xóa bình luận.
+		bạn cũng có thể cho phép hiển thị Icon của cấp độ điểm trước tên sử dụng bằng việc lụa chọn Icon cấp độ điểm.
+		Để kích hoạt chức năng này, bạn phải kích hoạt Addon Hệ thống điểm.
+	</description>
+	<description xml:lang="es">
+		Usted puede entregar puntos a las acciones de escribir/eliminar/agregar comentarios/eliminar comentarios.
+		Usted también puede mostrar el ícono de punto delande del nombre del usuario seleccionando el nivel sobre cada puntos.
+		Pero para activar esas funciones, Usted necesita activar addon relacionado a los puntos.
+	</description>
+	<description xml:lang="ru">
+		Вы можете назначать поинты за написание/удаление/добавление комментариев/удаление комментариев.
+		Вы также можете отображать икнку поинтов напротив имени пользователя, установив уровени для поинтов.
+		Но чтобы включить эти функции, Вам надо активировать аддоны, относящиеся к поинтам.
+	</description>
+	<description xml:lang="zh-TW">
+		可在發表、刪除文章及回覆時，付出相對應的點數。
+		也能以點數設置等級，並在用戶名稱前顯示等級圖示。
+		但是必須先啟用點數系統才能使用。
+	</description>
+	<version>1.7</version>
+	<date>2013-11-27</date>
+	<category>member</category>
 
-    <author email_address="developers@xpressengine.com" link="http://xpressengine.com/">
-        <name xml:lang="ko">NAVER</name>
-        <name xml:lang="vi">NAVER</name>
-        <name xml:lang="zh-CN">NAVER</name>
-        <name xml:lang="jp">NAVER</name>
-        <name xml:lang="en">NAVER</name>
-        <name xml:lang="es">NAVER</name>
-        <name xml:lang="ru">NAVER</name>
-        <name xml:lang="zh-TW">NAVER</name>
-        <name xml:lang="tr">NAVER</name>
-    </author>
+	<author email_address="developers@xpressengine.com" link="http://xpressengine.com/">
+		<name xml:lang="ko">NAVER</name>
+		<name xml:lang="vi">NAVER</name>
+		<name xml:lang="zh-CN">NAVER</name>
+		<name xml:lang="jp">NAVER</name>
+		<name xml:lang="en">NAVER</name>
+		<name xml:lang="es">NAVER</name>
+		<name xml:lang="ru">NAVER</name>
+		<name xml:lang="zh-TW">NAVER</name>
+		<name xml:lang="tr">NAVER</name>
+	</author>
 </module>

--- a/modules/point/conf/module.xml
+++ b/modules/point/conf/module.xml
@@ -2,15 +2,16 @@
 <module>
 	<grants />
 	<permissions>
-		<permission action="procPointAdminInsertPointModuleConfig" target="manager" />
+		<permission action="getMembersPointInfo" target="member" />
+		<permission action="procPointAdminInsertPointModuleConfig" target="manager" check_var="target_module_srl" />
 	</permissions>
 	<actions>
 		<action name="getMembersPointInfo" type="model" />
-
-		<!-- admin -->
+		
 		<action name="dispPointAdminConfig" type="view" admin_index="true" menu_name="point" menu_index="true" />
 		<action name="dispPointAdminModuleConfig" type="view" menu_name="point" />
 		<action name="dispPointAdminPointList" type="view" menu_name="point" />
+		
 		<action name="procPointAdminInsertConfig" type="controller" ruleset="insertConfig" />
 		<action name="procPointAdminInsertModuleConfig" type="controller" />
 		<action name="procPointAdminUpdatePoint" type="controller" ruleset="updatePoint" />

--- a/modules/point/conf/module.xml
+++ b/modules/point/conf/module.xml
@@ -16,9 +16,9 @@
 		<action name="procPointAdminInsertModuleConfig" type="controller" />
 		<action name="procPointAdminUpdatePoint" type="controller" ruleset="updatePoint" />
 		<action name="procPointAdminInsertPointModuleConfig" type="controller" />
+		<action name="procPointAdminReCal" type="controller" />
 		<action name="procPointAdminApplyPoint" type="controller" />
 		<action name="procPointAdminReset" type="controller" />
-		<action name="procPointAdminReCal" type="controller" />
 	</actions>
 	<menus>
 		<menu name="point">

--- a/modules/poll/conf/info.xml
+++ b/modules/poll/conf/info.xml
@@ -1,36 +1,36 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module version="0.2">
-    <title xml:lang="ko">설문</title>
-    <title xml:lang="zh-CN">投票系统</title>
-    <title xml:lang="jp">アンケート</title>
-    <title xml:lang="en">Poll</title>
-    <title xml:lang="vi">Bình chọn, Thăm dò</title>
-    <title xml:lang="es">Encuesta</title>
-    <title xml:lang="ru">Опрос</title>
-    <title xml:lang="zh-TW">投票調查</title>
-    <title xml:lang="tr">Oylama</title>
-    <description xml:lang="ko">설문조사 관리를 위한 모듈입니다.</description>
-    <description xml:lang="zh-CN">管理投票调查的模块。</description>
-    <description xml:lang="jp">アンケート管理モジュール</description>
-    <description xml:lang="en">This module is for managering polls.</description>
-    <description xml:lang="vi">Module này quản lý những bình chọn và thăm dò.</description>
-    <description xml:lang="es">Este módulo es para manejar las encuestas.</description>
-    <description xml:lang="ru">Этот модуль служит для управления опросами.</description>
-    <description xml:lang="zh-TW">管理投票調查的模組。</description>
-    <description xml:lang="tr">Oylamaları düzenlemek için kullanılan modüldür.</description>
-    <version>2.0</version>
-    <date>2015-06-09</date>
-    <category>content</category>
+	<title xml:lang="ko">설문</title>
+	<title xml:lang="zh-CN">投票系统</title>
+	<title xml:lang="jp">アンケート</title>
+	<title xml:lang="en">Poll</title>
+	<title xml:lang="vi">Bình chọn, Thăm dò</title>
+	<title xml:lang="es">Encuesta</title>
+	<title xml:lang="ru">Опрос</title>
+	<title xml:lang="zh-TW">投票調查</title>
+	<title xml:lang="tr">Oylama</title>
+	<description xml:lang="ko">설문조사 관리를 위한 모듈입니다.</description>
+	<description xml:lang="zh-CN">管理投票调查的模块。</description>
+	<description xml:lang="jp">アンケート管理モジュール</description>
+	<description xml:lang="en">This module is for managering polls.</description>
+	<description xml:lang="vi">Module này quản lý những bình chọn và thăm dò.</description>
+	<description xml:lang="es">Este módulo es para manejar las encuestas.</description>
+	<description xml:lang="ru">Этот модуль служит для управления опросами.</description>
+	<description xml:lang="zh-TW">管理投票調查的模組。</description>
+	<description xml:lang="tr">Oylamaları düzenlemek için kullanılan modüldür.</description>
+	<version>2.0</version>
+	<date>2015-06-09</date>
+	<category>content</category>
 
-    <author email_address="developers@xpressengine.com" link="http://xpressengine.com/">
-        <name xml:lang="ko">NAVER</name>
-        <name xml:lang="vi">NAVER</name>
-        <name xml:lang="zh-CN">NAVER</name>
-        <name xml:lang="jp">NAVER</name>
-        <name xml:lang="en">NAVER</name>
-        <name xml:lang="es">NAVER</name>
-        <name xml:lang="ru">NAVER</name>
-        <name xml:lang="zh-TW">NAVER</name>
-        <name xml:lang="tr">NAVER</name>
-    </author>
+	<author email_address="developers@xpressengine.com" link="http://xpressengine.com/">
+		<name xml:lang="ko">NAVER</name>
+		<name xml:lang="vi">NAVER</name>
+		<name xml:lang="zh-CN">NAVER</name>
+		<name xml:lang="jp">NAVER</name>
+		<name xml:lang="en">NAVER</name>
+		<name xml:lang="es">NAVER</name>
+		<name xml:lang="ru">NAVER</name>
+		<name xml:lang="zh-TW">NAVER</name>
+		<name xml:lang="tr">NAVER</name>
+	</author>
 </module>

--- a/modules/poll/conf/module.xml
+++ b/modules/poll/conf/module.xml
@@ -1,7 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <module>
 	<grants />
-	<permissions />
+	<permissions>
+		<permission action="procPollInsertItem" target="member" />
+		<permission action="procPollDeleteItem" target="member" />
+		<permission action="procPollGetList" target="root" />
+	</permissions>
 	<actions>
 		<action name="getPollstatus" type="model" />
 		<action name="getPollinfo" type="model" />
@@ -18,11 +22,12 @@
 		<action name="dispPollAdminList" type="view" admin_index="true" menu_name="poll" menu_index="true" />
 		<action name="dispPollAdminResult" type="view" />
 		<action name="dispPollAdminConfig" type="view" />
+		
 		<action name="getPollAdminTarget" type="model" />
 		
+		<action name="procPollAdminAddCart" type="controller" />
 		<action name="procPollAdminDeleteChecked" type="controller" ruleset="deleteChecked" />
 		<action name="procPollAdminInsertConfig" type="controller" ruleset="insertConfig" />
-		<action name="procPollAdminAddCart" type="controller" />
 	</actions>
 	<menus>
 		<menu name="poll">

--- a/modules/poll/conf/module.xml
+++ b/modules/poll/conf/module.xml
@@ -3,23 +3,23 @@
 	<grants />
 	<permissions />
 	<actions>
+		<action name="getPollstatus" type="model" />
+		<action name="getPollinfo" type="model" />
+		<action name="getPollitemInfo" type="model" />
 		<action name="getPollGetColorsetList" type="model" />
 		
-        <action name="getPollstatus" type="model" />
-        <action name="getPollinfo" type="model" />
-        <action name="getPollitemInfo" type="model" />
-        <action name="procPollInsert" type="controller" />
-        <action name="procPollInsertItem" type="controller" />
-        <action name="procPollDeleteItem" type="controller" />
-        <action name="procPoll" type="controller" ruleset="poll" />
-        <action name="procPollViewResult" type="controller" />
-        <action name="procPollGetList" type="controller" />
-
-		<!-- admin -->
+		<action name="procPollInsert" type="controller" />
+		<action name="procPollInsertItem" type="controller" />
+		<action name="procPollDeleteItem" type="controller" />
+		<action name="procPoll" type="controller" ruleset="poll" />
+		<action name="procPollViewResult" type="controller" />
+		<action name="procPollGetList" type="controller" />
+		
 		<action name="dispPollAdminList" type="view" admin_index="true" menu_name="poll" menu_index="true" />
 		<action name="dispPollAdminResult" type="view" />
 		<action name="dispPollAdminConfig" type="view" />
 		<action name="getPollAdminTarget" type="model" />
+		
 		<action name="procPollAdminDeleteChecked" type="controller" ruleset="deleteChecked" />
 		<action name="procPollAdminInsertConfig" type="controller" ruleset="insertConfig" />
 		<action name="procPollAdminAddCart" type="controller" />

--- a/modules/rss/conf/info.xml
+++ b/modules/rss/conf/info.xml
@@ -1,36 +1,36 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module version="0.2">
-    <title xml:lang="ko">RSS</title>
-    <title xml:lang="zh-CN">整站RSS</title>
-    <title xml:lang="jp">RSS</title>
-    <title xml:lang="en">RSS</title>
-    <title xml:lang="vi">RSS</title>
-    <title xml:lang="es">RSS</title>
-    <title xml:lang="ru">RSS</title>
-    <title xml:lang="zh-TW">RSS</title>
-    <title xml:lang="tr">RSS</title>
-    <description xml:lang="ko">RSS 출력을 담당</description>
-    <description xml:lang="zh-CN">负责输出RSS的模块。</description>
-    <description xml:lang="jp">RSS出力を担うモジュールです。</description>
-    <description xml:lang="en">This modules is for printing RSS.</description>
-    <description xml:lang="vi">Module này dành cho in ấn RSS.</description>
-    <description xml:lang="es">Este módulo es para imprimir RSS.</description>
-    <description xml:lang="ru">Этот модуль служит для печати RSS.</description>
-    <description xml:lang="zh-TW">負責輸出 RSS 的模組。</description>
-    <description xml:lang="tr">Bu modül RSS çıktısı almak içindir.</description>
-    <version>1.7</version>
-    <date>2013-11-27</date>
-    <category>utility</category>
+	<title xml:lang="ko">RSS</title>
+	<title xml:lang="zh-CN">整站RSS</title>
+	<title xml:lang="jp">RSS</title>
+	<title xml:lang="en">RSS</title>
+	<title xml:lang="vi">RSS</title>
+	<title xml:lang="es">RSS</title>
+	<title xml:lang="ru">RSS</title>
+	<title xml:lang="zh-TW">RSS</title>
+	<title xml:lang="tr">RSS</title>
+	<description xml:lang="ko">RSS 출력을 담당</description>
+	<description xml:lang="zh-CN">负责输出RSS的模块。</description>
+	<description xml:lang="jp">RSS出力を担うモジュールです。</description>
+	<description xml:lang="en">This modules is for printing RSS.</description>
+	<description xml:lang="vi">Module này dành cho in ấn RSS.</description>
+	<description xml:lang="es">Este módulo es para imprimir RSS.</description>
+	<description xml:lang="ru">Этот модуль служит для печати RSS.</description>
+	<description xml:lang="zh-TW">負責輸出 RSS 的模組。</description>
+	<description xml:lang="tr">Bu modül RSS çıktısı almak içindir.</description>
+	<version>1.7</version>
+	<date>2013-11-27</date>
+	<category>utility</category>
 
-    <author email_address="developers@xpressengine.com" link="http://xpressengine.com/">
-        <name xml:lang="ko">NAVER</name>
-        <name xml:lang="vi">NAVER</name>
-        <name xml:lang="zh-CN">NAVER</name>
-        <name xml:lang="jp">NAVER</name>
-        <name xml:lang="en">NAVER</name>
-        <name xml:lang="es">NAVER</name>
-        <name xml:lang="ru">NAVER</name>
-        <name xml:lang="zh-TW">NAVER</name>
-        <name xml:lang="tr">NAVER</name>
-    </author>
+	<author email_address="developers@xpressengine.com" link="http://xpressengine.com/">
+		<name xml:lang="ko">NAVER</name>
+		<name xml:lang="vi">NAVER</name>
+		<name xml:lang="zh-CN">NAVER</name>
+		<name xml:lang="jp">NAVER</name>
+		<name xml:lang="en">NAVER</name>
+		<name xml:lang="es">NAVER</name>
+		<name xml:lang="ru">NAVER</name>
+		<name xml:lang="zh-TW">NAVER</name>
+		<name xml:lang="tr">NAVER</name>
+	</author>
 </module>

--- a/modules/rss/conf/module.xml
+++ b/modules/rss/conf/module.xml
@@ -2,31 +2,30 @@
 <module>
 	<grants />
 	<permissions>
-		<permission action="procRssAdminInsertModuleConfig" target="manager" />
+		<permission action="procRssAdminInsertModuleConfig" target="manager" check_var="target_module_srl" />
 	</permissions>
 	<actions>
-		<action name="dispRssAdminIndex" type="view" index="true" admin_index="true" menu_name="rss" menu_index="true" />
 		<action name="rss" type="view" />
 		<action name="atom" type="view" />
-
-		<!-- admin -->
+		
+		<action name="dispRssAdminIndex" type="view" index="true" admin_index="true" menu_name="rss" menu_index="true" />
 		<action name="procRssAdminInsertConfig" type="controller" ruleset="insertRssConfig" />
 		<action name="procRssAdminDeleteFeedImage" type="controller" />
 		<action name="procRssAdminInsertModuleConfig" type="controller" />
 	</actions>
 	<menus>
 		<menu name="rss">
-			<title xml:lang="en">RSS</title>
-			<title xml:lang="ko">RSS</title>
-			<title xml:lang="zh-CN">RSS</title>
-			<title xml:lang="jp">RSS</title>
-			<title xml:lang="es">RSS</title>
-			<title xml:lang="ru">RSS</title>
-			<title xml:lang="fr">RSS</title>
-			<title xml:lang="zh-TW">RSS</title>
-			<title xml:lang="vi">RSS</title>
-			<title xml:lang="mn">RSS</title>
-			<title xml:lang="tr">RSS</title>
+		<title xml:lang="en">RSS</title>
+		<title xml:lang="ko">RSS</title>
+		<title xml:lang="zh-CN">RSS</title>
+		<title xml:lang="jp">RSS</title>
+		<title xml:lang="es">RSS</title>
+		<title xml:lang="ru">RSS</title>
+		<title xml:lang="fr">RSS</title>
+		<title xml:lang="zh-TW">RSS</title>
+		<title xml:lang="vi">RSS</title>
+		<title xml:lang="mn">RSS</title>
+		<title xml:lang="tr">RSS</title>
 		</menu>
 	</menus>
 </module>

--- a/modules/session/conf/info.xml
+++ b/modules/session/conf/info.xml
@@ -1,50 +1,51 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module version="0.2">
-    <title xml:lang="ko">세션 관리자</title>
-    <title xml:lang="jp">セッション管理</title>
-    <title xml:lang="en">Session</title>
-    <title xml:lang="vi">Session</title>
-    <title xml:lang="zh-CN">会话管理</title>
-    <title xml:lang="zh-TW">SESSION管理</title>
-    <title xml:lang="tr">Oturum</title>
-    <description xml:lang="ko">
-        접속자의 세션을 관리합니다.
-        기본적인 세션 설정과 사용뿐 아니라 세션 정보를 이용하여 접속자등의 세션 기반의 정보를 제공하는 기능도 있습니다.
-    </description>
-    <description xml:lang="jp">
-        アクセスユーザのセッションを管理します。
-        基本的セッション設定はもちろん、セッション情報を利用してアクセスユーザなどのセッション基盤の情報を提供する機能も持っています。
-    </description>
-    <description xml:lang="en">
-        This module manages session data.
-        It will allow you to get session setting, usage, and session-level data such as visitors.
-    </description>
-    <description xml:lang="tr">
-        Bu modül oturum verisini yönetir.
-        Siz sadece oturum ayarı veya kullanımı değil ayrıca oturum bilgilerini kullanan kullanıcıların oturum-seviyesi verilerini de elde edeceksiniz.
-    </description>
-    <description xml:lang="vi">Module này quản lý dữ liệu Session.
-        Bạn không phải chỉ duy nhất thiết lập Session hay sử dụng, Cấp độ của Session phụ thuộc vào lượng người truy cập trên Website của bạn.
-    </description>
-    <description xml:lang="zh-CN">
-        管理在线会员会话(session)功能的模块。
-        提供最基本的会话设置及使用，并且还可以获得基于会话功能的在线会员信息。
-    </description>
-    <description xml:lang="zh-TW">
-        管理線上會員SESSION功能的模組。
-        提供最基本的SESSION設置和使用，且還可以獲得此功能的線上會員資料。
-    </description>
-    <version>1.7</version>
-    <date>2013-11-27</date>
-    <category>system</category>
+	<title xml:lang="ko">세션 관리자</title>
+	<title xml:lang="jp">セッション管理</title>
+	<title xml:lang="en">Session</title>
+	<title xml:lang="vi">Session</title>
+	<title xml:lang="zh-CN">会话管理</title>
+	<title xml:lang="zh-TW">SESSION管理</title>
+	<title xml:lang="tr">Oturum</title>
+	<description xml:lang="ko">
+		접속자의 세션을 관리합니다.
+		기본적인 세션 설정과 사용뿐 아니라 세션 정보를 이용하여 접속자등의 세션 기반의 정보를 제공하는 기능도 있습니다.
+	</description>
+	<description xml:lang="jp">
+		アクセスユーザのセッションを管理します。
+		基本的セッション設定はもちろん、セッション情報を利用してアクセスユーザなどのセッション基盤の情報を提供する機能も持っています。
+	</description>
+	<description xml:lang="en">
+		This module manages session data.
+		It will allow you to get session setting, usage, and session-level data such as visitors.
+	</description>
+	<description xml:lang="tr">
+		Bu modül oturum verisini yönetir.
+		Siz sadece oturum ayarı veya kullanımı değil ayrıca oturum bilgilerini kullanan kullanıcıların oturum-seviyesi verilerini de elde edeceksiniz.
+	</description>
+	<description xml:lang="vi">
+		Module này quản lý dữ liệu Session.
+		Bạn không phải chỉ duy nhất thiết lập Session hay sử dụng, Cấp độ của Session phụ thuộc vào lượng người truy cập trên Website của bạn.
+	</description>
+	<description xml:lang="zh-CN">
+		管理在线会员会话(session)功能的模块。
+		提供最基本的会话设置及使用，并且还可以获得基于会话功能的在线会员信息。
+	</description>
+	<description xml:lang="zh-TW">
+		管理線上會員SESSION功能的模組。
+		提供最基本的SESSION設置和使用，且還可以獲得此功能的線上會員資料。
+	</description>
+	<version>1.7</version>
+	<date>2013-11-27</date>
+	<category>system</category>
 
-    <author email_address="developers@xpressengine.com" link="http://xpressengine.com/">
-        <name xml:lang="ko">NAVER</name>
-        <name xml:lang="vi">NAVER</name>
-        <name xml:lang="jp">NAVER</name>
-        <name xml:lang="en">NAVER</name>
-        <name xml:lang="zh-CN">NAVER</name>
-        <name xml:lang="zh-TW">NAVER</name>
-        <name xml:lang="tr">NAVER</name>
-    </author>
+	<author email_address="developers@xpressengine.com" link="http://xpressengine.com/">
+		<name xml:lang="ko">NAVER</name>
+		<name xml:lang="vi">NAVER</name>
+		<name xml:lang="jp">NAVER</name>
+		<name xml:lang="en">NAVER</name>
+		<name xml:lang="zh-CN">NAVER</name>
+		<name xml:lang="zh-TW">NAVER</name>
+		<name xml:lang="tr">NAVER</name>
+	</author>
 </module>

--- a/modules/session/conf/module.xml
+++ b/modules/session/conf/module.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <module>
-    <grants />
-    <permissions />
-    <actions>
-        <action name="dispSessionAdminIndex" type="view" admin_index="true" />
-        <action name="procSessionAdminClear" type="controller" />
-    </actions>
+	<grants />
+	<permissions />
+	<actions>
+		<action name="dispSessionAdminIndex" type="view" admin_index="true" />
+		<action name="procSessionAdminClear" type="controller" />
+	</actions>
 </module>

--- a/modules/spamfilter/conf/info.xml
+++ b/modules/spamfilter/conf/info.xml
@@ -1,36 +1,36 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module version="0.2">
-    <title xml:lang="ko">스팸필터</title>
-    <title xml:lang="zh-CN">垃圾过滤</title>
-    <title xml:lang="en">Spam Filter</title>
-    <title xml:lang="vi">Bộ lọc Spam</title>
-    <title xml:lang="es">Filtro de Spam</title>
-    <title xml:lang="jp">スパムフィルター</title>
-    <title xml:lang="ru">Фильтр спама</title>
-    <title xml:lang="tr">Spam Filtreleyici</title>
-    <title xml:lang="zh-TW">垃圾過濾</title>
-    <description xml:lang="ko">XE의 기본 스팸필터입니다.</description>
-    <description xml:lang="zh-CN">XE的基本垃圾过滤模块。</description>
-    <description xml:lang="en">The default spam filter of XE.</description>
-    <description xml:lang="vi">Bộ lọc Spam mặc định của XE.</description>
-    <description xml:lang="es">Filtro de Span predefinido de XE.</description>
-    <description xml:lang="jp">XEのスパムフィルターです。</description>
-    <description xml:lang="ru">Стандартный фильтр спама XE.</description>
-    <description xml:lang="zh-TW">XE的基本垃圾過濾模組。</description>
-    <description xml:lang="tr">XE\'nin varsayılan spam filtreleyicisidir.</description>
-    <version>1.7</version>
-    <date>2013-11-27</date>
-    <category>accessory</category>
+	<title xml:lang="ko">스팸필터</title>
+	<title xml:lang="zh-CN">垃圾过滤</title>
+	<title xml:lang="en">Spam Filter</title>
+	<title xml:lang="vi">Bộ lọc Spam</title>
+	<title xml:lang="es">Filtro de Spam</title>
+	<title xml:lang="jp">スパムフィルター</title>
+	<title xml:lang="ru">Фильтр спама</title>
+	<title xml:lang="tr">Spam Filtreleyici</title>
+	<title xml:lang="zh-TW">垃圾過濾</title>
+	<description xml:lang="ko">XE의 기본 스팸필터입니다.</description>
+	<description xml:lang="zh-CN">XE的基本垃圾过滤模块。</description>
+	<description xml:lang="en">The default spam filter of XE.</description>
+	<description xml:lang="vi">Bộ lọc Spam mặc định của XE.</description>
+	<description xml:lang="es">Filtro de Span predefinido de XE.</description>
+	<description xml:lang="jp">XEのスパムフィルターです。</description>
+	<description xml:lang="ru">Стандартный фильтр спама XE.</description>
+	<description xml:lang="zh-TW">XE的基本垃圾過濾模組。</description>
+	<description xml:lang="tr">XE\'nin varsayılan spam filtreleyicisidir.</description>
+	<version>1.7</version>
+	<date>2013-11-27</date>
+	<category>accessory</category>
 
-    <author email_address="developers@xpressengine.com" link="http://xpressengine.com/">
-        <name xml:lang="ko">NAVER</name>
-        <name xml:lang="vi">NAVER</name>
-        <name xml:lang="zh-CN">NAVER</name>
-        <name xml:lang="en">NAVER</name>
-        <name xml:lang="es">NAVER</name>
-        <name xml:lang="jp">NAVER</name>
-        <name xml:lang="ru">NAVER</name>
-        <name xml:lang="zh-TW">NAVER</name>
-        <name xml:lang="tr">NAVER</name>
-    </author>
+	<author email_address="developers@xpressengine.com" link="http://xpressengine.com/">
+		<name xml:lang="ko">NAVER</name>
+		<name xml:lang="vi">NAVER</name>
+		<name xml:lang="zh-CN">NAVER</name>
+		<name xml:lang="en">NAVER</name>
+		<name xml:lang="es">NAVER</name>
+		<name xml:lang="jp">NAVER</name>
+		<name xml:lang="ru">NAVER</name>
+		<name xml:lang="zh-TW">NAVER</name>
+		<name xml:lang="tr">NAVER</name>
+	</author>
 </module>

--- a/modules/spamfilter/conf/module.xml
+++ b/modules/spamfilter/conf/module.xml
@@ -6,10 +6,9 @@
 		<action name="dispSpamfilterAdminDeniedIPList" type="view" admin_index="true" menu_name="spamFilter" menu_index="true" />
 		<action name="dispSpamfilterAdminDeniedWordList" type="view" menu_name="spamFilter" />
 		<action name="dispSpamfilterAdminConfigBlock" type="view" menu_name="spamFilter" />
-
+		
 		<action name="procSpamfilterAdminInsertDeniedIP" type="controller" />
 		<action name="procSpamfilterAdminInsertDeniedWord" type="controller" />
-
 		<action name="procSpamfilterAdminDeleteDeniedIP" type="controller" />
 		<action name="procSpamfilterAdminDeleteDeniedWord" type="controller" />
 		<action name="procSpamfilterAdminInsertConfig" type="controller" ruleset="insertConfig" />

--- a/modules/spamfilter/conf/module.xml
+++ b/modules/spamfilter/conf/module.xml
@@ -8,8 +8,8 @@
 		<action name="dispSpamfilterAdminConfigBlock" type="view" menu_name="spamFilter" />
 		
 		<action name="procSpamfilterAdminInsertDeniedIP" type="controller" />
-		<action name="procSpamfilterAdminInsertDeniedWord" type="controller" />
 		<action name="procSpamfilterAdminDeleteDeniedIP" type="controller" />
+		<action name="procSpamfilterAdminInsertDeniedWord" type="controller" />
 		<action name="procSpamfilterAdminDeleteDeniedWord" type="controller" />
 		<action name="procSpamfilterAdminInsertConfig" type="controller" ruleset="insertConfig" />
 	</actions>

--- a/modules/tag/conf/info.xml
+++ b/modules/tag/conf/info.xml
@@ -1,36 +1,36 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module version="0.2">
-    <title xml:lang="ko">꼬리표</title>
-    <title xml:lang="zh-CN">标签</title>
-    <title xml:lang="jp">タグ</title>
-    <title xml:lang="en">Tag</title>
-    <title xml:lang="vi">Tag</title>
-    <title xml:lang="es">Etiqueta</title>
-    <title xml:lang="ru">Теги</title>
-    <title xml:lang="zh-TW">標籤</title>
-    <title xml:lang="tr">Etiket</title>
-    <description xml:lang="ko">꼬리표 관리</description>
-    <description xml:lang="zh-CN">标签管理模块。</description>
-    <description xml:lang="jp">タグ管理用のモジュールです。</description>
-    <description xml:lang="en">Module for managing tags.</description>
-    <description xml:lang="vi">Module quản lý Tag.</description>
-    <description xml:lang="es">Módulo para manejar etiquetas.</description>
-    <description xml:lang="ru">Модуль для управления тегами.</description>
-    <description xml:lang="zh-TW">標籤管理模組。</description>
-    <description xml:lang="tr">Etiketleri yönetme modülü.</description>
-    <version>1.7</version>
-    <date>2013-11-27</date>
-    <category>content</category>
+	<title xml:lang="ko">꼬리표</title>
+	<title xml:lang="zh-CN">标签</title>
+	<title xml:lang="jp">タグ</title>
+	<title xml:lang="en">Tag</title>
+	<title xml:lang="vi">Tag</title>
+	<title xml:lang="es">Etiqueta</title>
+	<title xml:lang="ru">Теги</title>
+	<title xml:lang="zh-TW">標籤</title>
+	<title xml:lang="tr">Etiket</title>
+	<description xml:lang="ko">꼬리표 관리</description>
+	<description xml:lang="zh-CN">标签管理模块。</description>
+	<description xml:lang="jp">タグ管理用のモジュールです。</description>
+	<description xml:lang="en">Module for managing tags.</description>
+	<description xml:lang="vi">Module quản lý Tag.</description>
+	<description xml:lang="es">Módulo para manejar etiquetas.</description>
+	<description xml:lang="ru">Модуль для управления тегами.</description>
+	<description xml:lang="zh-TW">標籤管理模組。</description>
+	<description xml:lang="tr">Etiketleri yönetme modülü.</description>
+	<version>1.7</version>
+	<date>2013-11-27</date>
+	<category>content</category>
 
-    <author email_address="developers@xpressengine.com" link="http://xpressengine.com/">
-        <name xml:lang="ko">NAVER</name>
-        <name xml:lang="vi">NAVER</name>
-        <name xml:lang="zh-CN">NAVER</name>
-        <name xml:lang="jp">NAVER</name>
-        <name xml:lang="en">NAVER</name>
-        <name xml:lang="es">NAVER</name>
-        <name xml:lang="ru">NAVER</name>
-        <name xml:lang="zh-TW">NAVER</name>
-        <name xml:lang="tr">NAVER</name>
-    </author>
+	<author email_address="developers@xpressengine.com" link="http://xpressengine.com/">
+		<name xml:lang="ko">NAVER</name>
+		<name xml:lang="vi">NAVER</name>
+		<name xml:lang="zh-CN">NAVER</name>
+		<name xml:lang="jp">NAVER</name>
+		<name xml:lang="en">NAVER</name>
+		<name xml:lang="es">NAVER</name>
+		<name xml:lang="ru">NAVER</name>
+		<name xml:lang="zh-TW">NAVER</name>
+		<name xml:lang="tr">NAVER</name>
+	</author>
 </module>

--- a/modules/trash/conf/info.xml
+++ b/modules/trash/conf/info.xml
@@ -1,23 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module version="0.2">
-    <title xml:lang="ko">휴지통</title>
-    <title xml:lang="en">trash</title>
-    <title xml:lang="jp">ゴミ箱</title>
-    <title xml:lang="zh-TW">回收桶</title>
-    <description xml:lang="ko">문서, 댓글 등을 완전히 삭제하지 않고 복구 가능한 상태로 만들어 관리합니다.</description>
-    <description xml:lang="jp">ドミュメンと、コメントなどを完全に削除せずに復旧可能な状態に作って管理します。</description>
-    <version>1.7</version>
-    <date>2013-11-27</date>
-    <category>content</category>
-    <author email_address="developers@xpressengine.com" link="http://xpressengine.com/">
-        <name xml:lang="ko">NAVER</name>
-        <name xml:lang="en">NAVER</name>
-        <name xml:lang="vi">NAVER</name>
-        <name xml:lang="es">NAVER</name>
-        <name xml:lang="zh-CN">NAVER</name>
-        <name xml:lang="jp">NAVER</name>
-        <name xml:lang="ru">NAVER</name>
-        <name xml:lang="zh-TW">NAVER</name>
-        <name xml:lang="tr">NAVER</name>
-    </author>
+	<title xml:lang="ko">휴지통</title>
+	<title xml:lang="en">trash</title>
+	<title xml:lang="jp">ゴミ箱</title>
+	<title xml:lang="zh-TW">回收桶</title>
+	<description xml:lang="ko">문서, 댓글 등을 완전히 삭제하지 않고 복구 가능한 상태로 만들어 관리합니다.</description>
+	<description xml:lang="jp">ドミュメンと、コメントなどを完全に削除せずに復旧可能な状態に作って管理します。</description>
+	<version>1.7</version>
+	<date>2013-11-27</date>
+	<category>content</category>
+	
+	<author email_address="developers@xpressengine.com" link="http://xpressengine.com/">
+		<name xml:lang="ko">NAVER</name>
+		<name xml:lang="en">NAVER</name>
+		<name xml:lang="vi">NAVER</name>
+		<name xml:lang="es">NAVER</name>
+		<name xml:lang="zh-CN">NAVER</name>
+		<name xml:lang="jp">NAVER</name>
+		<name xml:lang="ru">NAVER</name>
+		<name xml:lang="zh-TW">NAVER</name>
+		<name xml:lang="tr">NAVER</name>
+	</author>
 </module>

--- a/modules/trash/conf/module.xml
+++ b/modules/trash/conf/module.xml
@@ -1,18 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <module>
 	<grants />
-	<permissions>
-		<permission action="dispTrashAdminList" target="manager" />
-		<permission action="procTrashAdminRestore" target="manager" />
-	</permissions>
+	<permissions />
 	<actions>
 		<action name="dispTrashAdminList" type="view" admin_index="true" menu_name="trash" menu_index="true" />
-
+		<action name="dispTrashAdminView" type="view" menu_name="trash" />
+		
 		<action name="procTrashAdminEmptyTrash" type="controller" ruleset="emptyTrash" />
 		<action name="procTrashAdminRestore" type="controller" />
 		<action name="procTrashAdminGetList" type="controller" />
-
-		<action name="dispTrashAdminView" type="view" />
 	</actions>
 	<menus>
 		<menu name="trash">

--- a/modules/widget/conf/info.xml
+++ b/modules/widget/conf/info.xml
@@ -1,36 +1,36 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module version="0.2">
-    <title xml:lang="ko">위젯</title>
-    <title xml:lang="zh-CN">控件管理</title>
-    <title xml:lang="jp">ウィジェット</title>
-    <title xml:lang="en">Widget</title>
-    <title xml:lang="vi">Widget</title>
-    <title xml:lang="es">Widget</title>
-    <title xml:lang="ru">Виджеты</title>
-    <title xml:lang="zh-TW">Widget</title>
-    <title xml:lang="tr">Görsel Bileşen (widget)</title>
-    <description xml:lang="ko">위젯 관리</description>
-    <description xml:lang="zh-CN">控件管理模块。</description>
-    <description xml:lang="jp">ウィジェット管理モジュール</description>
-    <description xml:lang="en">Module for managing widgets.</description>
-    <description xml:lang="vi">Module dành cho quản lý Widget.</description>
-    <description xml:lang="es">Módulo para el manejo de widgets.</description>
-    <description xml:lang="ru">Модуль для управления виджетами.</description>
-    <description xml:lang="zh-TW">Widget 管理模組。</description>
-    <description xml:lang="tr">Widgetları yönetmek için kullanılan modüldür.</description>
-    <version>1.7</version>
-    <date>2013-11-27</date>
-    <category>construction</category>
+	<title xml:lang="ko">위젯</title>
+	<title xml:lang="zh-CN">控件管理</title>
+	<title xml:lang="jp">ウィジェット</title>
+	<title xml:lang="en">Widget</title>
+	<title xml:lang="vi">Widget</title>
+	<title xml:lang="es">Widget</title>
+	<title xml:lang="ru">Виджеты</title>
+	<title xml:lang="zh-TW">Widget</title>
+	<title xml:lang="tr">Görsel Bileşen (widget)</title>
+	<description xml:lang="ko">위젯 관리</description>
+	<description xml:lang="zh-CN">控件管理模块。</description>
+	<description xml:lang="jp">ウィジェット管理モジュール</description>
+	<description xml:lang="en">Module for managing widgets.</description>
+	<description xml:lang="vi">Module dành cho quản lý Widget.</description>
+	<description xml:lang="es">Módulo para el manejo de widgets.</description>
+	<description xml:lang="ru">Модуль для управления виджетами.</description>
+	<description xml:lang="zh-TW">Widget 管理模組。</description>
+	<description xml:lang="tr">Widgetları yönetmek için kullanılan modüldür.</description>
+	<version>1.7</version>
+	<date>2013-11-27</date>
+	<category>construction</category>
 
-    <author email_address="developers@xpressengine.com" link="http://xpressengine.com/">
-        <name xml:lang="ko">NAVER</name>
-        <name xml:lang="vi">NAVER</name>
-        <name xml:lang="zh-CN">NAVER</name>
-        <name xml:lang="jp">NAVER</name>
-        <name xml:lang="en">NAVER</name>
-        <name xml:lang="es">NAVER</name>
-        <name xml:lang="ru">NAVER</name>
-        <name xml:lang="zh-TW">NAVER</name>
-        <name xml:lang="tr">NAVER</name>
-    </author>
+	<author email_address="developers@xpressengine.com" link="http://xpressengine.com/">
+		<name xml:lang="ko">NAVER</name>
+		<name xml:lang="vi">NAVER</name>
+		<name xml:lang="zh-CN">NAVER</name>
+		<name xml:lang="jp">NAVER</name>
+		<name xml:lang="en">NAVER</name>
+		<name xml:lang="es">NAVER</name>
+		<name xml:lang="ru">NAVER</name>
+		<name xml:lang="zh-TW">NAVER</name>
+		<name xml:lang="tr">NAVER</name>
+	</author>
 </module>

--- a/modules/widget/conf/module.xml
+++ b/modules/widget/conf/module.xml
@@ -4,16 +4,16 @@
 	<permissions>
 		<permission action="dispWidgetInfo" target="all-managers" />
 		<permission action="dispWidgetGenerateCode" target="root" />
-		<permission action="dispWidgetGenerateCodeInPage" target="manager" check_var="module_srl" />
-		<permission action="dispWidgetStyleGenerateCodeInPage" target="page-managers" />
+		<permission action="dispWidgetGenerateCodeInPage" target="all-managers" />
+		<permission action="dispWidgetStyleGenerateCodeInPage" target="all-managers" />
 		
 		<permission action="procWidgetGenerateCode" target="root" />
-		<permission action="procWidgetGenerateCodeInPage" target="manager" check_var="module_srl" />
+		<permission action="procWidgetGenerateCodeInPage" target="all-managers" />
 		<permission action="procWidgetInsertDocument" target="manager" check_var="module_srl" />
-		<permission action="procWidgetCopyDocument" target="manager" check_type="document" check_var="document_srl" />
 		<permission action="procWidgetDeleteDocument" target="manager" check_type="document" check_var="document_srl" />
+		<permission action="procWidgetCopyDocument" target="manager" check_type="document" check_var="document_srl" />
 		<permission action="procWidgetGetColorsetList" target="all-managers" />
-		<permission action="procWidgetStyleExtraImageUpload" target="page-managers" />
+		<permission action="procWidgetStyleExtraImageUpload" target="all-managers" />
 		
 		<permission action="dispWidgetAdminAddContent" target="manager" check_var="module_srl" />
 	</permissions>
@@ -26,14 +26,14 @@
 		<action name="procWidgetGenerateCode" type="controller" />
 		<action name="procWidgetGenerateCodeInPage" type="controller" ruleset="generateCodeInPage" />
 		<action name="procWidgetInsertDocument" type="controller" />
-		<action name="procWidgetCopyDocument" type="controller" />
 		<action name="procWidgetDeleteDocument" type="controller" />
+		<action name="procWidgetCopyDocument" type="controller" />
 		<action name="procWidgetGetColorsetList" type="controller" />
 		<action name="procWidgetStyleExtraImageUpload" type="controller" />
 		
 		<action name="dispWidgetAdminDownloadedList" type="view" admin_index="true" menu_name="installedWidget" menu_index="true" />
-		<action name="dispWidgetAdminAddContent" type="view" />
 		<action name="dispWidgetAdminGenerateCode" type="view" menu_name="installedWidget" />
+		<action name="dispWidgetAdminAddContent" type="view" />
 	</actions>
 	<menus>
 		<menu name="installedWidget">

--- a/modules/widget/conf/module.xml
+++ b/modules/widget/conf/module.xml
@@ -2,37 +2,38 @@
 <module>
 	<grants />
 	<permissions>
-		<permission action="dispWidgetGenerateCode" target="manager" />
-		<permission action="dispWidgetGenerateCodeInPage" target="manager" />
-		<permission action="dispWidgetStyleGenerateCodeInPage" target="manager" />
-		<permission action="procWidgetGenerateCode" target="manager" />
-		<permission action="procWidgetStyleGenerateCodeInPage" target="manager" />
-		<permission action="procWidgetInsertDocument" target="manager" />
-		<permission action="procWidgetCopyDocument" target="manager" />
-		<permission action="procWidgetDeleteDocument" target="manager" />
-		<permission action="procWidgetGenerateCodeInPage" target="manager" />
-		<permission action="procWidgetGetColorsetList" target="manager" />
-		<permission action="procWidgetStyleExtraImageUpload" target="manager" />
+		<permission action="dispWidgetInfo" target="all-managers" />
+		<permission action="dispWidgetGenerateCode" target="root" />
+		<permission action="dispWidgetGenerateCodeInPage" target="manager" check_var="module_srl" />
+		<permission action="dispWidgetStyleGenerateCodeInPage" target="page-managers" />
+		
+		<permission action="procWidgetGenerateCode" target="root" />
+		<permission action="procWidgetGenerateCodeInPage" target="manager" check_var="module_srl" />
+		<permission action="procWidgetInsertDocument" target="manager" check_var="module_srl" />
+		<permission action="procWidgetCopyDocument" target="manager" check_type="document" check_var="document_srl" />
+		<permission action="procWidgetDeleteDocument" target="manager" check_type="document" check_var="document_srl" />
+		<permission action="procWidgetGetColorsetList" target="all-managers" />
+		<permission action="procWidgetStyleExtraImageUpload" target="page-managers" />
+		
+		<permission action="dispWidgetAdminAddContent" target="manager" check_var="module_srl" />
 	</permissions>
 	<actions>
 		<action name="dispWidgetInfo" type="view" />
 		<action name="dispWidgetGenerateCode" type="view" />
 		<action name="dispWidgetGenerateCodeInPage" type="view" />
 		<action name="dispWidgetStyleGenerateCodeInPage" type="view" />
+		
 		<action name="procWidgetGenerateCode" type="controller" />
-		<action name="procWidgetStyleGenerateCodeInPage" type="controller" />
+		<action name="procWidgetGenerateCodeInPage" type="controller" ruleset="generateCodeInPage" />
 		<action name="procWidgetInsertDocument" type="controller" />
 		<action name="procWidgetCopyDocument" type="controller" />
 		<action name="procWidgetDeleteDocument" type="controller" />
-		<action name="procWidgetGenerateCodeInPage" type="controller" ruleset="generateCodeInPage" />
 		<action name="procWidgetGetColorsetList" type="controller" />
 		<action name="procWidgetStyleExtraImageUpload" type="controller" />
-
-		<!-- admin -->
+		
 		<action name="dispWidgetAdminDownloadedList" type="view" admin_index="true" menu_name="installedWidget" menu_index="true" />
 		<action name="dispWidgetAdminAddContent" type="view" />
 		<action name="dispWidgetAdminGenerateCode" type="view" menu_name="installedWidget" />
-
 	</actions>
 	<menus>
 		<menu name="installedWidget">


### PR DESCRIPTION
먼저 뭔가 조잡해보이는 권한 함수를 정리해보았습니다.

그리고 `<permission>`에 `check_var` 와 `check_type` 라는 속성을 추가하여 더욱 세부적인 권한 체크를 할 수 있도록 기능을 추가하였습니다.

여기서 보안 취약점으로 보이는 코드도 삭제 되었습니다.

## module.xml의 `<permission>` 속성 (추가됨)

### `check_var` = module_srl 값을 가진 parameter 이름
- 단독 사용 가능.
- 구분자 `,(콤마)` or `|@|` 가 들어 있을 경우 배열로 자동 변환됨.

`Context::get($check_var)`로 module_srl 값 (배열도 가능) 을 전달 받은 후 해당 module_srl 값을 가진 모듈의 권한 설정으로 퍼미션을 체크합니다.

### `check_type` = 모듈 이름
- 단독 사용 불가 : 반드시 `check_var` 속성이 함께 있어야 함.
- `check_var` parameter의 값이 module_srl 이 아니라 특정 모듈에서 사용하는 srl (serial) 일 경우 사용
- 들어갈 수 있는 값 : `document, comment, file, module` (기본 모듈만 지원)

`Context::get($check_var)`로 특정 모듈에서 사용하는 srl (serial) 값 (배열도 가능) 을 전달 받은 후 해당 모듈에서 module_srl 값을 조회한 다음 module_srl 값을 가진 모듈의 권한 설정으로 퍼미션을 체크합니다.



### 참고

`check_type`을 사용할 경우 아래와 같은 과정을 거쳐 module_srl 값을 가져옵니다. (예시 : document 일 경우)
```
$oDocument = getModel('document')->getDocument($document_srl);
$document_module_srl = $oDocument->get('module_srl');
$module_srl = getModel('module')->getModuleInfoByModuleSrl($document_module_srl)->module_srl;
```

## 사용 예시
`<permission action="procDocumentAddCart" target="manager" check_type="document" check_var="srls" />`

##  효과
아래 코드와 동일 합니다.
```
foreach ($module_srl_list as $module_srl)
{
	$module_info = $oModuleModel->getModuleInfoByModuleSrl($module_srl);
	if (!$module_info->module_srl)
	{
		return new Object(-1, 'msg_invalid_request');
	}
	
	$module_grant = $oModuleModel->getGrant($module_info, $logged_info);
	if (!$module_grant->manager)
	{
		return new Object(-1, 'msg_not_permitted');
	}
}
```
## 문제 해결
이 기능으로 아래와 같은 퍼미션 문제를 해결할 수 있습니다.

https://www.xetown.com/lakepark/532843

이 기능을 사용하지 않고서 해결하는 방법은 원래대로 `<permission>`을 'member'로 변경하는 방법 뿐 입니다.

## 퍼미션 타입 추가
`guest, member, manager, root` 이외에 편의상 새로운 타입이 추가 되었습니다.
예시 `<permission action="dispWidgetInfo" target="all-managers" />`

### `all-managers` : 모든 매니저
- 사이트내에서 모듈 관리 권한을 하나라도 가지고 있다면 통과 됩니다.
- 보안 정도 : `member` 보다는 높으나, 관리 권한을 일반 회원에게 주는 특이한 경우도 있어 주의해야 합니다.

### `same-managers` : 같은 모듈에 있는 모든 매니저
- 게시판 모듈에서 사용한다면 '모든 게시판 관리자'를 의미 합니다.

### `모듈이름-managers` : 해당 모듈에 있는 모든 매니저
- `page-managers` 일 경우 '모든 페이지 관리자'를 의미 합니다.
