### PR TITLE
iOS에서 한글 입력시 줄바꿈이 잘 되지 않는 문제 보완

### DIFF
--- a/modules/editor/skins/ckeditor/editor.html
+++ b/modules/editor/skins/ckeditor/editor.html
@@ -106,7 +106,12 @@ var auto_saved_msg = "{$lang->msg_auto_saved}";
 			enableToolbar: true,
 			content_field: jQuery('[name={$editor_content_key_name}]')
 		};
-
+		
+		if (navigator.userAgent.match(/i(OS|Phone|Pad)/)) {
+			settings.ckeconfig.enterMode = CKEDITOR.ENTER_BR;
+			settings.ckeconfig.shiftEnterMode = CKEDITOR.ENTER_P;
+		}
+		
 		<!--@if($enable_component)-->
 			{@ $xe_component = array(); }
 			<!--@foreach($component_list as $component_name => $component)-->


### PR DESCRIPTION
iOS에서 CKEditor를 사용하여 아래와 같은 내용을 입력하려고 하면

> 가나다라
> 마바사아

줄바꿈이 먹히지 않으면서 아래와 같이 한 줄로 붙어서 나오거나

> 가나다라마바사아

버전에 따라서는 줄바꿈 직전의 문자가 두 번 나오는 경우도 있습니다.

> 가나다라라마바사아

CKEditor뿐 아니라 TinyMCE, Summernote, Quill 등 제가 테스트해본 대부분의 위지윅 에디터에서 동일한 문제가 발생하며, 블루투스 키보드를 사용해도 마찬가지입니다. 위지윅 에디터뿐 아니라 엑셀, 에버노트 등 다른 어플리케이션에서도 비슷한 문제가 발생한다고 합니다. 즉, 에디터의 버그가 아니라 iOS의 버그입니다.

참고: http://www.clien.net/cs2/bbs/board.php?bo_table=use&wr_id=884319

이 문제를 해결하기 위해 divarea 플러그인 사용, 폰트 변경을 통한 `<span>` 태그 삽입 등 여러 가지 방법을 시도해 보았으나 지금까지 발견한 가장 쓸만한 해결책은 `<p>` 태그가 아닌 `<br>` 태그로 줄바꿈을 하도록 설정하는 방법이었습니다.

이 PR은 iOS에서 에디터를 사용할 경우 `<p>` 태그가 아닌 `<br>` 태그로 줄바꿈을 하는 패치입니다.