### PR TITLE
댓글 삭제시 parent_srl 에 인덱스가 없어 쿼리시간이 오래걸리는 문제 고침

### DIFF
--- a/modules/comment/comment.class.php
+++ b/modules/comment/comment.class.php
@@ -105,6 +105,11 @@ class comment extends ModuleObject
 			return true;
 		}
 
+		if(!$oDB->isIndexExists("comments", "idx_parent_srl"))
+		{
+			return true;
+		}
+
 		return FALSE;
 	}
 
@@ -183,6 +188,11 @@ class comment extends ModuleObject
 		if(!$oDB->isColumnExists("comment_declared_log","declare_message"))
 		{
 			$oDB->addColumn('comment_declared_log',"declare_message","text");
+		}
+
+		if(!$oDB->isIndexExists("comments", "idx_parent_srl"))
+		{
+			$oDB->addIndex('comments', 'idx_parent_srl', array('parent_srl'));
 		}
 
 		return new Object(0, 'success_updated');

--- a/modules/comment/schemas/comments.xml
+++ b/modules/comment/schemas/comments.xml
@@ -2,7 +2,7 @@
     <column name="comment_srl" type="number" size="11" notnull="notnull" primary_key="primary_key" />
     <column name="module_srl" type="number" size="11" default="0" notnull="notnull" index="idx_module_srl" />
     <column name="document_srl" type="number" size="11" default="0" notnull="notnull" index="idx_document_srl" />
-    <column name="parent_srl" type="number" size="11" default="0" notnull="notnull" />
+    <column name="parent_srl" type="number" size="11" default="0" notnull="notnull" index="idx_parent_srl" />
     <column name="is_secret" type="char" size="1" default="N" notnull="notnull" />
     <column name="content" type="bigtext" notnull="notnull" />
     <column name="voted_count" type="number" size="11" default="0" notnull="notnull" index="idx_voted_count" />


### PR DESCRIPTION
원문 PR https://github.com/xpressengine/xe-core/pull/2082
라이믹스에서는 이 PR을 가져올 경우 충돌의 여지가 있어 새로운 커밋으로 처리합니다. (class에서 충돌)