### PR TITLE
모바일에서 댓글 작성 또는 수정시 HTML 태그가 escape되는 문제 수정

### DIFF
--- a/common/functions.php
+++ b/common/functions.php
@@ -595,6 +595,29 @@ function utf8_trim($str)
 }
 
 /**
+ * Check if a string contains HTML content.
+ * This function checks whether a string seems to contain HTML.
+ * It checks for tags like <p>, <div>, <br> at the beginning and end of lines.
+ * 
+ * @param string $str The input string
+ * @return bool
+ */
+function is_html_content($str)
+{
+	$str = preg_replace('![\r\n]+!', "\n", utf8_trim(utf8_clean($str)));
+	$line_count = substr_count($str, "\n") + 1;
+	$tag_count = preg_match_all('!(?:^<(?:p|div)(?:>|\s*[a-z])|<(?:/p|/div|br\s?/?)>$)!im', $str);
+	if ($tag_count > 4 || ($tag_count > 0 && $tag_count >= $line_count - 1))
+	{
+		return true;
+	}
+	else
+	{
+		return false;
+	}
+}
+
+/**
  * Check if HTML content is empty.
  * This function checks whether any printable characters remain
  * after removing all tags except images, videos, iframes, etc.

--- a/common/functions.php
+++ b/common/functions.php
@@ -616,7 +616,11 @@ function is_html_content($str)
 	{
 		return true;
 	}
-	
+	$span_tag_count = preg_match_all('!<span\s+style="[^"<>]*?">.+?</span>!i', $str);
+	if ($span_tag_count >= 1)
+	{
+		return true;
+	}
 	return false;
 }
 

--- a/common/functions.php
+++ b/common/functions.php
@@ -606,15 +606,18 @@ function is_html_content($str)
 {
 	$str = preg_replace('![\r\n]+!', "\n", utf8_trim(utf8_clean($str)));
 	$line_count = substr_count($str, "\n") + 1;
-	$tag_count = preg_match_all('!(?:^<(?:p|div)(?:>|\s*[a-z])|<(?:/p|/div|br\s?/?)>$)!im', $str);
-	if ($tag_count > 4 || ($tag_count > 0 && $tag_count >= $line_count - 1))
+	$p_tag_count = preg_match_all('!(?:^<(?:p|div|h[1-6])(?:>|\s*[a-z])|</(?:p|div|h[1-6])>$)!im', $str);
+	if ($p_tag_count > 4 || ($p_tag_count > 0 && $p_tag_count >= $line_count * 2))
 	{
 		return true;
 	}
-	else
+	$br_tag_count = preg_match_all('!<br\s?/?>$!im', $str);
+	if ($br_tag_count > 4 || ($br_tag_count > 0 && $br_tag_count >= $line_count - 1))
 	{
-		return false;
+		return true;
 	}
+	
+	return false;
 }
 
 /**

--- a/modules/comment/comment.controller.php
+++ b/modules/comment/comment.controller.php
@@ -426,6 +426,7 @@ class commentController extends comment
 
 		// remove Rhymix's own tags from the contents
 		$obj->content = preg_replace('!<\!--(Before|After)(Document|Comment)\(([0-9]+),([0-9]+)\)-->!is', '', $obj->content);
+
 		// Return error if content is empty.
 		if (!$manual_inserted && is_empty_html_content($obj->content))
 		{
@@ -435,25 +436,22 @@ class commentController extends comment
 		// if use editor of nohtml, Remove HTML tags from the contents.
 		if(!$manual_inserted)
 		{
-			if(Mobile::isFromMobilePhone() && $obj->use_editor != 'Y')
+			if ($obj->use_editor === 'Y' || $obj->use_html === 'Y')
 			{
-				if($obj->use_html != 'Y')
-				{
-					$obj->content = htmlspecialchars($obj->content, ENT_COMPAT | ENT_HTML401, 'UTF-8', false);
-				}
-				$obj->content = nl2br($obj->content);
+				$is_html_content = true;
+			}
+			elseif ($obj->use_editor === 'N' || $obj->use_html === 'N')
+			{
+				$is_html_content = false;
 			}
 			else
 			{
-				$oEditorModel = getModel('editor');
-				$editor_config = $oEditorModel->getEditorConfig($obj->module_srl);
-				
-				if(strpos($editor_config->sel_comment_editor_colorset, 'nohtml') !== FALSE)
-				{
-					$obj->content = preg_replace('/\<br(\s*)?\/?\>/i', PHP_EOL, $obj->content);
-					$obj->content = htmlspecialchars($obj->content, ENT_COMPAT | ENT_HTML401, 'UTF-8', false);
-					$obj->content = str_replace(array("\r\n", "\r", "\n"), '<br />', $obj->content);
-				}
+				$is_html_content = is_html_content($obj->content);
+			}
+			
+			if (!$is_html_content)
+			{
+				$obj->content = nl2br($obj->use_html === 'Y' ? $obj->content : escape($obj->content, false));
 			}
 		}
 
@@ -807,25 +805,22 @@ class commentController extends comment
 		// if use editor of nohtml, Remove HTML tags from the contents.
 		if(!$manual_updated)
 		{
-			if(Mobile::isFromMobilePhone() && $obj->use_editor != 'Y')
+			if ($obj->use_editor === 'Y' || $obj->use_html === 'Y')
 			{
-				if($obj->use_html != 'Y')
-				{
-					$obj->content = htmlspecialchars($obj->content, ENT_COMPAT | ENT_HTML401, 'UTF-8', false);
-				}
-				$obj->content = nl2br($obj->content);
+				$is_html_content = true;
+			}
+			elseif ($obj->use_editor === 'N' || $obj->use_html === 'N')
+			{
+				$is_html_content = false;
 			}
 			else
 			{
-				$oEditorModel = getModel('editor');
-				$editor_config = $oEditorModel->getEditorConfig($obj->module_srl);
-				
-				if(strpos($editor_config->sel_comment_editor_colorset, 'nohtml') !== FALSE)
-				{
-					$obj->content = preg_replace('/\<br(\s*)?\/?\>/i', PHP_EOL, $obj->content);
-					$obj->content = htmlspecialchars($obj->content, ENT_COMPAT | ENT_HTML401, 'UTF-8', false);
-					$obj->content = str_replace(array("\r\n", "\r", "\n"), '<br />', $obj->content);
-				}
+				$is_html_content = is_html_content($obj->content);
+			}
+			
+			if (!$is_html_content)
+			{
+				$obj->content = nl2br($obj->use_html === 'Y' ? $obj->content : escape($obj->content, false));
 			}
 		}
 

--- a/modules/comment/comment.controller.php
+++ b/modules/comment/comment.controller.php
@@ -437,7 +437,7 @@ class commentController extends comment
 		if(!$manual_inserted)
 		{
 			$editor_config = getModel('editor')->getEditorConfig($obj->module_srl);
-			if (strpos($editor_config->comment_editor_skin, 'textarea') !== false || strpos($editor_config->sel_comment_editor_colorset, 'nohtml') !== false)
+			if (strpos($editor_config->sel_comment_editor_colorset, 'nohtml') !== false)
 			{
 				$is_html_content = false;
 			}
@@ -811,7 +811,7 @@ class commentController extends comment
 		if(!$manual_updated)
 		{
 			$editor_config = getModel('editor')->getEditorConfig($obj->module_srl);
-			if (strpos($editor_config->comment_editor_skin, 'textarea') !== false || strpos($editor_config->sel_comment_editor_colorset, 'nohtml') !== false)
+			if (strpos($editor_config->sel_comment_editor_colorset, 'nohtml') !== false)
 			{
 				$is_html_content = false;
 			}

--- a/modules/comment/comment.controller.php
+++ b/modules/comment/comment.controller.php
@@ -436,7 +436,12 @@ class commentController extends comment
 		// if use editor of nohtml, Remove HTML tags from the contents.
 		if(!$manual_inserted)
 		{
-			if ($obj->use_editor === 'Y' || $obj->use_html === 'Y')
+			$editor_config = getModel('editor')->getEditorConfig($obj->module_srl);
+			if (strpos($editor_config->comment_editor_skin, 'textarea') !== false || strpos($editor_config->sel_comment_editor_colorset, 'nohtml') !== false)
+			{
+				$is_html_content = false;
+			}
+			elseif ($obj->use_editor === 'Y' || $obj->use_html === 'Y')
 			{
 				$is_html_content = true;
 			}
@@ -805,7 +810,12 @@ class commentController extends comment
 		// if use editor of nohtml, Remove HTML tags from the contents.
 		if(!$manual_updated)
 		{
-			if ($obj->use_editor === 'Y' || $obj->use_html === 'Y')
+			$editor_config = getModel('editor')->getEditorConfig($obj->module_srl);
+			if (strpos($editor_config->comment_editor_skin, 'textarea') !== false || strpos($editor_config->sel_comment_editor_colorset, 'nohtml') !== false)
+			{
+				$is_html_content = false;
+			}
+			elseif ($obj->use_editor === 'Y' || $obj->use_html === 'Y')
 			{
 				$is_html_content = true;
 			}

--- a/modules/document/document.controller.php
+++ b/modules/document/document.controller.php
@@ -457,27 +457,25 @@ class documentController extends document
 		// if use editor of nohtml, Remove HTML tags from the contents.
 		if(!$manual_inserted)
 		{
-			if(Mobile::isFromMobilePhone() && $obj->use_editor != 'Y')
+			if ($obj->use_editor === 'Y' || $obj->use_html === 'Y')
 			{
-				if($obj->use_html != 'Y')
-				{
-					$obj->content = htmlspecialchars($obj->content, ENT_COMPAT | ENT_HTML401, 'UTF-8', false);
-				}
-				$obj->content = nl2br($obj->content);
+				$is_html_content = true;
+			}
+			elseif ($obj->use_editor === 'N' || $obj->use_html === 'N')
+			{
+				$is_html_content = false;
 			}
 			else
 			{
-				$oEditorModel = getModel('editor');
-				$editor_config = $oEditorModel->getEditorConfig($obj->module_srl);
-				
-				if(strpos($editor_config->sel_editor_colorset, 'nohtml') !== FALSE)
-				{
-					$obj->content = preg_replace('/\<br(\s*)?\/?\>/i', PHP_EOL, $obj->content);
-					$obj->content = htmlspecialchars($obj->content, ENT_COMPAT | ENT_HTML401, 'UTF-8', false);
-					$obj->content = str_replace(array("\r\n", "\r", "\n"), '<br />', $obj->content);
-				}
+				$is_html_content = is_html_content($obj->content);
+			}
+			
+			if (!$is_html_content)
+			{
+				$obj->content = nl2br($obj->use_html === 'Y' ? $obj->content : escape($obj->content, false));
 			}
 		}
+
 		// Remove iframe and script if not a top adminisrator in the session.
 		if($logged_info->is_admin != 'Y') $obj->content = removeHackTag($obj->content);
 		// An error appears if both log-in info and user name don't exist.
@@ -713,27 +711,25 @@ class documentController extends document
 		// if use editor of nohtml, Remove HTML tags from the contents.
 		if(!$manual_updated)
 		{
-			if(Mobile::isFromMobilePhone() && $obj->use_editor != 'Y')
+			if ($obj->use_editor === 'Y' || $obj->use_html === 'Y')
 			{
-				if($obj->use_html != 'Y')
-				{
-					$obj->content = htmlspecialchars($obj->content, ENT_COMPAT | ENT_HTML401, 'UTF-8', false);
-				}
-				$obj->content = nl2br($obj->content);
+				$is_html_content = true;
+			}
+			elseif ($obj->use_editor === 'N' || $obj->use_html === 'N')
+			{
+				$is_html_content = false;
 			}
 			else
 			{
-				$oEditorModel = getModel('editor');
-				$editor_config = $oEditorModel->getEditorConfig($obj->module_srl);
-				
-				if(strpos($editor_config->sel_editor_colorset, 'nohtml') !== FALSE)
-				{
-					$obj->content = preg_replace('/\<br(\s*)?\/?\>/i', PHP_EOL, $obj->content);
-					$obj->content = htmlspecialchars($obj->content, ENT_COMPAT | ENT_HTML401, 'UTF-8', false);
-					$obj->content = str_replace(array("\r\n", "\r", "\n"), '<br />', $obj->content);
-				}
+				$is_html_content = is_html_content($obj->content);
+			}
+			
+			if (!$is_html_content)
+			{
+				$obj->content = nl2br($obj->use_html === 'Y' ? $obj->content : escape($obj->content, false));
 			}
 		}
+
 		// Change not extra vars but language code of the original document if document's lang_code is different from author's setting.
 		if($source_obj->get('lang_code') != Context::getLangType())
 		{

--- a/modules/document/document.controller.php
+++ b/modules/document/document.controller.php
@@ -457,7 +457,12 @@ class documentController extends document
 		// if use editor of nohtml, Remove HTML tags from the contents.
 		if(!$manual_inserted)
 		{
-			if ($obj->use_editor === 'Y' || $obj->use_html === 'Y')
+			$editor_config = getModel('editor')->getEditorConfig($obj->module_srl);
+			if (strpos($editor_config->comment_editor_skin, 'textarea') !== false || strpos($editor_config->sel_comment_editor_colorset, 'nohtml') !== false)
+			{
+				$is_html_content = false;
+			}
+			elseif ($obj->use_editor === 'Y' || $obj->use_html === 'Y')
 			{
 				$is_html_content = true;
 			}
@@ -711,7 +716,12 @@ class documentController extends document
 		// if use editor of nohtml, Remove HTML tags from the contents.
 		if(!$manual_updated)
 		{
-			if ($obj->use_editor === 'Y' || $obj->use_html === 'Y')
+			$editor_config = getModel('editor')->getEditorConfig($obj->module_srl);
+			if (strpos($editor_config->comment_editor_skin, 'textarea') !== false || strpos($editor_config->sel_comment_editor_colorset, 'nohtml') !== false)
+			{
+				$is_html_content = false;
+			}
+			elseif ($obj->use_editor === 'Y' || $obj->use_html === 'Y')
 			{
 				$is_html_content = true;
 			}

--- a/modules/document/document.controller.php
+++ b/modules/document/document.controller.php
@@ -458,7 +458,7 @@ class documentController extends document
 		if(!$manual_inserted)
 		{
 			$editor_config = getModel('editor')->getEditorConfig($obj->module_srl);
-			if (strpos($editor_config->comment_editor_skin, 'textarea') !== false || strpos($editor_config->sel_comment_editor_colorset, 'nohtml') !== false)
+			if (strpos($editor_config->sel_editor_colorset, 'nohtml') !== false)
 			{
 				$is_html_content = false;
 			}
@@ -717,7 +717,7 @@ class documentController extends document
 		if(!$manual_updated)
 		{
 			$editor_config = getModel('editor')->getEditorConfig($obj->module_srl);
-			if (strpos($editor_config->comment_editor_skin, 'textarea') !== false || strpos($editor_config->sel_comment_editor_colorset, 'nohtml') !== false)
+			if (strpos($editor_config->sel_editor_colorset, 'nohtml') !== false)
 			{
 				$is_html_content = false;
 			}

--- a/modules/editor/skins/ckeditor/editor.html
+++ b/modules/editor/skins/ckeditor/editor.html
@@ -45,10 +45,8 @@ var auto_saved_msg = "{$lang->msg_auto_saved}";
 </block>
 
 <script>
-(function($){
-	"use strict";
-	// editor
 	$(function(){
+		"use strict";
 		<!--@if(!FileHandler::exists('common/js/plugins/ckeditor/ckeditor/config.js'))-->CKEDITOR.config.customConfig = '';<!--@endif-->
 		
 		// Import CSS content from PHP.
@@ -69,7 +67,9 @@ var auto_saved_msg = "{$lang->msg_auto_saved}";
 			}
 		}
 		var font_list = [];
-		<block loop="$lang->edit->fontlist => $fontname">font_list.push({json_encode($fontname)});</block>
+		<!--@foreach($lang->edit->fontlist as $fontname)-->
+			font_list.push({json_encode($fontname)});
+		<!--@endforeach-->
 		if (default_font_fullname !== null && !$.inArray(default_font_fullname, font_list)) {
 			font_list.push(default_font_fullname);
 		}
@@ -89,6 +89,7 @@ var auto_saved_msg = "{$lang->msg_auto_saved}";
 			return val + "/" + val + "px";
 		}).join(";");
 		
+		// Initialize CKEditor settings.
 		var settings = {
 			ckeconfig: {
 				height: '{$editor_height}',
@@ -108,11 +109,13 @@ var auto_saved_msg = "{$lang->msg_auto_saved}";
 			content_field: jQuery('[name={$editor_content_key_name}]')
 		};
 		
+		// Temporary workaround for line break bug in recent versions of iOS.
 		if (navigator.userAgent.match(/i(OS|Phone|Pad)/)) {
 			settings.ckeconfig.enterMode = CKEDITOR.ENTER_BR;
 			settings.ckeconfig.shiftEnterMode = CKEDITOR.ENTER_P;
 		}
 
+		// Prevent removal of icon fonts and Google code.
 		CKEDITOR.dtd.$removeEmpty.i = 0;
 		CKEDITOR.dtd.$removeEmpty.ins = 0;
 
@@ -157,7 +160,22 @@ var auto_saved_msg = "{$lang->msg_auto_saved}";
 
 		CKEDITOR.addCss(css_content);
 
+		// Initialize CKEditor.
 		var ckeApp = $('#ckeditor_instance_{$editor_sequence}').XeCkEditor(settings);
+		
+		// Add use_editor and use_html fields to parent form.
+		var parentform = $('#ckeditor_instance_{$editor_sequence}').parents('form');
+		var use_editor = parentform.find("input[name='use_editor']");
+		var use_html = parentform.find("input[name='use_html']");
+		if (use_editor.size()) {
+			use_editor.val("Y");
+		} else {
+			parentform.append('<input type="hidden" name="use_editor" value="Y" />');
+		}
+		if (use_html.size()) {
+			use_html.val("Y");
+		} else {
+			parentform.append('<input type="hidden" name="use_html" value="Y" />');
+		}
 	});
-})(jQuery);
 </script>

--- a/modules/editor/skins/textarea/editor.html
+++ b/modules/editor/skins/textarea/editor.html
@@ -28,8 +28,23 @@
 			
 			// Save edited content
 			textarea.on("change", function() {
-				content_input.val("<p>" + String($(this).val()).escape().replace(/\r?\n/, "</p>\n<p>") + "</p>");
+				content_input.val("<p>" + String($(this).val()).escape().replace(/\r?\n/g, "</p>\n<p>") + "</p>");
 			});
+			
+			// Add use_editor and use_html fields to parent form.
+			var parentform = $('#textarea_instance_{$editor_sequence}').parents('form');
+			var use_editor = parentform.find("input[name='use_editor']");
+			var use_html = parentform.find("input[name='use_html']");
+			if (use_editor.size()) {
+				use_editor.val("Y");
+			} else {
+				parentform.append('<input type="hidden" name="use_editor" value="Y" />');
+			}
+			if (use_html.size()) {
+				use_html.val("Y");
+			} else {
+				parentform.append('<input type="hidden" name="use_html" value="Y" />');
+			}
 			
 		});
 	</script>

--- a/tests/unit/functions/FunctionsTest.php
+++ b/tests/unit/functions/FunctionsTest.php
@@ -176,9 +176,11 @@ class FunctionsTest extends \Codeception\TestCase\Test
 		$this->assertTrue(is_html_content("Hello<br />\nWorld"));
 		$this->assertTrue(is_html_content("<p class='foo'>Hello</p>\n<p class='bar'>World</p>"));
 		$this->assertTrue(is_html_content("<div>Hello<br>\r\n\n\n\n\nWorld</div>"));
+		$this->assertTrue(is_html_content('<p style="margin-top:16px">이럴 때는 &lt;p&gt; 태그나 &lt;span&gt; 태그를 사용해야 합니다.</p>'));
 		$this->assertTrue(is_html_content('This is <span style="font-style:italic">italic</span> text.'));
 		$this->assertFalse(is_html_content('This is an empty <span></span> tag. Most editors don\'t produce these.'));
-		$this->assertFalse(is_html_content("You have to use a <p> tag."));
+		$this->assertFalse(is_html_content('The <p class="foobar"> tag is the most appropriate here.'));
+		$this->assertFalse(is_html_content("이럴 때는 <p> 태그나 <span> 태그를 사용해야 합니다."));
 		$this->assertFalse(is_html_content("This is multiline content.\n<p> tag is here.\nOther lines are here, too.<br>\nMost lines don't have any tags."));
 		$this->assertFalse(is_html_content("<p> tag is unbalanced here.\nAnother line!<br />\nAnd a dangling line..."));
 		$this->assertFalse(is_html_content("Looks like a broken editor<br />\nthat produced\nthis kind of\nstring!</div>"));

--- a/tests/unit/functions/FunctionsTest.php
+++ b/tests/unit/functions/FunctionsTest.php
@@ -178,6 +178,8 @@ class FunctionsTest extends \Codeception\TestCase\Test
 		$this->assertTrue(is_html_content("<div>Hello<br>\r\n\n\n\n\nWorld</div>"));
 		$this->assertFalse(is_html_content("You have to use a <p> tag."));
 		$this->assertFalse(is_html_content("This is multiline content.\n<p> tag is here.\nOther lines are here, too.<br>\nMost lines don't have any tags."));
+		$this->assertFalse(is_html_content("<p> tag is unbalanced here.\nAnother line!<br />\nAnd a dangling line..."));
+		$this->assertFalse(is_html_content("Looks like a broken editor<br />\nthat produced\nthis kind of\nstring!</div>"));
 	}
 	
 	public function testIsEmptyHTMLContent()

--- a/tests/unit/functions/FunctionsTest.php
+++ b/tests/unit/functions/FunctionsTest.php
@@ -168,6 +168,18 @@ class FunctionsTest extends \Codeception\TestCase\Test
 		$this->assertEquals("Trimmed", utf8_trim("\x20\xe2\x80\x80Trimmed\x0a\x0c\x07\x09"));
 	}
 	
+	public function testIsHTMLContent()
+	{
+		$this->assertTrue(is_html_content("<p>Hello World</p>"));
+		$this->assertTrue(is_html_content("Hello World<br>"));
+		$this->assertTrue(is_html_content("Hello World<br/>"));
+		$this->assertTrue(is_html_content("Hello<br />\nWorld"));
+		$this->assertTrue(is_html_content("<p class='foo'>Hello</p>\n<p class='bar'>World</p>"));
+		$this->assertTrue(is_html_content("<div>Hello<br>\r\n\n\n\n\nWorld</div>"));
+		$this->assertFalse(is_html_content("You have to use a <p> tag."));
+		$this->assertFalse(is_html_content("This is multiline content.\n<p> tag is here.\nOther lines are here, too.<br>\nMost lines don't have any tags."));
+	}
+	
 	public function testIsEmptyHTMLContent()
 	{
 		$this->assertTrue(is_empty_html_content('<p>&nbsp;<br><br></p>'));

--- a/tests/unit/functions/FunctionsTest.php
+++ b/tests/unit/functions/FunctionsTest.php
@@ -176,6 +176,8 @@ class FunctionsTest extends \Codeception\TestCase\Test
 		$this->assertTrue(is_html_content("Hello<br />\nWorld"));
 		$this->assertTrue(is_html_content("<p class='foo'>Hello</p>\n<p class='bar'>World</p>"));
 		$this->assertTrue(is_html_content("<div>Hello<br>\r\n\n\n\n\nWorld</div>"));
+		$this->assertTrue(is_html_content('This is <span style="font-style:italic">italic</span> text.'));
+		$this->assertFalse(is_html_content('This is an empty <span></span> tag. Most editors don\'t produce these.'));
 		$this->assertFalse(is_html_content("You have to use a <p> tag."));
 		$this->assertFalse(is_html_content("This is multiline content.\n<p> tag is here.\nOther lines are here, too.<br>\nMost lines don't have any tags."));
 		$this->assertFalse(is_html_content("<p> tag is unbalanced here.\nAnother line!<br />\nAnd a dangling line..."));


### PR DESCRIPTION
서드파티 스킨에서 #859 와 같은 문제가 종종 발생하고 있습니다.

에디터를 사용하여 작성한 콘텐츠는 `use_editor`, `use_html` 등의 필드가 따라와야 하지만, 모바일 에디터 지원패치 이전에 작성된 대부분의 스킨에는 이런 필드가 없으며 대부분의 사용자들이 인터넷에 돌아다니는 각종 팁글을 참고하여 주먹구구식으로 고쳐쓰고 있기 때문에 일괄적인 수정 방법을 제시하기도 어려운 형편입니다.

그래서 코어의 문서 모듈과 댓글 모듈에서 HTML 여부를 판단하는 방법을 바꾸려고 합니다. `use_editor`, `use_html` 등의 필드가 없더라도 내용 자체를 분석하여, 줄바꿈 문자 앞뒤에 `<p>`, `<div>`, `<br>` 등의 태그가 일관성있게 들어 있거나 `<span style="..."></span>` 태그로 글자 속성을 변경한 것이 발견되면 HTML로 취급하여 이중으로 escape하지 않습니다.

(단, `use_editor`, `use_html` 필드가 있는 경우에는 내용 분석 없이 해당 설정을 따릅니다.)

예를 들어 아래와 같은 내용은 HTML로 취급합니다.

```
<p>라이믹스는</p>
<p>최고입니다</p>
````

```
<div style="text-align:center">안녕하세요<br />
라이믹스입니다.</div>
```

```
옛날 에디터로 작성한 글은<br>
이렇게 태그가 들어 있을 수도 있습니다.
```

```
글자 속성 변경에는 <span style="font-size:16px">이런</span> 태그를 사용합니다.
```

아래와 같은 내용은 HTML로 취급하지 않습니다. 이런 경우에는 escape를 해주어야 글쓴이가 의도한 대로 화면에 표시됩니다.

```
이럴 때는 <p> 태그나 <span> 태그를 사용해야 합니다.
```

```
<p> 태그를 사용하는 것이 바람직하지만, 원한다면 <br />을 사용해도 웹표준에 어긋나지는 않아요.
```

이러한 기능을 구현하기 위해 아래와 같은 단계를 거칩니다.

- [x] `is_html_content()` 함수 추가
- [x] 다양한 종류의 문자열을 제대로 처리하는지 확인하기 위한 유닛 테스트 작성
- [x] 문서 모듈과 댓글 모듈의 insert 및 update 액션에 적용
- [x] HTML 작성이 허용되지 않은 게시판에서 무단으로 사용하는 것을 방지
- [x] 에디터 사용시 `use_editor`, `use_html` 필드를 자동으로 추가하여 호환성 극대화