### PR TITLE
comment, document 모듈의 권한 정리

### DIFF
--- a/addons/blogapi/blogapi.addon.php
+++ b/addons/blogapi/blogapi.addon.php
@@ -233,7 +233,7 @@ if($called_position == 'before_module_proc')
 			{
 				$oDocumentModel = getModel('document');
 				$oDocument = $oDocumentModel->getDocument($document_srl);
-				if(!$oDocument->isExists() || !$oDocument->isGranted())
+				if(!$oDocument->isGranted())
 				{
 					printContent(getXmlRpcFailure(1, 'no permission'));
 				}

--- a/classes/module/ModuleHandler.class.php
+++ b/classes/module/ModuleHandler.class.php
@@ -228,12 +228,9 @@ class ModuleHandler extends Handler
 			{
 				$oDocumentModel = getModel('document');
 				$oDocument = $oDocumentModel->getDocument($this->document_srl);
-				if($oDocument->isSecret() || $oDocument->get('status') === $oDocumentModel->getConfigStatus('temp'))
+				if(!$oDocument->isAccessible())
 				{
-					if(!$oDocument->isGranted() && !$oDocument->isAccessible())
-					{
-						$this->httpStatusCode = '403';
-					}
+					$this->httpStatusCode = '403';
 				}
 			}
 		}

--- a/modules/board/board.view.php
+++ b/modules/board/board.view.php
@@ -782,7 +782,7 @@ class boardView extends board
 
 		// if the document is not granted, then back to the password input form
 		$oModuleModel = getModel('module');
-		if($oDocument->isExists()&&!$oDocument->isGranted())
+		if($oDocument->isExists() && !$oDocument->isGranted())
 		{
 			return $this->setTemplateFile('input_password_form');
 		}

--- a/modules/board/board.view.php
+++ b/modules/board/board.view.php
@@ -328,13 +328,12 @@ class boardView extends board
 				));
 
 				// update the document view count (if the document is not secret)
-				if(!$oDocument->isSecret() || $oDocument->isGranted())
+				if($oDocument->isAccessible())
 				{
 					$oDocument->updateReadedCount();
 				}
-
 				// disappear the document if it is secret
-				if($oDocument->isSecret() && !$oDocument->isGranted())
+				else
 				{
 					$oDocument->add('content',lang('thisissecret'));
 				}

--- a/modules/board/m.skins/default/read.html
+++ b/modules/board/m.skins/default/read.html
@@ -8,7 +8,7 @@
 	<a href="{getUrl('act','dispBoardWrite','document_srl','')}" class="write">{$lang->cmd_write}</a>
 </div>
 <div class="co">
-		<!--@if($oDocument->isSecret() && !$oDocument->isGranted())-->
+		<!--@if(!$oDocument->isAccessible())-->
 		<form action="./" method="get" class="ff" onsubmit="return procFilter(this, input_password)">
 		<input type="hidden" name="mid" value="{$mid}" />
 		<input type="hidden" name="page" value="{$page}" />

--- a/modules/board/m.skins/simpleGray/read.html
+++ b/modules/board/m.skins/simpleGray/read.html
@@ -9,7 +9,7 @@
 			<span>{$oDocument->getRegdate()}</span>
 		</div>
 		<div class="co">
-                <!--@if($oDocument->isSecret() && !$oDocument->isGranted())-->
+                <!--@if(!$oDocument->isAccessible())-->
                     <div class="secretContent">
                         <form action="./" method="get" onsubmit="return procFilter(this, input_password)">
                         <input type="hidden" name="mid" value="{$mid}" />

--- a/modules/board/skins/default/_read.html
+++ b/modules/board/skins/default/_read.html
@@ -20,7 +20,7 @@
 	</div>
 	<!-- /READ HEADER -->
 	<!-- Extra Output -->
-	<div class="exOut" cond="$oDocument->isExtraVarsExists() && (!$oDocument->isSecret() || $oDocument->isGranted())">
+	<div class="exOut" cond="$oDocument->isExtraVarsExists() && $oDocument->isAccessible()">
 		<table border="1" cellspacing="0" summary="Extra Form Output">
 			<tr loop="$oDocument->getExtraVars() => $key,$val">
 				<th scope="row">{$val->name}</th>
@@ -31,7 +31,7 @@
 	<!-- /Extra Output -->
 	<!-- READ BODY -->
 	<div class="read_body">
-		<!--@if($oDocument->isSecret() && !$oDocument->isGranted())-->
+		<!--@if(!$oDocument->isAccessible())-->
 		<form action="./" method="get" onsubmit="return procFilter(this, input_password)">
 			<input type="hidden" name="mid" value="{$mid}" />
 			<input type="hidden" name="page" value="{$page}" />

--- a/modules/board/skins/xedition/_read.html
+++ b/modules/board/skins/xedition/_read.html
@@ -24,7 +24,7 @@
 	</div>
 	<!-- /READ HEADER -->
 	<!-- Extra Output -->
-	<div class="exOut" cond="$oDocument->isExtraVarsExists() && (!$oDocument->isSecret() || $oDocument->isGranted())">
+	<div class="exOut" cond="$oDocument->isExtraVarsExists() && $oDocument->isAccessible()">
 		<table border="1" cellspacing="0" summary="Extra Form Output">
 			<tr loop="$oDocument->getExtraVars() => $key,$val">
 				<th scope="row">{$val->name}</th>
@@ -35,7 +35,7 @@
 	<!-- /Extra Output -->
 	<!-- READ BODY -->
 	<div class="read_body">
-		<!--@if($oDocument->isSecret() && !$oDocument->isGranted())-->
+		<!--@if(!$oDocument->isAccessible())-->
 		<form action="./" method="get" onsubmit="return procFilter(this, input_password)" class="secretForm">
 			<input type="hidden" name="mid" value="{$mid}" />
 			<input type="hidden" name="page" value="{$page}" />

--- a/modules/comment/comment.controller.php
+++ b/modules/comment/comment.controller.php
@@ -1257,7 +1257,7 @@ class commentController extends comment
 			$oDocument = $oDocumentModel->getDocument($document_srl);
 		}
 
-		if(!$oDocument->isExists() || !$oDocument->isGranted())
+		if(!$oDocument->isGranted())
 		{
 			return new BaseObject(-1, 'msg_not_permitted');
 		}

--- a/modules/comment/comment.item.php
+++ b/modules/comment/comment.item.php
@@ -17,7 +17,11 @@ class commentItem extends BaseObject
 	 * @var int
 	 */
 	var $comment_srl = 0;
-
+	/**
+	 * grant
+	 * @var bool
+	 */
+	var $grant_cache = null;
 	/**
 	 * Get the column list int the table
 	 * @var array
@@ -88,52 +92,85 @@ class commentItem extends BaseObject
 
 	function isExists()
 	{
-		return $this->comment_srl ? TRUE : FALSE;
+		return (bool) $this->comment_srl;
 	}
-
+	
 	function isGranted()
 	{
-		if($_SESSION['granted_comment'][$this->comment_srl])
+		if ($_SESSION['granted_comment'][$this->comment_srl])
 		{
-			return TRUE;
+			return $this->grant_cache = true;
 		}
-
-		if(!Context::get('is_logged'))
+		
+		if ($this->grant_cache !== null)
 		{
-			return FALSE;
+			return $this->grant_cache;
 		}
-
+		
 		$logged_info = Context::get('logged_info');
-		if($logged_info->is_admin == 'Y')
+		if (!$logged_info->member_srl)
 		{
-			return TRUE;
+			return $this->grant_cache = false;
 		}
-
-		$grant = Context::get('grant');
-		if($grant->manager)
+		if ($logged_info->is_admin == 'Y')
 		{
-			return TRUE;
+			return $this->grant_cache = true;
 		}
-
-		if($this->get('member_srl') && ($this->get('member_srl') == $logged_info->member_srl || $this->get('member_srl') * -1 == $logged_info->member_srl))
+		if ($this->get('member_srl') && abs($this->get('member_srl')) == $logged_info->member_srl)
 		{
-			return TRUE;
+			return $this->grant_cache = true;
 		}
-
-		return FALSE;
+		
+		$oModuleModel = getModel('module');
+		$grant = $oModuleModel->getGrant($oModuleModel->getModuleInfoByModuleSrl($this->get('module_srl')), $logged_info);
+		if ($grant->manager)
+		{
+			return $this->grant_cache = true;
+		}
+		
+		return $this->grant_cache = false;
 	}
-
+	
 	function setGrant()
 	{
-		$this->is_granted = TRUE;
+		$this->grant_cache = true;
 	}
-
+	
 	function setGrantForSession()
 	{
 		$_SESSION['granted_comment'][$this->comment_srl] = true;
 		$this->setGrant();
 	}
-
+	
+	function isAccessible()
+	{
+		if ($_SESSION['accessible'][$this->comment_srl] === $this->get('last_update'))
+		{
+			return true;
+		}
+		
+		if ($this->get('status') == RX_STATUS_PUBLIC)
+		{
+			$this->setAccessible();
+			return true;
+		}
+		
+		if ($this->isGranted())
+		{
+			$this->setAccessible();
+			return true;
+		}
+		
+		$oDocument = getModel('document')->getDocument($this->get('document_srl'));
+		if ($oDocument->isExists() && $oDocument->isGranted())
+		{
+			$this->setAccessible();
+			return true;
+		}
+		
+		return false;
+	}
+	
 	function setAccessible()
 	{
 		if(Context::getSessionStatus())
@@ -141,58 +178,30 @@ class commentItem extends BaseObject
 			$_SESSION['accessible'][$this->comment_srl] = $this->get('last_update');
 		}
 	}
-
+	
 	function isEditable()
 	{
-		if($this->isGranted() || !$this->get('member_srl'))
-		{
-			return TRUE;
-		}
-		return FALSE;
+		return !$this->get('member_srl') || $this->isGranted();
 	}
-
+	
 	function isSecret()
 	{
-		return $this->get('is_secret') == 'Y' ? TRUE : FALSE;
+		return $this->get('is_secret') == 'Y';
 	}
-
+	
 	function isDeleted()
 	{
 		return $this->get('status') == RX_STATUS_DELETED || $this->get('status') == RX_STATUS_DELETED_BY_ADMIN;
 	}
-
+	
 	function isDeletedByAdmin()
 	{
 		return $this->get('status') == RX_STATUS_DELETED_BY_ADMIN;
 	}
-
-	function isAccessible()
-	{
-		if (isset($_SESSION['accessible'][$this->comment_srl]) && $_SESSION['accessible'][$this->comment_srl] === $this->get('last_update'))
-		{
-			return TRUE;
-		}
-
-		if (!$this->isSecret() || $this->isGranted())
-		{
-			$this->setAccessible();
-			return TRUE;
-		}
-
-		$oDocumentModel = getModel('document');
-		$oDocument = $oDocumentModel->getDocument($this->get('document_srl'));
-		if ($oDocument->isExists() && $oDocument->isGranted())
-		{
-			$this->setAccessible();
-			return TRUE;
-		}
-
-		return FALSE;
-	}
-
+	
 	function useNotify()
 	{
-		return $this->get('notify_message') == 'Y' ? TRUE : FALSE;
+		return $this->get('notify_message') == 'Y';
 	}
 
 	/**

--- a/modules/comment/comment.model.php
+++ b/modules/comment/comment.model.php
@@ -297,7 +297,7 @@ class commentModel extends comment
 	 * @param bool $published
 	 * @return int
 	 */
-	function getCommentAllCount($module_srl, $published = null)
+	function getCommentAllCount($module_srl, $published = false)
 	{
 		$args = new stdClass();
 		$args->module_srl = $module_srl;

--- a/modules/document/document.class.php
+++ b/modules/document/document.class.php
@@ -373,8 +373,7 @@ class document extends ModuleObject
 	 */
 	function getConfigStatus($key)
 	{
-		if(array_key_exists(strtolower($key), $this->statusList)) return $this->statusList[$key];
-		else $this->getDefaultStatus();
+		return $this->statusList[$key];
 	}
 }
 /* End of file document.class.php */

--- a/modules/document/document.item.php
+++ b/modules/document/document.item.php
@@ -214,7 +214,8 @@ class documentItem extends BaseObject
 			return true;
 		}
 		
-		if ($this->get('status') === $this->getConfigStatus('public') || $this->get('status') === $this->getConfigStatus('temp'))
+		$status_list = getModel('document')->getStatusList();
+		if ($this->get('status') === $status_list['public'] || $this->get('status') === $status_list['temp'])
 		{
 			$this->setAccessible();
 			return true;
@@ -302,7 +303,7 @@ class documentItem extends BaseObject
 	
 	function isSecret()
 	{
-		return $this->get('status') == $this->getConfigStatus('secret');
+		return $this->get('status') == getModel('document')->getConfigStatus('secret');
 	}
 	
 	function isNotice()

--- a/modules/document/tpl/print_page.html
+++ b/modules/document/tpl/print_page.html
@@ -2,14 +2,12 @@
 <h1 class="h1">{$oDocument->getTitleText()}</h1>
 <a href="#popup_menu_area" class="member_{$oDocument->get('member_srl')}">{$oDocument->get('nick_name')}</a>
 {$oDocument->getRegdate()}
-<!--@if($oDocument->isExtraVarsExists() && (!$oDocument->isSecret() || $oDocument->isGranted()) )-->
+<!--@if($oDocument->isExtraVarsExists() && $oDocument->isAccessible())-->
 <!--@foreach($oDocument->getExtraVars() as $key => $val)-->    
 {$val->name}: {$val->getValueHtml()}
 <!--@end-->
 <!--@end-->    
 {$oDocument->getContent(false, false)} 
 <script>
-//<![CDATA[
-    jQuery(window).load(function() { window.print(); } );
-//]]>
+jQuery(window).load(function() { window.print(); } );
 </script>

--- a/modules/file/file.model.php
+++ b/modules/file/file.model.php
@@ -43,7 +43,7 @@ class fileModel extends file
 			if(!$oDocument->isExists())
 			{
 				$oComment = $oCommentModel->getComment($upload_target_srl);
-				if($oComment->isExists() && $oComment->isSecret() && !$oComment->isGranted())
+				if($oComment->isExists() && !$oComment->isAccessible())
 				{
 					return $this->setError('msg_not_permitted');
 				}
@@ -52,7 +52,7 @@ class fileModel extends file
 			}
 
 			// document 권한 확인
-			if($oDocument->isExists() && $oDocument->isSecret() && !$oDocument->isGranted())
+			if($oDocument->isExists() && !$oDocument->isAccessible())
 			{
 				return $this->setError('msg_not_permitted');
 			}

--- a/modules/member/member.controller.php
+++ b/modules/member/member.controller.php
@@ -130,7 +130,7 @@ class memberController extends member
 		$oDocument = $oDocumentModel->getDocument($document_srl);
 		
 		// Check document
-		if($oDocument->isSecret() && !$oDocument->isGranted())
+		if(!$oDocument->isAccessible())
 		{
 			return $this->setError('msg_is_secret');
 		}


### PR DESCRIPTION
comment, document 모듈에서 권한 문제를 당담하는 `isGranted()` `isAccessible()`를 정리하였습니다.

- comment, document 모듈의 `isGranted()` `isAccessible()` 통일
- 코어내 비밀글 조건문 통일 (서드파티 권장)
`$oDocument->isSecret() && !$oDocument->isGranted()` -> `!$oDocument->isAccessible()`
`!$oDocument->isSecret() || $oDocument->isGranted()` -> `$oDocument->isAccessible()`
- 기타 코드 정리

## Document의 status
현재 Document 모듈에는 `private` `public` `secret` `temp` 이렇게 네가지의 status가 존재합니다.
그 역할을 다음과 같이 정리해보았습니다.

구분 | public | private | secret | temp
----- | ------ | --------| -------| ------
목록에 게시 | O | X | O | X
본인만 열람 | X | O | O | ~~X~~O

~~이에 따라 `public` `temp` 문서일 경우 `isAccessible()`시 `true`를 반환하도록 하였습니다.~~