### PR TITLE
알림센터 디비 삭제시 캐시파일 재생성 보완

### DIFF
--- a/modules/ncenterlite/ncenterlite.admin.controller.php
+++ b/modules/ncenterlite/ncenterlite.admin.controller.php
@@ -171,7 +171,7 @@ class ncenterliteAdminController extends ncenterlite
 			FileHandler::makeDir(\RX_BASEDIR . 'files/cache/ncenterlite/new_notify/');
 		}
 		$reg_obj = new stdClass();
-		$reg_obj->regdate = date('YmdHis');
+		$reg_obj->regdate = time();
 		$buff = "<?php return unserialize(" . var_export(serialize($reg_obj), true) . ");\n";
 		FileHandler::writeFile($flag_path, $buff);
 

--- a/modules/ncenterlite/ncenterlite.admin.controller.php
+++ b/modules/ncenterlite/ncenterlite.admin.controller.php
@@ -165,7 +165,7 @@ class ncenterliteAdminController extends ncenterlite
 			$this->setMessage('ncenterlite_message_delete_notification_all');
 		}
 
-		$flag_path = \RX_BASEDIR . 'files/cache/ncenterlite/new_notify/regdate_new.php';
+		$flag_path = \RX_BASEDIR . 'files/cache/ncenterlite/new_notify/delete_date.php';
 		if(!FileHandler::isDir(\RX_BASEDIR . 'files/cache/ncenterlite/new_notify'))
 		{
 			FileHandler::makeDir(\RX_BASEDIR . 'files/cache/ncenterlite/new_notify/');

--- a/modules/ncenterlite/ncenterlite.admin.controller.php
+++ b/modules/ncenterlite/ncenterlite.admin.controller.php
@@ -165,7 +165,15 @@ class ncenterliteAdminController extends ncenterlite
 			$this->setMessage('ncenterlite_message_delete_notification_all');
 		}
 
-		$this->removeAllFlagFile();
+		$flag_path = \RX_BASEDIR . 'files/cache/ncenterlite/new_notify/regdate_new.php';
+		if(!FileHandler::isDir(\RX_BASEDIR . 'files/cache/ncenterlite/new_notify'))
+		{
+			FileHandler::makeDir(\RX_BASEDIR . 'files/cache/ncenterlite/new_notify/');
+		}
+		$reg_obj = new stdClass();
+		$reg_obj->regdate = date('YmdHis');
+		$buff = "<?php return unserialize(" . var_export(serialize($reg_obj), true) . ");\n";
+		FileHandler::writeFile($flag_path, $buff);
 
 		if(Context::get('success_return_url'))
 		{
@@ -202,15 +210,6 @@ class ncenterliteAdminController extends ncenterlite
 		else
 		{
 			$this->setRedirectUrl(getNotEncodedUrl('', 'module', 'admin', 'act', 'dispNcenterliteAdminCustomList'));
-		}
-	}
-
-	function removeAllFlagFile()
-	{
-		$flag_path = \RX_BASEDIR . 'files/cache/ncenterlite/new_notify/';
-		if(FileHandler::isDir($flag_path))
-		{
-			FileHandler::removeFilesInDir($flag_path);
 		}
 	}
 }

--- a/modules/ncenterlite/ncenterlite.admin.controller.php
+++ b/modules/ncenterlite/ncenterlite.admin.controller.php
@@ -165,15 +165,11 @@ class ncenterliteAdminController extends ncenterlite
 			$this->setMessage('ncenterlite_message_delete_notification_all');
 		}
 
-		$flag_path = \RX_BASEDIR . 'files/cache/ncenterlite/new_notify/delete_date.php';
-		if(!FileHandler::isDir(\RX_BASEDIR . 'files/cache/ncenterlite/new_notify'))
-		{
-			FileHandler::makeDir(\RX_BASEDIR . 'files/cache/ncenterlite/new_notify/');
-		}
 		$reg_obj = new stdClass();
 		$reg_obj->regdate = time();
-		$buff = "<?php return unserialize(" . var_export(serialize($reg_obj), true) . ");\n";
-		FileHandler::writeFile($flag_path, $buff);
+
+		$flag_path = \RX_BASEDIR . 'files/cache/ncenterlite/new_notify/delete_date.php';
+		Rhymix\Framework\Storage::writePHPData($flag_path, $reg_obj);
 
 		if(Context::get('success_return_url'))
 		{

--- a/modules/ncenterlite/ncenterlite.controller.php
+++ b/modules/ncenterlite/ncenterlite.controller.php
@@ -1118,7 +1118,7 @@ class ncenterliteController extends ncenterlite
 		FileHandler::writeFile($flag_path, $buff);
 	}
 
-	public static function removeFlagFile($member_srl = null)
+	public function removeFlagFile($member_srl = null)
 	{
 		if($member_srl === null)
 		{

--- a/modules/ncenterlite/ncenterlite.controller.php
+++ b/modules/ncenterlite/ncenterlite.controller.php
@@ -65,7 +65,7 @@ class ncenterliteController extends ncenterlite
 		}
 		else
 		{
-			self::removeFlagFile($args->member_srl);
+			$this->removeFlagFile($args->member_srl);
 		}
 		return new Object();
 	}
@@ -443,7 +443,7 @@ class ncenterliteController extends ncenterlite
 			foreach($member_srls as $member_srl)
 			{
 				//Remove flag files
-				self::removeFlagFile($member_srl);
+				$this->removeFlagFile($member_srl);
 			}
 		}
 
@@ -498,7 +498,7 @@ class ncenterliteController extends ncenterlite
 			foreach($member_srls as $member_srl)
 			{
 				//Remove flag files
-				self::removeFlagFile($member_srl);
+				$this->removeFlagFile($member_srl);
 			}
 		}
 		return new Object();
@@ -548,7 +548,7 @@ class ncenterliteController extends ncenterlite
 				if($output_update->toBool())
 				{
 					//Remove flag files
-					self::removeFlagFile($args->member_srl);
+					$this->removeFlagFile($args->member_srl);
 				}
 			}
 		}
@@ -570,7 +570,7 @@ class ncenterliteController extends ncenterlite
 					if($outputs->toBool())
 					{
 						//Remove flag files
-						self::removeFlagFile($args->member_srl);
+						$this->removeFlagFile($args->member_srl);
 					}
 				}
 			}
@@ -617,7 +617,7 @@ class ncenterliteController extends ncenterlite
 				if($update_output->toBool())
 				{
 					//Remove flag files
-					self::removeFlagFile($args->member_srl);
+					$this->removeFlagFile($args->member_srl);
 				}
 			}
 		}
@@ -678,7 +678,7 @@ class ncenterliteController extends ncenterlite
 				if($output->toBool())
 				{
 					//Remove flag files
-					self::removeFlagFile($args->member_srl);
+					$this->removeFlagFile($args->member_srl);
 				}
 			}
 		}
@@ -692,7 +692,7 @@ class ncenterliteController extends ncenterlite
 			if($output->toBool())
 			{
 				//Remove flag files
-				self::removeFlagFile($args->member_srl);
+				$this->removeFlagFile($args->member_srl);
 			}
 		}
 
@@ -923,7 +923,7 @@ class ncenterliteController extends ncenterlite
 		//$output = executeQuery('ncenterlite.deleteNotify', $args);
 
 		//Remove flag files
-		self::removeFlagFile($args->member_srl);
+		$this->removeFlagFile($args->member_srl);
 		return $output;
 	}
 
@@ -936,7 +936,7 @@ class ncenterliteController extends ncenterlite
 		//$output = executeQuery('ncenterlite.deleteNotifyByTargetSrl', $args);
 
 		//Remove flag files
-		self::removeFlagFile($args->member_srl);
+		$this->removeFlagFile($args->member_srl);
 		return $output;
 	}
 
@@ -948,7 +948,7 @@ class ncenterliteController extends ncenterlite
 		//$output = executeQuery('ncenterlite.deleteNotifyByMemberSrl', $args);
 
 		//Remove flag files
-		self::removeFlagFile($args->member_srl);
+		$this->removeFlagFile($args->member_srl);
 		return $output;
 	}
 
@@ -1096,7 +1096,7 @@ class ncenterliteController extends ncenterlite
 			}
 		}
 
-		self::removeFlagFile($args->member_srl);
+		$this->removeFlagFile($args->member_srl);
 
 		return $output;
 	}

--- a/modules/ncenterlite/ncenterlite.model.php
+++ b/modules/ncenterlite/ncenterlite.model.php
@@ -225,30 +225,29 @@ class ncenterliteModel extends ncenterlite
 		if(FileHandler::exists($flag_path) && $page <= 1)
 		{
 			$deleteFlagPath = \RX_BASEDIR . 'files/cache/ncenterlite/new_notify/delete_date.php';
-			if(FileHandler::exists($deleteFlagPath))
-			{
-				$deleteOutput = require_once $deleteFlagPath;
-				if(is_object($deleteOutput))
-				{
-					$create_time = filemtime($flag_path);
 
-					if($create_time <= $deleteOutput->regdate)
+			$deleteOutput = Rhymix\Framework\Storage::readPHPData($deleteFlagPath);
+			if($deleteOutput !== false)
+			{
+				$create_time = filemtime($flag_path);
+
+				if($create_time <= $deleteOutput->regdate)
+				{
+					$oNcenterliteController = getController('ncenterlite');
+					$oNcenterliteController->removeFlagFile($member_srl);
+				}
+				else
+				{
+					$output = require_once $flag_path;
+					if(is_object($output))
 					{
-						$oNcenterliteController = getController('ncenterlite');
-						$oNcenterliteController->removeFlagFile($member_srl);
-					}
-					else
-					{
-						$output = require_once $flag_path;
-						if(is_object($output))
-						{
-							$output->flag_exists = true;
-							return $output;
-						}
+						$output->flag_exists = true;
+						return $output;
 					}
 				}
 			}
 		}
+
 		$args = new stdClass();
 		$args->member_srl = $member_srl;
 		$args->page = $page ? $page : 1;

--- a/modules/ncenterlite/ncenterlite.model.php
+++ b/modules/ncenterlite/ncenterlite.model.php
@@ -238,8 +238,8 @@ class ncenterliteModel extends ncenterlite
 				}
 				else
 				{
-					$output = require_once $flag_path;
-					if(is_object($output))
+					$output = Rhymix\Framework\Storage::readPHPData($flag_path);
+					if($output !== false)
 					{
 						$output->flag_exists = true;
 						return $output;

--- a/modules/ncenterlite/ncenterlite.model.php
+++ b/modules/ncenterlite/ncenterlite.model.php
@@ -224,11 +224,29 @@ class ncenterliteModel extends ncenterlite
 
 		if(FileHandler::exists($flag_path) && $page <= 1)
 		{
-			$output = require_once $flag_path;
-			if(is_object($output))
+			$deleteFlagPath = \RX_BASEDIR . 'files/cache/ncenterlite/new_notify/delete_date.php';
+			if(FileHandler::exists($deleteFlagPath))
 			{
-				$output->flag_exists = true;
-				return $output;
+				$deleteOutput = require_once $deleteFlagPath;
+				if(is_object($deleteOutput))
+				{
+					$create_time = filemtime($flag_path);
+
+					if($create_time <= $deleteOutput->regdate)
+					{
+						$oNcenterliteController = getController('ncenterlite');
+						$oNcenterliteController->removeFlagFile($member_srl);
+					}
+					else
+					{
+						$output = require_once $flag_path;
+						if(is_object($output))
+						{
+							$output->flag_exists = true;
+							return $output;
+						}
+					}
+				}
 			}
 		}
 		$args = new stdClass();


### PR DESCRIPTION
기존의 삭제 방식을 버리고, 캐시파일 생성한 내용에 날짜오브젝트를 넣어두고 해당 날자 이후의 경우 캐시파일을 그대로 유지하도록 하고 해당 날자의 이전의 경우 해당 캐시파일을 지우도록 하여 새롭게 생성하도록 만듬.
