### PR TITLE
회원의 익명글도 확인할 수 있도록 개선

### DIFF
--- a/modules/document/document.admin.view.php
+++ b/modules/document/document.admin.view.php
@@ -40,9 +40,18 @@ class documentAdminView extends document
 		$args->page = Context::get('page'); // /< Page
 		$args->list_count = 30; // /< the number of posts to display on a single page
 		$args->page_count = 5; // /< the number of pages that appear in the page navigation
-
+		
 		$args->search_target = Context::get('search_target'); // /< search (title, contents ...)
 		$args->search_keyword = Context::get('search_keyword'); // /< keyword to search
+		if ($args->search_target === 'member_srl')
+		{
+			$logged_info = Context::get('logged_info');
+			if ($logged_info->is_admin === 'Y' || intval($logged_info->member_srl) === intval($args->search_keyword))
+			{
+				$args->member_srl = array(intval($args->search_keyword), intval($args->search_keyword) * -1);
+				unset($args->search_target, $args->search_keyword);
+			}
+		}
 
 		$args->sort_index = 'list_order'; // /< sorting value
 

--- a/modules/document/document.model.php
+++ b/modules/document/document.model.php
@@ -1405,11 +1405,6 @@ class documentModel extends document
 					elseif($search_keyword=='temp') $args->statusList = array($this->getConfigStatus('temp'));
 					break;
 				case 'member_srl' :
-					if($logged_info->member_srl == $searchOpt->search_keyword || $logged_info->is_admin == 'Y')
-					{
-						$args->member_srl = -1*$searchOpt->search_keyword . ',' . $searchOpt->search_keyword;
-					}
-					break;
 				case 'readed_count' :
 				case 'voted_count' :
 				case 'comment_count' :

--- a/modules/document/document.model.php
+++ b/modules/document/document.model.php
@@ -1325,7 +1325,7 @@ class documentModel extends document
 		if($searchOpt->mid)
 		{
 			$oModuleModel = getModel('module');
-			$args->module_srl = $oModuleModel->getModuleSrlByMid($obj->mid);
+			$args->module_srl = $oModuleModel->getModuleSrlByMid($searchOpt->mid);
 			unset($searchOpt->mid);
 		}
 
@@ -1405,6 +1405,11 @@ class documentModel extends document
 					elseif($search_keyword=='temp') $args->statusList = array($this->getConfigStatus('temp'));
 					break;
 				case 'member_srl' :
+					if($logged_info->member_srl == $searchOpt->search_keyword || $logged_info->is_admin == 'Y')
+					{
+						$args->member_srl = -1*$searchOpt->search_keyword . ',' . $searchOpt->search_keyword;
+					}
+					break;
 				case 'readed_count' :
 				case 'voted_count' :
 				case 'comment_count' :

--- a/modules/document/queries/getDocumentList.xml
+++ b/modules/document/queries/getDocumentList.xml
@@ -10,7 +10,7 @@
         <condition operation="notin" column="module_srl" var="exclude_module_srl" filter="number" pipe="and" />
         <condition operation="in" column="category_srl" var="category_srl" pipe="and" />
         <condition operation="equal" column="is_notice" var="s_is_notice" pipe="and" />
-        <condition operation="equal" column="member_srl" var="member_srl" filter="number" pipe="and" />
+        <condition operation="in" column="member_srl" var="member_srl" pipe="and" />
         <condition operation="in" column="status" var="statusList" pipe="and" />
         <group pipe="and">
             <condition operation="more" column="list_order" var="division" pipe="and" />

--- a/modules/member/member.view.php
+++ b/modules/member/member.view.php
@@ -358,9 +358,11 @@ class memberView extends member
 	 */
 	function dispMemberOwnDocument()
 	{
-		$oMemberModel = getModel('member');
 		// A message appears if the user is not logged-in
-		if(!$oMemberModel->isLogged()) return $this->stop('msg_not_logged');
+		if(!Context::get('is_logged'))
+		{
+			return new Object(-1, 'msg_not_logged');
+		}
 
 		$logged_info = Context::get('logged_info');
 		$member_srl = $logged_info->member_srl;


### PR DESCRIPTION
#723 이슈의 내용을 처리하는 이슈입니다.

자체적으로 쿼리르 돌리고, 권한 탈취의 우려를 최대한 줄이기 위해 $logged_info 함수를 가져와서 member_srl 을 넘기도록 쿼리를 추가하였습니다.

그리고 document_list.html 에 작성된 템플릿의 특성상 new DocumentItem 을 사용하는 형식이기에 해당 부분도 모두 변환할 수 있도록 세팅했습니다.
