### PR TITLE
관리자 페이지에서 알림삭제시 캐시데이터가 남아있는 문제 고침

### DIFF
--- a/modules/ncenterlite/ncenterlite.admin.controller.php
+++ b/modules/ncenterlite/ncenterlite.admin.controller.php
@@ -165,11 +165,15 @@ class ncenterliteAdminController extends ncenterlite
 			$this->setMessage('ncenterlite_message_delete_notification_all');
 		}
 
-		if(!in_array(Context::getRequestMethod(),array('XMLRPC','JSON')))
+		$this->removeAllFlagFile();
+
+		if(Context::get('success_return_url'))
 		{
-			$returnUrl = Context::get('success_return_url') ?  Context::get('success_return_url') : getNotEncodedUrl('', 'module', 'admin', 'act', 'dispNcenterliteAdminList');
-			header('location: ' .$returnUrl);
-			return;
+			$this->setRedirectUrl(Context::get('success_return_url'));
+		}
+		else
+		{
+			$this->setRedirectUrl(getNotEncodedUrl('', 'module', 'admin', 'act', 'dispNcenterliteAdminList'));
 		}
 	}
 
@@ -198,6 +202,15 @@ class ncenterliteAdminController extends ncenterlite
 		else
 		{
 			$this->setRedirectUrl(getNotEncodedUrl('', 'module', 'admin', 'act', 'dispNcenterliteAdminCustomList'));
+		}
+	}
+
+	function removeAllFlagFile()
+	{
+		$flag_path = \RX_BASEDIR . 'files/cache/ncenterlite/new_notify/';
+		if(FileHandler::isDir($flag_path))
+		{
+			FileHandler::removeFilesInDir($flag_path);
 		}
 	}
 }


### PR DESCRIPTION
#817 의 문제를 고칩니다. 알림센터에 남아있는 전체삭제 기능을 사용할 경우 알림캐시를 삭제하지 않아 알림이 있는 것으로 나타나는 문제를 해결합니다.

1달이전의 데이터를 삭제하더라도 모든 데이터를 삭제하여 새롭게 쿼리를 할 수 있도록 되어있습니다~