### PR TITLE
사이트 디자인 설정내 쉬운설치의 섬네일 오류

### DIFF
--- a/modules/menu/tpl/sitemap.html
+++ b/modules/menu/tpl/sitemap.html
@@ -2496,11 +2496,10 @@ jQuery(function($){
 						sIsInstalled = "";
 					}
 
-					var sScreenshot = item.item_screenshot_url.replace(/^https:\/\//, "");
 					$node = $.tmpl( "downloadableItem", {
 						MenuType: item.title,
 						MenuTypeDesc: item.package_description,
-						ScreenShotURL: sScreenshot,
+						ScreenShotURL: item.item_screenshot_url,
 						Score: item.package_star,
 						TotalVotes: item.package_voted,
 						LastUpdatedWithTime: formatUpdatedDateWithTime(item.item_regdate),


### PR DESCRIPTION
사이트 디자인 설정 내 쉬운설치 메뉴에서 섬네일 주소 오류가 있었습니다.
수정합니다.

# Remove unnecessary string replacing.

I have an mistake at
https://github.com/rhymix/rhymix/commit/3dc1b5d804d931df8b8a2e9cf7a20cfa30f6b7b3
. It was late, but I fix it now.