### PR TITLE
module 시리얼 넘버가 누락되면 모든 모듈을 가져옴.

### DIFF
--- a/modules/module/module.model.php
+++ b/modules/module/module.model.php
@@ -357,6 +357,10 @@ class moduleModel extends module
 	 */
 	function getModuleInfoByModuleSrl($module_srl, $columnList = array())
 	{
+		if(!$module_srl)
+		{
+			return false;
+		}
 		$mid_info = Rhymix\Framework\Cache::get("site_and_module:mid_info:$module_srl");
 		if($mid_info === null)
 		{


### PR DESCRIPTION
모듈 시리얼 넘버가 getModuleInfoByModuleSrl 실행할때 누락이 되면 모든 모듈리스트의 정보를 array형태로 반환하게 됩니다.

하나의 모듈의 정보를 가져오기 위한 함수이니 만큼 정리할 필요가 있어보입니다.

그리고 쿼리에서 module_srl에 notnull="notnull" 옵션도 필요해 보이네요..

혹시 문제가 되지 않을지 검토해주세요!