### PR TITLE
module.xml <action>에 permission 속성 추가

### DIFF
--- a/classes/module/ModuleHandler.class.php
+++ b/classes/module/ModuleHandler.class.php
@@ -556,13 +556,14 @@ class ModuleHandler extends Handler
 			}
 
 			$forward = NULL;
+			
 			// 1. Look for the module with action name
 			if(preg_match('/^([a-z]+)([A-Z])([a-z0-9\_]+)(.*)$/', $this->act, $matches))
 			{
 				$module = strtolower($matches[2] . $matches[3]);
 				$xml_info = $oModuleModel->getModuleActionXml($module);
 
-				if($xml_info->action->{$this->act} && ((stripos($this->act, 'admin') !== FALSE) || $xml_info->action->{$this->act}->standalone != 'false'))
+				if($xml_info->action->{$this->act} && ($this->module == 'admin' || $xml_info->action->{$this->act}->standalone != 'false'))
 				{
 					$forward = new stdClass();
 					$forward->module = $module;
@@ -581,12 +582,12 @@ class ModuleHandler extends Handler
 					return $oMessageObject;
 				}
 			}
-
+			
 			if(!$forward)
 			{
 				$forward = $oModuleModel->getActionForward($this->act);
 			}
-
+			
 			if($forward->module && $forward->type && $forward->act && $forward->act == $this->act)
 			{
 				$kind = stripos($forward->act, 'admin') !== FALSE ? 'admin' : '';
@@ -594,9 +595,24 @@ class ModuleHandler extends Handler
 				$ruleset = $forward->ruleset;
 				$tpl_path = $oModule->getTemplatePath();
 				$orig_module = $oModule;
-
+				
 				$xml_info = $oModuleModel->getModuleActionXml($forward->module);
-
+				
+				// Protect admin action
+				if(($this->module == 'admin' || $kind == 'admin') && !$oModuleModel->getGrant($forward, $logged_info)->root)
+				{
+					if($this->module == 'admin' || empty($xml_info->permission->{$this->act}))
+					{
+						self::_setInputErrorToContext();
+						$this->error = 'admin.msg_is_not_administrator';
+						$oMessageObject = self::getModuleInstance('message', $display_mode);
+						$oMessageObject->setError(-1);
+						$oMessageObject->setMessage($this->error);
+						$oMessageObject->dispMessage();
+						return $oMessageObject;
+					}
+				}
+				
 				// SECISSUE also check foward act method
 				// check REQUEST_METHOD in controller
 				if($type == 'controller')
@@ -668,21 +684,6 @@ class ModuleHandler extends Handler
 						$oMessageObject->setHttpStatusCode($this->httpStatusCode);
 					}
 					return $oMessageObject;
-				}
-				
-				// Protect admin action
-				if(($this->module == 'admin' || $kind == 'admin') && !$oModuleModel->getGrant($forward, $logged_info)->root)
-				{
-					if($this->module == 'admin' || strpos($xml_info->permission->{$this->act}, 'manager') === false)
-					{
-						self::_setInputErrorToContext();
-						$this->error = 'admin.msg_is_not_administrator';
-						$oMessageObject = self::getModuleInstance('message', $display_mode);
-						$oMessageObject->setError(-1);
-						$oMessageObject->setMessage($this->error);
-						$oMessageObject->dispMessage();
-						return $oMessageObject;
-					}
 				}
 				
 				// Admin page layout

--- a/classes/module/ModuleObject.class.php
+++ b/classes/module/ModuleObject.class.php
@@ -297,34 +297,40 @@ class ModuleObject extends Object
 		if($permission)
 		{
 			// If permission is 'member', check logged-in
-			if($permission == 'member' && !Context::get('is_logged'))
+			if($permission == 'member')
 			{
-				return false;
+				if(!Context::get('is_logged'))
+				{
+					return false;
+				}
 			}
 			// If permission is 'manager', check 'is user have manager privilege(granted)'
-			else if(preg_match('/^(manager|([a-z0-9\_]+)-managers)$/', $permission, $type) && !$grant->manager)
+			else if(preg_match('/^(manager|([a-z0-9\_]+)-managers)$/', $permission, $type))
 			{
-				// If permission is '*-managers', search modules to find manager privilege of the member
-				if(Context::get('is_logged') && $find && isset($type[2]))
+				if(!$grant->manager)
 				{
-					// Manager privilege of the member is found by search all modules, Pass
-					if($type[2] == 'all' && getModel('module')->findManagerPrivilege($member_info) !== false)
+					// If permission is '*-managers', search modules to find manager privilege of the member
+					if(Context::get('is_logged') && $find && isset($type[2]))
 					{
-						return true;
+						// Manager privilege of the member is found by search all modules, Pass
+						if($type[2] == 'all' && getModel('module')->findManagerPrivilege($member_info) !== false)
+						{
+							return true;
+						}
+						// Manager privilege of the member is found by search same module as this module, Pass
+						else if($type[2] == 'same' && getModel('module')->findManagerPrivilege($member_info, $this->module) !== false)
+						{
+							return true;
+						}
+						// Manager privilege of the member is found by search same module as the module, Pass
+						else if(getModel('module')->findManagerPrivilege($member_info, $type[2]) !== false)
+						{
+							return true;
+						}
 					}
-					// Manager privilege of the member is found by search same module as this module, Pass
-					else if($type[2] == 'same' && getModel('module')->findManagerPrivilege($member_info, $this->module) !== false)
-					{
-						return true;
-					}
-					// Manager privilege of the member is found by search same module as the module, Pass
-					else if(getModel('module')->findManagerPrivilege($member_info, $type[2]) !== false)
-					{
-						return true;
-					}
+					
+					return false;
 				}
-				
-				return false;
 			}
 			// If permission is 'root', Error!
 			// Because an administrator who have root privilege(granted) was passed already

--- a/classes/module/ModuleObject.class.php
+++ b/classes/module/ModuleObject.class.php
@@ -333,7 +333,7 @@ class ModuleObject extends Object
 				return false;
 			}
 			// If grant name, check the privilege(granted) of the user
-			else if($grant_names = explode('|', $permission))
+			else if($grant_names = explode(',', $permission))
 			{
 				$privilege_list = array_keys((array) $this->xml_info->grant);
 				

--- a/classes/module/ModuleObject.class.php
+++ b/classes/module/ModuleObject.class.php
@@ -221,7 +221,7 @@ class ModuleObject extends Object
 					}
 					
 					// Check permission
-					if($this->checkPermission($grant, false) !== true)
+					if($this->checkPermission($grant) !== true)
 					{
 						$this->stop('msg_not_permitted_act');
 						return false;
@@ -254,11 +254,10 @@ class ModuleObject extends Object
 	/**
 	 * Check permission
 	 * @param object $grant privileges(granted) information of user
-	 * @param object $find if user doesn't have privilege(granted), find more privilege of the user
 	 * @param object $member_info member information
 	 * @return boolean success : true, fail : false
 	 * */
-	function checkPermission($grant = null, $find = true, $member_info = null)
+	function checkPermission($grant = null, $member_info = null)
 	{
 		// Get logged-in member information
 		if(!$member_info)
@@ -281,79 +280,76 @@ class ModuleObject extends Object
 		// Get permission types(guest, member, manager, root) of the currently requested action
 		$permission = $this->xml_info->permission->{$this->act};
 		
-		// If permission is 'guest', Pass
-		if($permission == 'guest')
-		{
-			return true;
-		}
-		
 		// If admin action, set default permission
 		if(empty($permission) && stripos($this->act, 'admin') !== false)
 		{
 			$permission = 'root';
 		}
 		
-		// If 'act' have permission, but user does not have privilege(granted), error
-		if($permission)
+		// If permission is not or 'guest', Pass
+		if(empty($permission) || $permission == 'guest')
 		{
-			// If permission is 'member', check logged-in
-			if($permission == 'member')
+			return true;
+		}
+		// If permission is 'member', check logged-in
+		else if($permission == 'member')
+		{
+			if(Context::get('is_logged'))
 			{
-				if(!Context::get('is_logged'))
+				return true;
+			}
+		}
+		// If permission is 'manager', check 'is user have manager privilege(granted)'
+		else if(preg_match('/^(manager|([a-z0-9\_]+)-managers)$/', $permission, $type))
+		{
+			if($grant->manager)
+			{
+				return true;
+			}
+			
+			// If permission is '*-managers', search modules to find manager privilege of the member
+			if(Context::get('is_logged') && isset($type[2]))
+			{
+				// Manager privilege of the member is found by search all modules, Pass
+				if($type[2] == 'all' && getModel('module')->findManagerPrivilege($member_info) !== false)
 				{
-					return false;
+					return true;
 				}
-			}
-			// If permission is 'manager', check 'is user have manager privilege(granted)'
-			else if(preg_match('/^(manager|([a-z0-9\_]+)-managers)$/', $permission, $type))
-			{
-				if(!$grant->manager)
+				// Manager privilege of the member is found by search same module as this module, Pass
+				else if($type[2] == 'same' && getModel('module')->findManagerPrivilege($member_info, $this->module) !== false)
 				{
-					// If permission is '*-managers', search modules to find manager privilege of the member
-					if(Context::get('is_logged') && $find && isset($type[2]))
-					{
-						// Manager privilege of the member is found by search all modules, Pass
-						if($type[2] == 'all' && getModel('module')->findManagerPrivilege($member_info) !== false)
-						{
-							return true;
-						}
-						// Manager privilege of the member is found by search same module as this module, Pass
-						else if($type[2] == 'same' && getModel('module')->findManagerPrivilege($member_info, $this->module) !== false)
-						{
-							return true;
-						}
-						// Manager privilege of the member is found by search same module as the module, Pass
-						else if(getModel('module')->findManagerPrivilege($member_info, $type[2]) !== false)
-						{
-							return true;
-						}
-					}
-					
-					return false;
+					return true;
 				}
-			}
-			// If permission is 'root', Error!
-			// Because an administrator who have root privilege(granted) was passed already
-			else if($permission == 'root')
-			{
-				return false;
-			}
-			// If grant name, check the privilege(granted) of the user
-			else if($grant_names = explode(',', $permission))
-			{
-				$privilege_list = array_keys((array) $this->xml_info->grant);
-				
-				foreach($grant_names as $name)
+				// Manager privilege of the member is found by search same module as the module, Pass
+				else if(getModel('module')->findManagerPrivilege($member_info, $type[2]) !== false)
 				{
-					if(!in_array($name, $privilege_list) || !$grant->$name)
-					{
-						return false;
-					}
+					return true;
 				}
 			}
 		}
+		// If permission is 'root', false
+		// Because an administrator who have root privilege(granted) was passed already
+		else if($permission == 'root')
+		{
+			return false;
+		}
+		// If grant name, check the privilege(granted) of the user
+		else if($grant_names = explode(',', $permission))
+		{
+			$privilege_list = array_keys((array) $this->xml_info->grant);
+			
+			foreach($grant_names as $name)
+			{
+				if(!in_array($name, $privilege_list) || !$grant->$name)
+				{
+					return false;
+				}
+			}
+			
+			return true;
+		}
 		
-		return true;
+		return false;
 	}
 	
 	/**

--- a/classes/module/ModuleObject.class.php
+++ b/classes/module/ModuleObject.class.php
@@ -302,23 +302,23 @@ class ModuleObject extends Object
 				return false;
 			}
 			// If permission is 'manager', check 'is user have manager privilege(granted)'
-			else if(strpos($permission, 'manager') !== false && !$grant->manager)
+			else if(preg_match('/^(manager|([a-z0-9\_]+)-managers)$/', $permission, $type) && !$grant->manager)
 			{
 				// If permission is '*-managers', search modules to find manager privilege of the member
-				if(Context::get('is_logged') && $find && preg_match('/^([a-z0-9\_]+)-managers$/', $permission, $type) && $type[1])
+				if(Context::get('is_logged') && $find && isset($type[2]))
 				{
 					// Manager privilege of the member is found by search all modules, Pass
-					if($type[1] == 'all' && getModel('module')->findManagerPrivilege($member_info) !== false)
+					if($type[2] == 'all' && getModel('module')->findManagerPrivilege($member_info) !== false)
 					{
 						return true;
 					}
 					// Manager privilege of the member is found by search same module as this module, Pass
-					else if($type[1] == 'same' && getModel('module')->findManagerPrivilege($member_info, $this->module) !== false)
+					else if($type[2] == 'same' && getModel('module')->findManagerPrivilege($member_info, $this->module) !== false)
 					{
 						return true;
 					}
 					// Manager privilege of the member is found by search same module as the module, Pass
-					else if(getModel('module')->findManagerPrivilege($member_info, $type[1]) !== false)
+					else if(getModel('module')->findManagerPrivilege($member_info, $type[2]) !== false)
 					{
 						return true;
 					}

--- a/modules/addon/conf/module.xml
+++ b/modules/addon/conf/module.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <module>
 	<grants />
-	<permissions />
 	<actions>
 		<action name="dispAddonAdminIndex" type="view" admin_index="true" menu_name="installedAddon" menu_index="true" />
 		<action name="dispAddonAdminInfo" type="view" />

--- a/modules/admin/conf/module.xml
+++ b/modules/admin/conf/module.xml
@@ -1,11 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <module>
 	<grants />
-	<permissions>
-		<permission action="getSiteAllList" target="root" />
-	</permissions>
 	<actions>
-		<action name="getSiteAllList" type="model" />
+		<action name="getSiteAllList" type="model" permission="root" />
 		
 		<action name="dispAdminIndex" type="view" index="true" />
 		<action name="dispAdminConfigGeneral" type="view" menu_name="adminConfigurationGeneral" menu_index="true" />

--- a/modules/adminlogging/conf/module.xml
+++ b/modules/adminlogging/conf/module.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <module>
     <grants />
-    <permissions />
     <actions>
     </actions>
 </module>

--- a/modules/advanced_mailer/conf/module.xml
+++ b/modules/advanced_mailer/conf/module.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <module>
 	<grants />
-	<permissions />
 	<actions>
 		<action name="dispAdvanced_mailerAdminConfig" type="view" admin_index="true" menu_name="advanced_mailer" />
 		<action name="dispAdvanced_mailerAdminExceptions" type="view" />

--- a/modules/autoinstall/conf/module.xml
+++ b/modules/autoinstall/conf/module.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <module>
 	<grants />
-	<permissions />
 	<actions>
 		<action name="dispAutoinstallAdminIndex" type="view" admin_index="true" menu_name="easyInstall" menu_index="true" />
 		<action name="dispAutoinstallAdminInstall" type="view" menu_name="easyInstall" />

--- a/modules/board/conf/module.xml
+++ b/modules/board/conf/module.xml
@@ -21,12 +21,6 @@
 			<title xml:lang="zh-TW">檢視</title>
 			<title xml:lang="tr">görüş</title>
 		</grant>
-		<grant name="update_view" default="guest">
-			<title xml:lang="ko">수정내역 조회</title>
-		</grant>
-		<grant name="vote_log_view" default="guest">
-			<title xml:lang="ko">추천인 조회</title>
-		</grant>
 		<grant name="write_document" default="guest">
 			<title xml:lang="ko">글 작성</title>
 			<title xml:lang="zh-CN">发表新主题</title>
@@ -47,73 +41,69 @@
 			<title xml:lang="zh-TW">發表評論</title>
 			<title xml:lang="es">yorum yaz</title>
 		</grant>
+		<grant name="vote_log_view" default="guest">
+			<title xml:lang="ko">추천인 보기</title>
+			<title xml:lang="en">view recommender</title>
+		</grant>
+		<grant name="update_view" default="guest">
+			<title xml:lang="ko">수정 내역 보기</title>
+			<title xml:lang="en">view update history</title>
+		</grant>
 		<grant name="consultation_read" default="manager">
-			<title xml:lang="ko">상담글 조회</title>
-			<title xml:lang="en">Consultation Document Read</title>
+			<title xml:lang="ko">상담글 열람</title>
+			<title xml:lang="en">view consultation document</title>
 			<title xml:lang="jp">相談文照会</title>
 		</grant>
 	</grants>
-	<permissions>
-		<permission action="dispBoardAdminBoardInfo" target="manager" />
-		<permission action="dispBoardAdminCategoryInfo" target="manager" />
-		<permission action="dispBoardAdminExtraVars" target="manager" />
-		<permission action="dispBoardAdminGrantInfo" target="manager" />
-		<permission action="dispBoardAdminBoardAdditionSetup" target="manager" />
-		<permission action="dispBoardAdminSkinInfo" target="manager" />
-		<permission action="dispBoardAdminMobileSkinInfo" target="manager" />
-		
-		<permission action="procBoardAdminInsertBoard" target="manager" check_var="module_srl" />
-		<permission action="procBoardAdminSaveCategorySettings" target="manager" check_var="module_srl" />
-	</permissions>
 	<actions>
-		<action name="dispBoardContent" type="view" standalone="false" index="true" />
-		<action name="dispBoardWrite" type="view" standalone="false" />
-		<action name="dispBoardDelete" type="view" standalone="false" />
-		<action name="dispBoardWriteComment" type="view" standalone="false" />
-		<action name="dispBoardReplyComment" type="view" standalone="false" />
-		<action name="dispBoardModifyComment" type="view" standalone="false" />
-		<action name="dispBoardDeleteComment" type="view" standalone="false" />
-		<action name="dispBoardDeleteTrackback" type="view" standalone="false" />
-		<action name="dispBoardContentList" type="view" standalone="false" />
-		<action name="dispBoardContentView" type="view" standalone="false" />
-		<action name="dispBoardUpdateLog" type="view" standalone="false" />
-		<action name="dispBoardUpdateLogView" type="view" standalone="false" />
-		<action name="dispBoardVoteLog" type="view" standalone="false" />
+		<action name="dispBoardContent" type="view" permission="list" standalone="false" index="true" />
+		<action name="dispBoardWrite" type="view" permission="write_document" standalone="false" />
+		<action name="dispBoardDelete" type="view" permission="write_document" standalone="false" />
+		<action name="dispBoardWriteComment" type="view" permission="write_comment" standalone="false" />
+		<action name="dispBoardReplyComment" type="view" permission="write_comment" standalone="false" />
+		<action name="dispBoardModifyComment" type="view" permission="write_comment" standalone="false" />
+		<action name="dispBoardDeleteComment" type="view" permission="write_comment" standalone="false" />
+		<action name="dispBoardDeleteTrackback" type="view" permission="list|view" standalone="false" />
+		<action name="dispBoardContentList" type="view" permission="list" standalone="false" />
+		<action name="dispBoardContentView" type="view" permission="view" standalone="false" />
+		<action name="dispBoardUpdateLog" type="view" permission="update_view" standalone="false" />
+		<action name="dispBoardUpdateLogView" type="view" permission="update_view" standalone="false" />
+		<action name="dispBoardVoteLog" type="view" permission="vote_log_view" standalone="false" />
 		
-		<action name="dispBoardNoticeList" type="view" standalone="false" />
-		<action name="dispBoardCategoryList" type="view" standalone="false" />
-		<action name="dispBoardContentCommentList" type="view" standalone="false" />
-		<action name="dispBoardContentFileList" type="view" standalone="false" />
-		<action name="dispBoardTagList" type="view" standalone="false" />
-		<action name="dispBoardCategory" type="mobile" standalone="false" />
-		<action name="getBoardCommentPage" type="mobile" standalone="false" />
+		<action name="dispBoardNoticeList" type="view" permission="list" standalone="false" />
+		<action name="dispBoardCategoryList" type="view" permission="list" standalone="false" />
+		<action name="dispBoardContentCommentList" type="view" permission="view" standalone="false" />
+		<action name="dispBoardContentFileList" type="view" permission="view" standalone="false" />
+		<action name="dispBoardTagList" type="view" permission="list" standalone="false" />
+		<action name="dispBoardCategory" type="mobile" permission="list" standalone="false" />
+		<action name="getBoardCommentPage" type="mobile" permission="view" standalone="false" />
 		
-		<action name="procBoardInsertDocument" type="controller" ruleset="insertDocument" standalone="false" />
-		<action name="procBoardDeleteDocument" type="controller" standalone="false" />
-		<action name="procBoardRevertDocument" type="controller" standalone="false" />
-		<action name="procBoardInsertComment" type="controller" standalone="false" />
-		<action name="procBoardDeleteComment" type="controller" standalone="false" />
-		<action name="procBoardDeleteTrackback" type="controller" standalone="false" />
-		<action name="procBoardVerificationPassword" type="controller" standalone="false" />
-		<action name="procBoardVoteDocument" type="controller" standalone="false" />
+		<action name="procBoardInsertDocument" type="controller" permission="write_document" standalone="false" ruleset="insertDocument" />
+		<action name="procBoardDeleteDocument" type="controller" permission="write_document" standalone="false" />
+		<action name="procBoardRevertDocument" type="controller" permission="update_view" standalone="false" />
+		<action name="procBoardInsertComment" type="controller" permission="write_comment" standalone="false" />
+		<action name="procBoardDeleteComment" type="controller" permission="write_comment" standalone="false" />
+		<action name="procBoardDeleteTrackback" type="controller" permission="list|view" standalone="false" />
+		<action name="procBoardVerificationPassword" type="controller" permission="view" standalone="false" />
+		<action name="procBoardVoteDocument" type="controller" permission="view" standalone="false" />
 		
 		<action name="dispBoardAdminContent" type="view" admin_index="true" menu_name="board" menu_index="true" />
 		<action name="dispBoardAdminInsertBoard" type="view" setup_index="true" menu_name="board" />
 		<action name="dispBoardAdminDeleteBoard" type="view" menu_name="board" />
-		<action name="dispBoardAdminBoardInfo" type="view" menu_name="board" />
-		<action name="dispBoardAdminCategoryInfo" type="view" menu_name="board" />
-		<action name="dispBoardAdminExtraVars" type="view" menu_name="board" />
-		<action name="dispBoardAdminGrantInfo" type="view" menu_name="board" />
-		<action name="dispBoardAdminBoardAdditionSetup" type="view" menu_name="board" />
-		<action name="dispBoardAdminSkinInfo" type="view" menu_name="board" />
-		<action name="dispBoardAdminMobileSkinInfo" type="view" menu_name="board" />
+		<action name="dispBoardAdminBoardInfo" type="view" permission="manager" menu_name="board" />
+		<action name="dispBoardAdminCategoryInfo" type="view" permission="manager" menu_name="board" />
+		<action name="dispBoardAdminExtraVars" type="view" permission="manager" menu_name="board" />
+		<action name="dispBoardAdminGrantInfo" type="view" permission="manager" menu_name="board" />
+		<action name="dispBoardAdminBoardAdditionSetup" type="view" permission="manager" menu_name="board" />
+		<action name="dispBoardAdminSkinInfo" type="view" permission="manager" menu_name="board" />
+		<action name="dispBoardAdminMobileSkinInfo" type="view" permission="manager" menu_name="board" />
 		
 		<action name="getBoardAdminSimpleSetup" type="model" simple_setup_index="true" />
 		
-		<action name="procBoardAdminInsertBoard" type="controller" ruleset="insertBoard" />
+		<action name="procBoardAdminInsertBoard" type="controller" permission="manager" check_var="module_srl" ruleset="insertBoard" />
 		<action name="procBoardAdminDeleteBoard" type="controller" />
 		<action name="procBoardAdminUpdateBoardFroBasic" type="controller" ruleset="insertBoardForBasic" />
-		<action name="procBoardAdminSaveCategorySettings" type="controller" ruleset="saveCategorySettings" />
+		<action name="procBoardAdminSaveCategorySettings" type="controller" permission="manager" check_var="module_srl" ruleset="saveCategorySettings" />
 	</actions>
 	<menus>
 		<menu name="board" type="all">

--- a/modules/board/conf/module.xml
+++ b/modules/board/conf/module.xml
@@ -63,7 +63,7 @@
 		<action name="dispBoardReplyComment" type="view" permission="write_comment" standalone="false" />
 		<action name="dispBoardModifyComment" type="view" permission="write_comment" standalone="false" />
 		<action name="dispBoardDeleteComment" type="view" permission="write_comment" standalone="false" />
-		<action name="dispBoardDeleteTrackback" type="view" permission="list|view" standalone="false" />
+		<action name="dispBoardDeleteTrackback" type="view" permission="list,view" standalone="false" />
 		<action name="dispBoardContentList" type="view" permission="list" standalone="false" />
 		<action name="dispBoardContentView" type="view" permission="view" standalone="false" />
 		<action name="dispBoardUpdateLog" type="view" permission="update_view" standalone="false" />
@@ -83,7 +83,7 @@
 		<action name="procBoardRevertDocument" type="controller" permission="update_view" standalone="false" />
 		<action name="procBoardInsertComment" type="controller" permission="write_comment" standalone="false" />
 		<action name="procBoardDeleteComment" type="controller" permission="write_comment" standalone="false" />
-		<action name="procBoardDeleteTrackback" type="controller" permission="list|view" standalone="false" />
+		<action name="procBoardDeleteTrackback" type="controller" permission="list,view" standalone="false" />
 		<action name="procBoardVerificationPassword" type="controller" permission="view" standalone="false" />
 		<action name="procBoardVoteDocument" type="controller" permission="view" standalone="false" />
 		

--- a/modules/comment/conf/module.xml
+++ b/modules/comment/conf/module.xml
@@ -1,35 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module>
 	<grants />
-	<permissions>
-		<permission action="dispCommentDeclare" target="member" />
-		<permission action="getCommentVotedMemberList" target="root" />
-		
-		<permission action="procCommentVoteUp" target="member" />
-		<permission action="procCommentVoteUpCancel" target="member" />
-		<permission action="procCommentVoteDown" target="member" />
-		<permission action="procCommentVoteDownCancel" target="member" />
-		<permission action="procCommentDeclare" target="member" />
-		<permission action="procCommentGetList" target="manager" check_type="comment" check_var="comment_srls" />
-		<permission action="procCommentInsertModuleConfig" target="manager" check_var="target_module_srl" />
-		
-		<permission action="procCommentAdminAddCart" target="manager" check_type="comment" check_var="comment_srl" />
-		<permission action="procCommentAdminDeleteChecked" target="manager" check_type="comment" check_var="cart" />
-		<permission action="procCommentAdminMoveToTrash" target="manager" check_type="comment" check_var="comment_srl" />
-	</permissions>
 	<actions>
-		<action name="dispCommentDeclare" type="view" />
+		<action name="dispCommentDeclare" type="view" permission="manager" />
 		
 		<action name="getCommentMenu" type="model" />
-		<action name="getCommentVotedMemberList" type="model" />
+		<action name="getCommentVotedMemberList" type="model" permission="root" />
 		
-		<action name="procCommentVoteUp" type="controller" />
-		<action name="procCommentVoteUpCancel" type="controller" />
-		<action name="procCommentVoteDown" type="controller" />
-		<action name="procCommentVoteDownCancel" type="controller" />
-		<action name="procCommentDeclare" type="controller" />
-		<action name="procCommentGetList" type="controller" />
-		<action name="procCommentInsertModuleConfig" type="controller" ruleset="insertCommentModuleConfig" />
+		<action name="procCommentVoteUp" type="controller" permission="member" />
+		<action name="procCommentVoteUpCancel" type="controller" permission="member" />
+		<action name="procCommentVoteDown" type="controller" permission="member" />
+		<action name="procCommentVoteDownCancel" type="controller" permission="member" />
+		<action name="procCommentDeclare" type="controller" permission="member" />
+		<action name="procCommentGetList" type="controller" permission="manager" check_type="comment" check_var="comment_srls" />
+		<action name="procCommentInsertModuleConfig" type="controller" permission="manager" check_var="target_module_srl" ruleset="insertCommentModuleConfig" />
 		
 		<action name="dispCommentAdminList" type="view" admin_index="true" menu_name="comment" menu_index="true" />
 		<action name="dispCommentAdminDeclared" type="view" menu_name="comment" />
@@ -38,9 +22,9 @@
 		<action name="procCommentAdminChangeStatus" type="controller"/>
 		<action name="procCommentAdminChangePublishedStatusChecked" type="controller" />
 		<action name="procCommentAdminCancelDeclare" type="controller" />
-		<action name="procCommentAdminAddCart" type="controller" />
-		<action name="procCommentAdminDeleteChecked" type="controller" ruleset="deleteChecked" />
-		<action name="procCommentAdminMoveToTrash" type="controller" />
+		<action name="procCommentAdminAddCart" type="controller" permission="manager" check_type="comment" check_var="comment_srl" />
+		<action name="procCommentAdminDeleteChecked" type="controller" permission="manager" check_type="comment" check_var="cart" ruleset="deleteChecked" />
+		<action name="procCommentAdminMoveToTrash" type="controller" permission="manager" check_type="comment" check_var="comment_srl" />
 	</actions>
 	<menus>
 		<menu name="comment">

--- a/modules/communication/conf/module.xml
+++ b/modules/communication/conf/module.xml
@@ -1,47 +1,26 @@
 <?xml version="1.0" encoding="utf-8"?>
 <module>
 	<grants />
-	<permissions>
-		<permission action="dispCommunicationMessages" target="member" />
-		<permission action="dispCommunicationSendMessage" target="member" />
-		<permission action="dispCommunicationNewMessage" target="member" />
-		<permission action="dispCommunicationFriend" target="member" />
-		<permission action="dispCommunicationAddFriend" target="member" />
-		<permission action="dispCommunicationAddFriendGroup" target="member" />
-		<permission action="dispCommunicationMessageBoxList" target="member" />
-		
-		<permission action="procCommunicationUpdateAllowMessage" target="member" />
-		<permission action="procCommunicationSendMessage" target="member" />
-		<permission action="procCommunicationStoreMessage" target="member" />
-		<permission action="procCommunicationDeleteMessage" target="member" />
-		<permission action="procCommunicationDeleteMessages" target="member" />
-		<permission action="procCommunicationAddFriend" target="member" />
-		<permission action="procCommunicationAddFriendGroup" target="member" />
-		<permission action="procCommunicationMoveFriend" target="member" />
-		<permission action="procCommunicationDeleteFriend" target="member" />
-		<permission action="procCommunicationDeleteFriendGroup" target="member" />
-		<permission action="procCommunicationRenameFriendGroup" target="member" />
-	</permissions>
 	<actions>
-		<action name="dispCommunicationMessages" type="view" />
-		<action name="dispCommunicationSendMessage" type="view" />
-		<action name="dispCommunicationNewMessage" type="view" />
-		<action name="dispCommunicationFriend" type="view" />
-		<action name="dispCommunicationAddFriend" type="view" />
-		<action name="dispCommunicationAddFriendGroup" type="view" />
-		<action name="dispCommunicationMessageBoxList" type="mobile" />
+		<action name="dispCommunicationMessages" type="view" permission="member" />
+		<action name="dispCommunicationSendMessage" type="view" permission="member" />
+		<action name="dispCommunicationNewMessage" type="view" permission="member" />
+		<action name="dispCommunicationFriend" type="view" permission="member" />
+		<action name="dispCommunicationAddFriend" type="view" permission="member" />
+		<action name="dispCommunicationAddFriendGroup" type="view" permission="member" />
+		<action name="dispCommunicationMessageBoxList" type="mobile" permission="member" />
 		
-		<action name="procCommunicationUpdateAllowMessage" type="controller" />
-		<action name="procCommunicationSendMessage" type="controller" ruleset="sendMessage" />
-		<action name="procCommunicationStoreMessage" type="controller" />
-		<action name="procCommunicationDeleteMessage" type="controller" />
-		<action name="procCommunicationDeleteMessages" type="controller" />
-		<action name="procCommunicationAddFriend" type="controller" ruleset="addFriend" />
-		<action name="procCommunicationAddFriendGroup" type="controller" ruleset="addFriendGroup" />
-		<action name="procCommunicationMoveFriend" type="controller" ruleset="deleteCheckedFriend" />
-		<action name="procCommunicationDeleteFriend" type="controller" ruleset="deleteCheckedFriend" />
-		<action name="procCommunicationDeleteFriendGroup" type="controller" />
-		<action name="procCommunicationRenameFriendGroup" type="controller" />
+		<action name="procCommunicationUpdateAllowMessage" type="controller" permission="member" />
+		<action name="procCommunicationSendMessage" type="controller" permission="member" ruleset="sendMessage" />
+		<action name="procCommunicationStoreMessage" type="controller" permission="member" />
+		<action name="procCommunicationDeleteMessage" type="controller" permission="member" />
+		<action name="procCommunicationDeleteMessages" type="controller" permission="member" />
+		<action name="procCommunicationAddFriend" type="controller" permission="member" ruleset="addFriend" />
+		<action name="procCommunicationAddFriendGroup" type="controller" permission="member" ruleset="addFriendGroup" />
+		<action name="procCommunicationMoveFriend" type="controller" permission="member" ruleset="deleteCheckedFriend" />
+		<action name="procCommunicationDeleteFriend" type="controller" permission="member" ruleset="deleteCheckedFriend" />
+		<action name="procCommunicationDeleteFriendGroup" type="controller" permission="member" />
+		<action name="procCommunicationRenameFriendGroup" type="controller" permission="member" />
 		
 		<action name="dispCommunicationAdminConfig" type="view" admin_index="true" />
 		<action name="getCommunicationAdminColorset" type="model" />

--- a/modules/counter/conf/module.xml
+++ b/modules/counter/conf/module.xml
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <module>
 	<grants />
-	<permissions>
-		<permission action="getWeeklyUniqueVisitor" target="root" />
-		<permission action="getWeeklyPageView" target="root" />
-	</permissions>
 	<actions>
+		<action name="getWeeklyPageView" type="model" permission="root" />
+		<action name="getWeeklyUniqueVisitor" type="model" permission="root" />
+		
 		<action name="dispCounterAdminIndex" type="view" admin_index="true" />
-		<action name="getWeeklyUniqueVisitor" type="model" />
-		<action name="getWeeklyPageView" type="model" />
 	</actions>
 </module>

--- a/modules/document/conf/module.xml
+++ b/modules/document/conf/module.xml
@@ -1,57 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module>
 	<grants />
-	<permissions>
-		<permission action="dispTempSavedList" target="member" />
-		<permission action="dispDocumentDeclare" target="member" />
-		<permission action="dispDocumentManageDocument" target="all-managers" />
-		
-		<permission action="getDocumentCategories" target="all-managers" />
-		<permission action="getDocumentCategoryTplInfo" target="manager" check_var="module_srl" />
-		<permission action="getDocumentVotedMemberList" target="root" />
-		
-		<permission action="procDocumentTempSave" target="member" />
-		<permission action="procDocumentDeclare" target="member" />
-		<permission action="procDocumentGetList" target="manager" check_type="document" check_var="document_srls" />
-		<permission action="procDocumentAddCart" target="manager" check_type="document" check_var="srls" />
-		<permission action="procDocumentManageCheckedDocument" target="manager" check_type="document" check_var="cart" />
-		<permission action="procDocumentInsertModuleConfig" target="manager" check_var="target_module_srl" />
-		<permission action="procDocumentInsertCategory" target="manager" check_var="module_srl" />
-		<permission action="procDocumentDeleteCategory" target="manager" check_var="module_srl" />
-		<permission action="procDocumentMoveCategory" target="manager" check_var="module_srl" />
-		<permission action="procDocumentMakeXmlFile" target="manager" check_var="module_srl" />
-		
-		<permission action="procDocumentAdminMoveToTrash" target="manager" check_type="document" check_var="document_srl" />
-		<permission action="procDocumentAdminInsertExtraVar" target="manager" check_var="module_srl" />
-		<permission action="procDocumentAdminDeleteExtraVar" target="manager" check_var="module_srl" />
-		<permission action="procDocumentAdminMoveExtraVar" target="manager" check_var="module_srl" />
-	</permissions>
 	<actions>
 		<action name="dispDocumentPrint" type="view" />
 		<action name="dispDocumentPreview" type="view" />
-		<action name="dispTempSavedList" type="view" />
-		<action name="dispDocumentDeclare" type="view" />
-		<action name="dispDocumentManageDocument" type="view" />
+		<action name="dispTempSavedList" type="view" permission="member" />
+		<action name="dispDocumentDeclare" type="view" permission="member" />
+		<action name="dispDocumentManageDocument" type="view" permission="all-managers" />
 		
 		<action name="getDocumentMenu" type="model" />
-		<action name="getDocumentCategories" type="model" />
-		<action name="getDocumentCategoryTplInfo" type="model" />
-		<action name="getDocumentVotedMemberList" type="model" />
+		<action name="getDocumentCategories" type="model" permission="all-managers" />
+		<action name="getDocumentCategoryTplInfo" type="model" permission="manager" check_var="module_srl" />
+		<action name="getDocumentVotedMemberList" type="model" permission="root" />
 		
 		<action name="procDocumentVoteUp" type="controller" />
-		<action name="procDocumentVoteUpCancel" type="controller" />.
+		<action name="procDocumentVoteUpCancel" type="controller" />
 		<action name="procDocumentVoteDown" type="controller" />
 		<action name="procDocumentVoteDownCancel" type="controller" />
-		<action name="procDocumentTempSave" type="controller" />
-		<action name="procDocumentDeclare" type="controller" />
-		<action name="procDocumentGetList" type="controller" />
-		<action name="procDocumentAddCart" type="controller" />
-		<action name="procDocumentManageCheckedDocument" type="controller" />
-		<action name="procDocumentInsertModuleConfig" type="controller" />
-		<action name="procDocumentInsertCategory" type="controller" ruleset="insertCategory" />
-		<action name="procDocumentDeleteCategory" type="controller" />
-		<action name="procDocumentMoveCategory" type="controller" />
-		<action name="procDocumentMakeXmlFile" type="controller" />
+		<action name="procDocumentTempSave" type="controller" permission="member" />
+		<action name="procDocumentDeclare" type="controller" permission="member" />
+		<action name="procDocumentGetList" type="controller" permission="manager" check_type="document" check_var="document_srls" />
+		<action name="procDocumentAddCart" type="controller" permission="manager" check_type="document" check_var="srls" />
+		<action name="procDocumentManageCheckedDocument" type="controller" permission="manager" check_type="document" check_var="cart" />
+		<action name="procDocumentInsertModuleConfig" type="controller" permission="manager" check_var="target_module_srl" />
+		<action name="procDocumentInsertCategory" type="controller" permission="manager" check_var="module_srl" ruleset="insertCategory" />
+		<action name="procDocumentDeleteCategory" type="controller" permission="manager" check_var="module_srl" />
+		<action name="procDocumentMoveCategory" type="controller" permission="manager" check_var="module_srl" />
+		<action name="procDocumentMakeXmlFile" type="controller" permission="manager" check_var="module_srl" />
 		
 		<action name="dispDocumentAdminList" type="view" admin_index="true" menu_name="document" menu_index="true" />
 		<action name="dispDocumentAdminConfig" type="view" menu_name="document" />
@@ -66,11 +41,11 @@
 		<action name="procDocumentAdminCancelDeclare" type="controller" />
 		<action name="procDocumentAdminInsertAlias" type="controller" ruleset="insertAlias" />
 		<action name="procDocumentAdminDeleteAlias" type="controller" ruleset="deleteAlias" />
-		<action name="procDocumentAdminMoveToTrash" type="controller" />
+		<action name="procDocumentAdminMoveToTrash" type="controller" permission="manager" check_type="document" check_var="document_srl" />
 		<action name="procDocumentAdminRestoreTrash" type="controller" />
-		<action name="procDocumentAdminInsertExtraVar" type="controller" ruleset="insertExtraVar" />
-		<action name="procDocumentAdminDeleteExtraVar" type="controller" />
-		<action name="procDocumentAdminMoveExtraVar" type="controller" />
+		<action name="procDocumentAdminInsertExtraVar" type="controller" permission="manager" check_var="module_srl" ruleset="insertExtraVar" />
+		<action name="procDocumentAdminDeleteExtraVar" type="controller" permission="manager" check_var="module_srl" />
+		<action name="procDocumentAdminMoveExtraVar" type="controller" permission="manager" check_var="module_srl" />
 	</actions>
 	<menus>
 		<menu name="document">

--- a/modules/editor/conf/module.xml
+++ b/modules/editor/conf/module.xml
@@ -1,24 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <module>
 	<grants />
-	<permissions>
-		<permission action="dispEditorSkinColorset" target="root" />
-		<permission action="dispEditorConfigPreview" target="root" />
-		
-		<permission action="procEditorInsertModuleConfig" target="manager" check_var="target_module_srl" />
-	</permissions>
 	<actions>
 		<action name="dispEditorComponentInfo" type="view" />
 		<action name="dispEditorPopup" type="view" />
 		<action name="dispEditorPreview" type="view" />
-		<action name="dispEditorSkinColorset" type="view" />
-		<action name="dispEditorConfigPreview" type="view" />
+		<action name="dispEditorSkinColorset" type="view" permission="root" />
+		<action name="dispEditorConfigPreview" type="view" permission="root" />
 		
 		<action name="procEditorCall" type="controller" />
 		<action name="procEditorSaveDoc" type="controller" />
 		<action name="procEditorRemoveSavedDoc" type="controller" />
 		<action name="procEditorLoadSavedDocument" type="controller" />
-		<action name="procEditorInsertModuleConfig" type="controller" />
+		<action name="procEditorInsertModuleConfig" type="controller" permission="manager" check_var="target_module_srl" />
 		
 		<action name="dispEditorAdminIndex" type="view" menu_name="editor" menu_index="true" admin_index="true" />
 		<action name="dispEditorAdminSetupComponent" type="view" menu_name="editor" />

--- a/modules/file/conf/module.xml
+++ b/modules/file/conf/module.xml
@@ -1,10 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <module>
 	<grants />
-	<permissions>
-		<permission action="procFileGetList" target="root" />
-		<permission action="procFileAdminInsertModuleConfig" target="manager" check_var="target_module_srl" />
-	</permissions>
 	<actions>
 		<action name="getFileList" type="model" />
 		
@@ -15,7 +11,7 @@
 		<action name="procFileSetCoverImage" type="controller" />
 		<action name="procFileDownload" type="controller" method="GET|POST" />
 		<action name="procFileOutput" type="controller" method="GET|POST" />
-		<action name="procFileGetList" type="controller" />
+		<action name="procFileGetList" type="controller" permission="root" />
 		
 		<action name="dispFileAdminList" type="view" admin_index="true" menu_name="file" menu_index="true" />
 		<action name="dispFileAdminConfig" type="view" menu_name="fileUpload" menu_index="true" />
@@ -23,7 +19,7 @@
 		<action name="procFileAdminAddCart" type="controller" />
 		<action name="procFileAdminDeleteChecked" type="controller" ruleset="deleteChecked" />
 		<action name="procFileAdminInsertConfig" type="controller" ruleset="insertConfig" />
-		<action name="procFileAdminInsertModuleConfig" type="controller" ruleset="fileModuleConfig" />
+		<action name="procFileAdminInsertModuleConfig" type="controller" permission="manager" check_var="target_module_srl" ruleset="fileModuleConfig" />
 	</actions>
 	<menus>
 		<menu name="file">

--- a/modules/importer/conf/module.xml
+++ b/modules/importer/conf/module.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <module>
 	<grants />
-	<permissions />
 	<actions>
 		<action name="dispImporterAdminImportForm" type="view" admin_index="true" menu_name="importer" menu_index="true" />
 		

--- a/modules/install/conf/module.xml
+++ b/modules/install/conf/module.xml
@@ -1,16 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <module>
 	<grants />
-	<permissions>
-		<permission action="getInstallFTPList" target="root" />
-	</permissions>
 	<actions>
 		<action name="dispInstallIndex" type="view" index="true" />
 		<action name="dispInstallCheckEnv" type="view" />
 		<action name="dispInstallDBConfig" type="view" />
 		<action name="dispInstallOtherConfig" type="view" />
 		
-		<action name="getInstallFTPList" type="model" />
+		<action name="getInstallFTPList" type="model" permission="root" />
 		
 		<action name="procInstallLicenseAgreement" type="controller" />
 		<action name="procDBConfig" type="controller" />

--- a/modules/integration_search/conf/module.xml
+++ b/modules/integration_search/conf/module.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <module>
 	<grants />
-	<permissions />
 	<actions>
 		<action name="IS" type="view" />
 		

--- a/modules/krzip/conf/module.xml
+++ b/modules/krzip/conf/module.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module>
 	<grants />
-	<permissions />
 	<actions>
 		<action name="dispKrzipSearchForm" type="view" />
 		<action name="getKrzipCodeList" type="model" />

--- a/modules/layout/conf/module.xml
+++ b/modules/layout/conf/module.xml
@@ -1,15 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <module>
 	<grants />
-	<permissions>
-		<permission action="dispLayoutPreview" target="root" />
-		<permission action="dispLayoutPreviewWithModule" target="root" />
-		<permission action="getLayoutInstanceListForJSONP" target="root" />
-	</permissions>
 	<actions>
-		<action name="dispLayoutPreview" type="view" />
-		<action name="dispLayoutPreviewWithModule" type="view" />
-		<action name="getLayoutInstanceListForJSONP" type="model" />
+		<action name="dispLayoutPreview" type="view" permission="root" />
+		<action name="dispLayoutPreviewWithModule" type="view" permission="root" />
+		<action name="getLayoutInstanceListForJSONP" type="model" permission="root" />
 		
 		<action name="dispLayoutAdminInstalledList" type="view" admin_index="true" menu_name="installedLayout" menu_index="true" />
 		<action name="dispLayoutAdminAllInstanceList" type="view" menu_name="installedLayout" />

--- a/modules/member/conf/module.xml
+++ b/modules/member/conf/module.xml
@@ -1,66 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module>
 	<grants />
-	<permissions>
-		<permission action="dispMemberInfo" target="member" />
-		<permission action="dispMemberModifyInfo" target="member" />
-		<permission action="dispMemberModifyPassword" target="member" />
-		<permission action="dispMemberModifyEmailAddress" target="member" />
-		<permission action="dispMemberLeave" target="member" />
-		<permission action="dispMemberScrappedDocument" target="member" />
-		<permission action="dispMemberSavedDocument" target="member" />
-		<permission action="dispMemberOwnDocument" target="member" />
-		<permission action="dispMemberOwnComment" target="member" />
-		<permission action="dispMemberActiveLogins" target="member" />
-		<permission action="dispMemberModifyNicknameLog" target="member" />
-		<permission action="dispMemberLogout" target="member" />
-		<permission action="dispMemberSpammer" target="manager" check_var="module_srl" />
-		
-		<permission action="getApiGroups" target="root" />
-		
-		<permission action="procMemberModifyInfoBefore" target="member" />
-		<permission action="procMemberModifyInfo" target="member" />
-		<permission action="procMemberModifyPassword" target="member" />
-		<permission action="procMemberModifyEmailAddress" target="member" />
-		<permission action="procMemberLeave" target="member" />
-		<permission action="procMemberInsertProfileImage" target="member" />
-		<permission action="procMemberDeleteProfileImage" target="member" />
-		<permission action="procMemberInsertImageName" target="member" />
-		<permission action="procMemberDeleteImageName" target="member" />
-		<permission action="procMemberInsertImageMark" target="member" />
-		<permission action="procMemberDeleteImageMark" target="member" />
-		<permission action="procMemberScrapDocument" target="member" />
-		<permission action="procMemberDeleteScrap" target="member" />
-		<permission action="procMemberSaveDocument" target="member" />
-		<permission action="procMemberDeleteSavedDocument" target="member" />
-		<permission action="procMemberDeleteAutologin" target="member" />
-		<permission action="procMemberSiteSignUp" target="member" />
-		<permission action="procMemberSiteLeave" target="member" />
-		<permission action="procMemberLogout" target="member" />
-		<permission action="procMemberSpammerManage" target="manager" check_var="module_srl" />
-	</permissions>
 	<actions>
 		<action name="dispMemberSignUpForm" type="view" />
 		<action name="dispMemberLoginForm" type="view" />
 		<action name="dispMemberFindAccount" type="view" />
 		<action name="dispMemberResendAuthMail" type="view" />
 		<action name="dispMemberGetTempPassword" type="view" />
-		<action name="dispMemberInfo" type="view" />
-		<action name="dispMemberModifyInfo" type="view" />
-		<action name="dispMemberModifyPassword" type="view" />
-		<action name="dispMemberModifyEmailAddress" type="view" />
-		<action name="dispMemberLeave" type="view" />
-		<action name="dispMemberScrappedDocument" type="view" />
-		<action name="dispMemberSavedDocument" type="view" />
-		<action name="dispMemberOwnDocument" type="view" />
-		<action name="dispMemberOwnComment" type="view" />
-		<action name="dispMemberActiveLogins" type="view" />
-		<action name="dispMemberModifyNicknameLog" type="view" />
-		<action name="dispMemberLogout" type="view" />
-		<action name="dispMemberSpammer" type="view" />
+		<action name="dispMemberInfo" type="view" permission="member" />
+		<action name="dispMemberModifyInfo" type="view" permission="member" />
+		<action name="dispMemberModifyPassword" type="view" permission="member" />
+		<action name="dispMemberModifyEmailAddress" type="view" permission="member" />
+		<action name="dispMemberLeave" type="view" permission="member" />
+		<action name="dispMemberScrappedDocument" type="view" permission="member" />
+		<action name="dispMemberSavedDocument" type="view" permission="member" />
+		<action name="dispMemberOwnDocument" type="view" permission="member" />
+		<action name="dispMemberOwnComment" type="view" permission="member" />
+		<action name="dispMemberActiveLogins" type="view" permission="member" />
+		<action name="dispMemberModifyNicknameLog" type="view" permission="member" />
+		<action name="dispMemberLogout" type="view" permission="member" />
+		<action name="dispMemberSpammer" type="view" permission="manager" check_var="module_srl" />
 		
 		<action name="getMemberMenu" type="model" />
-		<action name="getApiGroups" type="model" />
+		<action name="getApiGroups" type="model" permission="root" />
 		
 		<action name="procMemberInsert" type="controller" ruleset="@insertMember" />
 		<action name="procMemberCheckValue" type="controller" />
@@ -71,26 +33,26 @@
 		<action name="procMemberAuthEmailAddress" type="controller" method="GET|POST" />
 		<action name="procMemberResendAuthMail" type="controller" ruleset="resendAuthMail" />
 		<action name="procMemberResetAuthMail" type="controller" ruleset="resetAuthMail" />
-		<action name="procMemberModifyInfoBefore" type="controller" ruleset="recheckedPassword" />
-		<action name="procMemberModifyInfo" type="controller" ruleset="@insertMember" />
-		<action name="procMemberModifyPassword" type="controller" ruleset="modifyPassword" />
-		<action name="procMemberModifyEmailAddress" type="controller" ruleset="modifyEmailAddress" />
-		<action name="procMemberLeave" type="controller" ruleset="leaveMember" />
-		<action name="procMemberInsertProfileImage" type="controller" ruleset="insertProfileImage" />
-		<action name="procMemberDeleteProfileImage" type="controller" />
-		<action name="procMemberInsertImageName" type="controller" ruleset="insertImageName" />
-		<action name="procMemberDeleteImageName" type="controller" />
-		<action name="procMemberInsertImageMark" type="controller" ruleset="insertImageMark" />
-		<action name="procMemberDeleteImageMark" type="controller" />
-		<action name="procMemberScrapDocument" type="controller" />
-		<action name="procMemberDeleteScrap" type="controller" />
-		<action name="procMemberSaveDocument" type="controller" />
-		<action name="procMemberDeleteSavedDocument" type="controller" />
-		<action name="procMemberDeleteAutologin" type="controller" />
-		<action name="procMemberSiteSignUp" type="controller" />
-		<action name="procMemberSiteLeave" type="controller" />
-		<action name="procMemberLogout" type="controller" />
-		<action name="procMemberSpammerManage" type="controller" />
+		<action name="procMemberModifyInfoBefore" type="controller" permission="member" ruleset="recheckedPassword" />
+		<action name="procMemberModifyInfo" type="controller" permission="member" ruleset="@insertMember" />
+		<action name="procMemberModifyPassword" type="controller" permission="member" ruleset="modifyPassword" />
+		<action name="procMemberModifyEmailAddress" type="controller" permission="member" ruleset="modifyEmailAddress" />
+		<action name="procMemberLeave" type="controller" permission="member" ruleset="leaveMember" />
+		<action name="procMemberInsertProfileImage" type="controller" permission="member" ruleset="insertProfileImage" />
+		<action name="procMemberDeleteProfileImage" type="controller" permission="member" />
+		<action name="procMemberInsertImageName" type="controller" permission="member" ruleset="insertImageName" />
+		<action name="procMemberDeleteImageName" type="controller" permission="member" />
+		<action name="procMemberInsertImageMark" type="controller" permission="member" ruleset="insertImageMark" />
+		<action name="procMemberDeleteImageMark" type="controller" permission="member" />
+		<action name="procMemberScrapDocument" type="controller" permission="member" />
+		<action name="procMemberDeleteScrap" type="controller" permission="member" />
+		<action name="procMemberSaveDocument" type="controller" permission="member" />
+		<action name="procMemberDeleteSavedDocument" type="controller" permission="member" />
+		<action name="procMemberDeleteAutologin" type="controller" permission="member" />
+		<action name="procMemberSiteSignUp" type="controller" permission="member" />
+		<action name="procMemberSiteLeave" type="controller" permission="member" />
+		<action name="procMemberLogout" type="controller" permission="member" />
+		<action name="procMemberSpammerManage" type="controller" permission="manager" check_var="module_srl" />
 		
 		<action name="dispMemberAdminList" type="view" index="true" admin_index="true" menu_name="userList" menu_index="true"/>
 		<action name="dispMemberAdminInfo" type="view" menu_name="userList" />

--- a/modules/menu/conf/module.xml
+++ b/modules/menu/conf/module.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <module>
 	<grants />
-	<permissions />
 	<actions>
 		<action name="dispMenuMenu" type="mobile" />
 		

--- a/modules/message/conf/module.xml
+++ b/modules/message/conf/module.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <module>
 	<grants />
-	<permissions />
 	<actions>
 		<action name="dispMessage" type="view" index="true" />
 		

--- a/modules/module/conf/module.xml
+++ b/modules/module/conf/module.xml
@@ -1,45 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
 <module>
 	<grants />
-	<permissions>
-		<permission action="dispModuleSelectList" target="root" />
-		<permission action="dispModuleSkinInfo" target="all-managers" />
-		<permission action="dispModuleFileBox" target="root" />
-		<permission action="dispModuleFileBoxAdd" target="root" />
-		
-		<permission action="getModuleSkinInfoList" target="root" />
-		<permission action="getFileBoxListHtml" target="root" />
-		<permission action="getModuleInfoByMenuItemSrl" target="root" />
-		<permission action="getLangListByLangcodeForAutoComplete" target="manager" />
-		
-		<permission action="procModuleFileBoxAdd" target="root" />
-		<permission action="procModuleFileBoxDelete" target="root" />
-		
-		<permission action="getModuleAdminLangCode" target="manager" />
-		<permission action="getModuleAdminLangListByName" target="manager" />
-		<permission action="getModuleAdminLangListByValue" target="manager" />
-		<permission action="getModuleAdminMultilingualHtml" target="manager" />
-		<permission action="getModuleAdminLangListHtml" target="manager" />
-		
-		<permission action="procModuleAdminInsertGrant" target="manager" check_var="module_srl" />
-		<permission action="procModuleAdminUpdateSkinInfo" target="manager" check_var="module_srl" />
-		<permission action="procModuleAdminInsertLang" target="manager" />
-	</permissions>
 	<actions>
-		<action name="dispModuleSelectList" type="view" />
-		<action name="dispModuleSkinInfo" type="view" />
-		<action name="dispModuleFileBox" type="view" />
-		<action name="dispModuleFileBoxAdd" type="view" />
+		<action name="dispModuleSelectList" type="view" permission="root" />
+		<action name="dispModuleSkinInfo" type="view" permission="all-managers" />
+		<action name="dispModuleFileBox" type="view" permission="root" />
+		<action name="dispModuleFileBoxAdd" type="view" permission="root" />
 		<action name="dispModuleChangeLang" type="mobile" />
 		
-		<action name="getModuleSkinInfoList" type="model" />
-		<action name="getFileBoxListHtml" type="model" />
-		<action name="getModuleInfoByMenuItemSrl" type="model" />
-		<action name="getLangListByLangcodeForAutoComplete" type="model" />
+		<action name="getModuleSkinInfoList" type="model" permission="root" />
+		<action name="getFileBoxListHtml" type="model" permission="root" />
+		<action name="getModuleInfoByMenuItemSrl" type="model" permission="root" />
+		<action name="getLangListByLangcodeForAutoComplete" type="model" permission="manager" />
 		<action name="getLangByLangcode" type="model" />
 		
-		<action name="procModuleFileBoxAdd" type="controller" />
-		<action name="procModuleFileBoxDelete" type="controller" />
+		<action name="procModuleFileBoxAdd" type="controller" permission="root" />
+		<action name="procModuleFileBoxDelete" type="controller" permission="root" />
 		
 		<action name="dispModuleAdminContent" type="view" menu_name="installedModule" menu_index="true" admin_index="true" />
 		<action name="dispModuleAdminCategory" type="view" menu_name="installedModule" />
@@ -54,12 +30,12 @@
 		<action name="getModuleAdminModuleList" type="model" />
 		<action name="getModuleAdminModuleInfo" type="model" />
 		<action name="getModuleAdminGrant" type="model" />
-		<action name="getModuleAdminLangCode" type="model" />
-		<action name="getModuleAdminLangListByName" type="model" />
-		<action name="getModuleAdminLangListByValue" type="model" />
+		<action name="getModuleAdminLangCode" type="model" permission="manager" />
+		<action name="getModuleAdminLangListByName" type="model" permission="manager" />
+		<action name="getModuleAdminLangListByValue" type="model" permission="manager" />
 		<action name="getModuleAdminModuleSearcherHtml" type="model" />
-		<action name="getModuleAdminMultilingualHtml" type="model" />
-		<action name="getModuleAdminLangListHtml" type="model" />
+		<action name="getModuleAdminMultilingualHtml" type="model" permission="manager" />
+		<action name="getModuleAdminLangListHtml" type="model" permission="manager" />
 		
 		<action name="procModuleAdminInsertCategory" type="controller" ruleset="insertCategory" />
 		<action name="procModuleAdminUpdateCategory" type="controller" ruleset="updateCategory" />
@@ -67,9 +43,9 @@
 		<action name="procModuleAdminModuleSetup" type="controller" ruleset="insertModuleSetup" />
 		<action name="procModuleAdminModuleGrantSetup" type="controller" ruleset="insertModulesGrant" />		
 		<action name="procModuleAdminCopyModule" type="controller" ruleset="copyModule" />
-		<action name="procModuleAdminInsertGrant" type="controller" />
-		<action name="procModuleAdminUpdateSkinInfo" type="controller" />
-		<action name="procModuleAdminInsertLang" type="controller" />
+		<action name="procModuleAdminInsertGrant" type="controller" permission="manager" check_var="module_srl" />
+		<action name="procModuleAdminUpdateSkinInfo" type="controller" permission="manager" check_var="module_srl" />
+		<action name="procModuleAdminInsertLang" type="controller" permission="manager" />
 		<action name="procModuleAdminDeleteLang" type="controller" />
 		<action name="procModuleAdminGetList" type="controller" />
 		<action name="procModuleAdminSetDesignInfo" type="controller" />

--- a/modules/module/module.model.php
+++ b/modules/module/module.model.php
@@ -837,22 +837,29 @@ class moduleModel extends module
 			{
 				if(is_array($permissions)) $permission_list = $permissions;
 				else $permission_list[] = $permissions;
-
+				
 				$buff[] = '$info->permission = new stdClass;';
-				$info->permission = new stdClass();
+				$buff[] = '$info->permission_check = new stdClass;';
+				
+				$info->permission = new stdClass;
+				$info->permission_check = new stdClass;
 				
 				foreach($permission_list as $permission)
 				{
 					$action = $permission->attrs->action;
 					$target = $permission->attrs->target;
 					
-					$info->permission->{$action} = $target;
-					$info->permission_check->{$action}->key = $permission->attrs->check_var ?: '';
-					$info->permission_check->{$action}->type = $permission->attrs->check_type ?: '';
+					$info->permission->$action = $target;
 					
 					$buff[] = sprintf('$info->permission->%s = \'%s\';', $action, $target);
-					$buff[] = sprintf('$info->permission_check->%s->key = \'%s\';', $action, $info->permission_check->{$action}->key);
-					$buff[] = sprintf('$info->permission_check->%s->type = \'%s\';', $action, $info->permission_check->{$action}->type);
+					
+					$info->permission_check->$action = new stdClass;
+					$info->permission_check->$action->key = $permission->attrs->check_var ?: '';
+					$info->permission_check->$action->type = $permission->attrs->check_type ?: '';
+					
+					$buff[] = sprintf('$info->permission_check->%s = new stdClass;', $action);
+					$buff[] = sprintf('$info->permission_check->%s->key = \'%s\';', $action, $info->permission_check->$action->key);
+					$buff[] = sprintf('$info->permission_check->%s->type = \'%s\';', $action, $info->permission_check->$action->type);
 				}
 			}
 			// for admin menus
@@ -890,7 +897,10 @@ class moduleModel extends module
 				if(!isset($info->permission))
 				{
 					$buff[] = '$info->permission = new stdClass;';
-					$info->permission = new stdClass();
+					$buff[] = '$info->permission_check = new stdClass;';
+					
+					$info->permission = new stdClass;
+					$info->permission_check = new stdClass;
 				}
 				
 				$buff[] = '$info->action = new stdClass;';
@@ -904,10 +914,14 @@ class moduleModel extends module
 					if($action->attrs->permission)
 					{
 						$info->permission->$name = $action->attrs->permission;
+						
+						$buff[] = sprintf('$info->permission->%s = \'%s\';', $name, $info->permission->$name);
+						
+						$info->permission_check->$name = new stdClass;
 						$info->permission_check->$name->key = $action->attrs->check_var ?: '';
 						$info->permission_check->$name->type = $action->attrs->check_type ?: '';
 						
-						$buff[] = sprintf('$info->permission->%s = \'%s\';', $name, $info->permission->$name);
+						$buff[] = sprintf('$info->permission_check->%s = new stdClass;', $name);
 						$buff[] = sprintf('$info->permission_check->%s->key = \'%s\';', $name, $info->permission_check->$name->key);
 						$buff[] = sprintf('$info->permission_check->%s->type = \'%s\';', $name, $info->permission_check->$name->type);
 					}

--- a/modules/module/module.model.php
+++ b/modules/module/module.model.php
@@ -1974,7 +1974,7 @@ class moduleModel extends module
 		$privilege_list = array_keys((array) $xml_info->grant);
 		
 		// Prepend default 'privilege name'
-		// is_admin, manager, is_site_admin not distinguish because of compatibility.
+		// manager, is_site_admin not distinguish because of compatibility.
 		array_unshift($privilege_list, 'access', 'is_admin', 'manager', 'is_site_admin', 'root');
 		
 		// Unique
@@ -1988,8 +1988,8 @@ class moduleModel extends module
 			{
 				$grant->{$val} = true;
 			}
-			// If a module manager, grant all (except 'root')
-			else if($is_module_admin === true && $val !== 'root')
+			// If a module manager, grant all (except 'root', 'is_admin')
+			else if($is_module_admin === true && $val !== 'root' && $val !== 'is_admin')
 			{
 				$grant->{$val} = true;
 			}

--- a/modules/module/module.model.php
+++ b/modules/module/module.model.php
@@ -839,13 +839,13 @@ class moduleModel extends module
 				else $permission_list[] = $permissions;
 
 				$buff[] = '$info->permission = new stdClass;';
-
 				$info->permission = new stdClass();
+				
 				foreach($permission_list as $permission)
 				{
 					$action = $permission->attrs->action;
 					$target = $permission->attrs->target;
-
+					
 					$info->permission->{$action} = $target;
 					$info->permission_check->{$action}->key = $permission->attrs->check_var ?: '';
 					$info->permission_check->{$action}->type = $permission->attrs->check_type ?: '';
@@ -863,6 +863,7 @@ class moduleModel extends module
 
 				$buff[] = '$info->menu = new stdClass;';
 				$info->menu = new stdClass();
+				
 				foreach($menu_list as $menu)
 				{
 					$menu_name = $menu->attrs->name;
@@ -885,20 +886,39 @@ class moduleModel extends module
 			{
 				if(is_array($actions)) $action_list = $actions;
 				else $action_list[] = $actions;
-
+				
+				if(!isset($info->permission))
+				{
+					$buff[] = '$info->permission = new stdClass;';
+					$info->permission = new stdClass();
+				}
+				
 				$buff[] = '$info->action = new stdClass;';
 				$info->action = new stdClass();
+				
 				foreach($action_list as $action)
 				{
 					$name = $action->attrs->name;
-
+					
+					// <action permission="...">
+					if($action->attrs->permission)
+					{
+						$info->permission->$name = $action->attrs->permission;
+						$info->permission_check->$name->key = $action->attrs->check_var ?: '';
+						$info->permission_check->$name->type = $action->attrs->check_type ?: '';
+						
+						$buff[] = sprintf('$info->permission->%s = \'%s\';', $name, $info->permission->$name);
+						$buff[] = sprintf('$info->permission_check->%s->key = \'%s\';', $name, $info->permission_check->$name->key);
+						$buff[] = sprintf('$info->permission_check->%s->type = \'%s\';', $name, $info->permission_check->$name->type);
+					}
+					
 					$type = $action->attrs->type;
 					$grant = $action->attrs->grant?$action->attrs->grant:'guest';
 					$standalone = $action->attrs->standalone=='false'?'false':'true';
 					$ruleset = $action->attrs->ruleset?$action->attrs->ruleset:'';
 					$method = $action->attrs->method?$action->attrs->method:'';
 					$check_csrf = $action->attrs->check_csrf=='false'?'false':'true';
-
+					
 					$index = $action->attrs->index;
 					$admin_index = $action->attrs->admin_index;
 					$setup_index = $action->attrs->setup_index;

--- a/modules/ncenterlite/conf/module.xml
+++ b/modules/ncenterlite/conf/module.xml
@@ -1,27 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module>
 	<grants />
-	<permissions>
-		<permission action="dispNcenterliteNotifyList" target="member" />
-		<permission action="dispNcenterliteUserConfig" target="member" />
-		
-		<permission action="getColorsetList" target="root" />
-		<permission action="getMyNotifyListTpl" target="member" />
-		
-		<permission action="procNcenterliteUserConfig" target="member" />
-		<permission action="procNcenterliteNotifyReadAll" target="member" />
-		<permission action="procNcenterliteRedirect" target="member" />
-	</permissions>
 	<actions>
-		<action name="dispNcenterliteNotifyList" type="view" />
-		<action name="dispNcenterliteUserConfig" type="view" />
+		<action name="dispNcenterliteNotifyList" type="view" permission="member" />
+		<action name="dispNcenterliteUserConfig" type="view" permission="member" />
 		
-		<action name="getColorsetList" type="model" />
-		<action name="getMyNotifyListTpl" type="model" />
+		<action name="getColorsetList" type="model" permission="root" />
+		<action name="getMyNotifyListTpl" type="model" permission="member" />
 		
-		<action name="procNcenterliteUserConfig" type="controller" />
-		<action name="procNcenterliteNotifyReadAll" type="controller" />
-		<action name="procNcenterliteRedirect" type="controller" method="GET|POST" />
+		<action name="procNcenterliteUserConfig" type="controller" permission="member" />
+		<action name="procNcenterliteNotifyReadAll" type="controller" permission="member" />
+		<action name="procNcenterliteRedirect" type="controller" permission="member" method="GET|POST" />
 		
 		<action name="dispNcenterliteAdminConfig" type="view" admin_index="true" menu_name="ncenterlite" menu_index="true" />
 		<action name="dispNcenterliteAdminAdvancedconfig" type="view" menu_name="ncenterlite" />

--- a/modules/page/conf/module.xml
+++ b/modules/page/conf/module.xml
@@ -1,42 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module>
-	<grants />
-	<permissions>
-		<permission action="dispPageAdminInfo" target="manager" check_var="module_srl" />
-		<permission action="dispPageAdminPageAdditionSetup" target="manager" check_var="module_srl" />
-		<permission action="dispPageAdminGrantInfo" target="manager" check_var="module_srl" />
-		<permission action="dispPageAdminSkinInfo" target="manager" check_var="module_srl" />
-		<permission action="dispPageAdminMobileSkinInfo" target="manager" check_var="module_srl" />
-		<permission action="dispPageAdminContentModify" target="manager" />
-		<permission action="dispPageAdminMobileContent" target="manager" />
-		<permission action="dispPageAdminMobileContentModify" target="manager" />
-		
-		<permission action="procPageAdminUpdate" target="manager" check_var="module_srl" />
-		<permission action="procPageAdminInsertContent" target="manager" check_var="module_srl" />
-		<permission action="procPageAdminArticleDocumentInsert" target="manager" />
-		<permission action="procPageAdminRemoveWidgetCache" target="manager" check_var="module_srl" />
-	</permissions>
+	<grants>
+		<grant name="modify" default="manager">
+			<title xml:lang="ko">페이지 수정</title>
+			<title xml:lang="en">page modify</title>
+		</grant>
+	</grants>
 	<actions>
 		<action name="dispPageIndex" type="view" standalone="false" index="true" />
 		
 		<action name="dispPageAdminContent" type="view" admin_index="true" menu_name="page" menu_index="true" />
 		<action name="dispPageAdminDelete" type="view" menu_name="page" />
-		<action name="dispPageAdminInfo" type="view" setup_index="true" menu_name="page" />
-		<action name="dispPageAdminPageAdditionSetup" type="view" menu_name="page" />
-		<action name="dispPageAdminGrantInfo" type="view" menu_name="page" />
-		<action name="dispPageAdminSkinInfo" type="view" menu_name="page" />
-		<action name="dispPageAdminMobileSkinInfo" type="view" menu_name="page" />
-		<action name="dispPageAdminContentModify" type="view" />
-		<action name="dispPageAdminMobileContent" type="view" />
-		<action name="dispPageAdminMobileContentModify" type="view" />
+		<action name="dispPageAdminInfo" type="view" permission="manager" check_var="module_srl" setup_index="true" menu_name="page" />
+		<action name="dispPageAdminPageAdditionSetup" type="view" permission="manager" check_var="module_srl" menu_name="page" />
+		<action name="dispPageAdminGrantInfo" type="view" permission="manager" check_var="module_srl" menu_name="page" />
+		<action name="dispPageAdminSkinInfo" type="view" permission="manager" check_var="module_srl" menu_name="page" />
+		<action name="dispPageAdminMobileSkinInfo" type="view" permission="manager" check_var="module_srl" menu_name="page" />
+		<action name="dispPageAdminContentModify" type="view" permission="modify" standalone="false" />
+		<action name="dispPageAdminMobileContent" type="view" permission="modify" standalone="false" />
+		<action name="dispPageAdminMobileContentModify" type="view" permission="modify" standalone="false" />
 		
 		<action name="procPageAdminInsert" type="controller" ruleset="insertPage" />
-		<action name="procPageAdminUpdate" type="controller" ruleset="updatePage" />
+		<action name="procPageAdminUpdate" type="controller" permission="manager" check_var="module_srl" ruleset="updatePage" />
 		<action name="procPageAdminDelete" type="controller" ruleset="deletePage" />
 		<action name="procPageAdminInsertConfig" type="controller" />
-		<action name="procPageAdminInsertContent" type="controller" />
-		<action name="procPageAdminArticleDocumentInsert" type="controller" />
-		<action name="procPageAdminRemoveWidgetCache" type="controller" />
+		<action name="procPageAdminInsertContent" type="controller" permission="modify" check_var="module_srl" standalone="false" />
+		<action name="procPageAdminArticleDocumentInsert" type="controller" permission="modify" standalone="false" />
+		<action name="procPageAdminRemoveWidgetCache" type="controller" permission="modify" check_var="module_srl" />
 	</actions>
 	<menus>
 		<menu name="page" type="all">

--- a/modules/point/conf/module.xml
+++ b/modules/point/conf/module.xml
@@ -1,12 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <module>
 	<grants />
-	<permissions>
-		<permission action="getMembersPointInfo" target="member" />
-		<permission action="procPointAdminInsertPointModuleConfig" target="manager" check_var="target_module_srl" />
-	</permissions>
 	<actions>
-		<action name="getMembersPointInfo" type="model" />
+		<action name="getMembersPointInfo" type="model" permission="member" />
 		
 		<action name="dispPointAdminConfig" type="view" admin_index="true" menu_name="point" menu_index="true" />
 		<action name="dispPointAdminModuleConfig" type="view" menu_name="point" />
@@ -15,7 +11,7 @@
 		<action name="procPointAdminInsertConfig" type="controller" ruleset="insertConfig" />
 		<action name="procPointAdminInsertModuleConfig" type="controller" />
 		<action name="procPointAdminUpdatePoint" type="controller" ruleset="updatePoint" />
-		<action name="procPointAdminInsertPointModuleConfig" type="controller" />
+		<action name="procPointAdminInsertPointModuleConfig" type="controller" permission="manager" check_var="target_module_srl" />
 		<action name="procPointAdminReCal" type="controller" />
 		<action name="procPointAdminApplyPoint" type="controller" />
 		<action name="procPointAdminReset" type="controller" />

--- a/modules/poll/conf/module.xml
+++ b/modules/poll/conf/module.xml
@@ -1,11 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <module>
 	<grants />
-	<permissions>
-		<permission action="procPollInsertItem" target="member" />
-		<permission action="procPollDeleteItem" target="member" />
-		<permission action="procPollGetList" target="root" />
-	</permissions>
 	<actions>
 		<action name="getPollstatus" type="model" />
 		<action name="getPollinfo" type="model" />
@@ -13,11 +8,11 @@
 		<action name="getPollGetColorsetList" type="model" />
 		
 		<action name="procPollInsert" type="controller" />
-		<action name="procPollInsertItem" type="controller" />
-		<action name="procPollDeleteItem" type="controller" />
+		<action name="procPollInsertItem" type="controller" permission="member" />
+		<action name="procPollDeleteItem" type="controller" permission="member" />
 		<action name="procPoll" type="controller" ruleset="poll" />
 		<action name="procPollViewResult" type="controller" />
-		<action name="procPollGetList" type="controller" />
+		<action name="procPollGetList" type="controller" permission="root" />
 		
 		<action name="dispPollAdminList" type="view" admin_index="true" menu_name="poll" menu_index="true" />
 		<action name="dispPollAdminResult" type="view" />

--- a/modules/rss/conf/module.xml
+++ b/modules/rss/conf/module.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module>
 	<grants />
-	<permissions>
-		<permission action="procRssAdminInsertModuleConfig" target="manager" check_var="target_module_srl" />
-	</permissions>
 	<actions>
 		<action name="rss" type="view" />
 		<action name="atom" type="view" />
@@ -11,7 +8,7 @@
 		<action name="dispRssAdminIndex" type="view" index="true" admin_index="true" menu_name="rss" menu_index="true" />
 		<action name="procRssAdminInsertConfig" type="controller" ruleset="insertRssConfig" />
 		<action name="procRssAdminDeleteFeedImage" type="controller" />
-		<action name="procRssAdminInsertModuleConfig" type="controller" />
+		<action name="procRssAdminInsertModuleConfig" type="controller" permission="manager" check_var="target_module_srl" />
 	</actions>
 	<menus>
 		<menu name="rss">

--- a/modules/session/conf/module.xml
+++ b/modules/session/conf/module.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <module>
 	<grants />
-	<permissions />
 	<actions>
 		<action name="dispSessionAdminIndex" type="view" admin_index="true" />
 		<action name="procSessionAdminClear" type="controller" />

--- a/modules/spamfilter/conf/module.xml
+++ b/modules/spamfilter/conf/module.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <module>
 	<grants />
-	<permissions />
 	<actions>
 		<action name="dispSpamfilterAdminDeniedIPList" type="view" admin_index="true" menu_name="spamFilter" menu_index="true" />
 		<action name="dispSpamfilterAdminDeniedWordList" type="view" menu_name="spamFilter" />

--- a/modules/trash/conf/module.xml
+++ b/modules/trash/conf/module.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <module>
 	<grants />
-	<permissions />
 	<actions>
 		<action name="dispTrashAdminList" type="view" admin_index="true" menu_name="trash" menu_index="true" />
 		<action name="dispTrashAdminView" type="view" menu_name="trash" />

--- a/modules/widget/conf/module.xml
+++ b/modules/widget/conf/module.xml
@@ -1,39 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <module>
 	<grants />
-	<permissions>
-		<permission action="dispWidgetInfo" target="all-managers" />
-		<permission action="dispWidgetGenerateCode" target="root" />
-		<permission action="dispWidgetGenerateCodeInPage" target="all-managers" />
-		<permission action="dispWidgetStyleGenerateCodeInPage" target="all-managers" />
-		
-		<permission action="procWidgetGenerateCode" target="root" />
-		<permission action="procWidgetGenerateCodeInPage" target="all-managers" />
-		<permission action="procWidgetInsertDocument" target="manager" check_var="module_srl" />
-		<permission action="procWidgetDeleteDocument" target="manager" check_type="document" check_var="document_srl" />
-		<permission action="procWidgetCopyDocument" target="manager" check_type="document" check_var="document_srl" />
-		<permission action="procWidgetGetColorsetList" target="all-managers" />
-		<permission action="procWidgetStyleExtraImageUpload" target="all-managers" />
-		
-		<permission action="dispWidgetAdminAddContent" target="manager" check_var="module_srl" />
-	</permissions>
 	<actions>
-		<action name="dispWidgetInfo" type="view" />
-		<action name="dispWidgetGenerateCode" type="view" />
-		<action name="dispWidgetGenerateCodeInPage" type="view" />
-		<action name="dispWidgetStyleGenerateCodeInPage" type="view" />
+		<action name="dispWidgetInfo" type="view" permission="all-managers" />
+		<action name="dispWidgetGenerateCode" type="view" permission="root" />
+		<action name="dispWidgetGenerateCodeInPage" type="view" permission="all-managers" />
+		<action name="dispWidgetStyleGenerateCodeInPage" type="view" permission="all-managers" />
 		
-		<action name="procWidgetGenerateCode" type="controller" />
-		<action name="procWidgetGenerateCodeInPage" type="controller" ruleset="generateCodeInPage" />
-		<action name="procWidgetInsertDocument" type="controller" />
-		<action name="procWidgetDeleteDocument" type="controller" />
-		<action name="procWidgetCopyDocument" type="controller" />
-		<action name="procWidgetGetColorsetList" type="controller" />
-		<action name="procWidgetStyleExtraImageUpload" type="controller" />
+		<action name="procWidgetGenerateCode" type="controller" permission="root" />
+		<action name="procWidgetGenerateCodeInPage" type="controller" permission="all-managers" ruleset="generateCodeInPage" />
+		<action name="procWidgetInsertDocument" type="controller" permission="manager" check_var="module_srl" />
+		<action name="procWidgetDeleteDocument" type="controller" permission="manager" check_type="document" check_var="document_srl" />
+		<action name="procWidgetCopyDocument" type="controller" permission="manager" check_type="document" check_var="document_srl" />
+		<action name="procWidgetGetColorsetList" type="controller" permission="all-managers" />
+		<action name="procWidgetStyleExtraImageUpload" type="controller" permission="all-managers" />
 		
 		<action name="dispWidgetAdminDownloadedList" type="view" admin_index="true" menu_name="installedWidget" menu_index="true" />
 		<action name="dispWidgetAdminGenerateCode" type="view" menu_name="installedWidget" />
-		<action name="dispWidgetAdminAddContent" type="view" />
+		<action name="dispWidgetAdminAddContent" type="view" permission="manager" check_var="module_srl" />
 	</actions>
 	<menus>
 		<menu name="installedWidget">


### PR DESCRIPTION
module.xml <action>에 `permission` 속성을 추가하여 깔끔하게 개선시켰습니다.
또한 사용자의 승인 권한 (grant)도 `permission` 속성으로 체크할 수 있도록 기능을 추가했습니다.

## 사용 예시
**퍼미션 체크 예**
게시판 모듈 관리에서 매니저 퍼미션 체크
`<action name="procBoardAdminInsertBoard" type="controller" permission="manager" check_var="module_srl" />`

! 필요에 따라 `check_var`, `check_type` 속성도 함께 사용할 수 있습니다.

**승인 권한 (grant) 체크 예 1**
사용자에게 게시판 모듈의 글쓰기 권한 (grant name : write_document)이 있는 지 체크
`<action name="dispBoardWrite" type="view" permission="write_document" />`

**승인 권한 (grant) 체크 예 2**
두가지 이상의 승인 권한을 모두 체크해야 할 경우 `,` 으로 구분을 하여 지정할 수 있습니다.
`<action name="dispBoardDeleteTrackback" type="view" permission="list,view" />`

`,` 구분자의 의미는 `or`이 아니라 `and` 입니다. 즉, 지정된 승인 권한을 모두 가지고 있어야 통과 됩니다.

## 기타
**권장**
보안을 위해 `<action>` 을 지정할때 `permission` 속성도 거의 필수로 지정하시기 바랍니다.
모든 사용자가 접근할 수 있는 개방된 act 일 경우 `permission="guest"` 으로 지정할 수 있습니다.

**참고**
해당 모듈에서 선언한 승인 권한 `<grant name="...">` 만 체크할 수 있습니다.
선언 되지 않은 승인 권한을 지정할 경우 무조건 거부 처리 됩니다.

**서드파티 호환성**
`<permission>` 태그 또한 여전히 사용할 수 있으며, `permission` 속성과 동일한 방식으로 작동 됩니다.

## 퍼미션 타입
퍼미션 타입은 선언한 승인 권한 (grant)이 아님에도 불구하고, `permission` 속성에 들어갈 수 있는 특별한 이름입니다. **퍼미션 타입과 선언한 승인 권한 (grant)의 이름이 같을 경우 퍼미션 타입이 우선입니다**

! 현재 사용 가능한 퍼미션 타입 입니다.
- `guest` : 모든 사용자 접근 가능
- `member` : 회원만 접근 가능
- `manager` : 해당 mid의 관리자만 접근 가능
- `root` : 최고 관리자만 접근 가능
- `all-managers` : 사이트의 모든 mid의 관리자 접근 가능
- `same-managers` : 해당 모듈에서 생성된 모든 mid의 관리자 접근 가능
게시판 모듈에서 사용한다면 '모든 게시판 관리자'를 의미 합니다.
- `모듈이름-managers` : '모듈이름'이란 모듈에서 생성된 모든 mid의 관리자 접근 가능
page-managers 일 경우 '모든 페이지 관리자'를 의미 합니다.