### PR TITLE
Board API를 통한 데이터 노출 방지

### DIFF
--- a/modules/board/board.view.php
+++ b/modules/board/board.view.php
@@ -416,6 +416,7 @@ class boardView extends board
 		$oDocumentModel = getModel('document');
 		$document_srl = Context::get('document_srl');
 		$oDocument = $oDocumentModel->getDocument($document_srl);
+		Context::set('oDocument', $oDocument);
 		Context::set('file_list',$oDocument->getUploadedFiles());
 
 		$oSecurity = new Security();


### PR DESCRIPTION
xpressengine/xe-core#2074 에서 이미 문제점이 공개되어 버렸기에 공개적으로 패치합니다.

아래의 모든 문제들은 board 모듈의 액션들을 JSON으로 요청할 경우 board.view.php와 함께 board.api.php가 실행되면서 발생하는 문제입니다.

- dispBoardContentView에서 권한이 없는 사용자에게 확장변수가 노출되는 문제 (확장변수를 통해 개인정보를 입력받고 스킨에서 숨기는 사이트가 많습니다)
- dispBoardContentList에서 권한이 없는 사용자에게 비밀글 내용이 노출되는 문제
- dispBoardContentCommentList에서 권한이 없는 사용자에게 비밀댓글 내용이 노출되는 문제
- dispBoardContentFileList에서 파일을 직접 다운받을 수 있는 링크와 sid 등이 노출되는 문제
- 글이나 댓글을 반환할때 글쓴이의 아이디, 이름, 메일 주소 등 일반적인 게시판에서 노출되지 않는 개인정보가 포함되는 문제 (닉네임만 포함하여 반환하도록 변경)

이 패치로 인하여 board API에 의존하는 서드파티 자료가 정상 작동하지 않게 될 수 있으나, 보안과 직결된 문제이므로 그 정도는 감수해야 한다고 생각합니다. 만약 board API가 또다시 문제를 일으킨다면 접근 권한이 더욱 축소될 수도 있습니다.
