### PR TITLE
약관 설정의 내용 편집이 textarea 에디터 스킨도 호환 가능하도록 개선 #1003

### DIFF
--- a/modules/editor/skins/ckeditor/editor.html
+++ b/modules/editor/skins/ckeditor/editor.html
@@ -184,5 +184,21 @@ var auto_saved_msg = "{$lang->msg_auto_saved}";
 		} else {
 			parentform.append('<input type="hidden" name="use_html" value="Y" />');
 		}
+
+		if(typeof rx_agt_parent_input !== 'undefined') {
+			CKEDITOR.on('instanceReady', function(evt) {
+				var editor = evt.editor;
+				editor.setData(rx_agt_parent_input.val());
+	
+				editor.on("resize", function(evt){
+					rx_agt_parent_iframe.height(evt.data.outerHeight);
+				});
+				editor.on("change", function() {
+					rx_agt_parent_input.val(editor.getData());
+				});
+
+				rx_agt_parent_iframe.height($(".cke_chrome").parent().height());
+			});
+		}
 	});
 </script>

--- a/modules/editor/skins/textarea/editor.html
+++ b/modules/editor/skins/textarea/editor.html
@@ -24,6 +24,15 @@
 			
 			// Load
 			editorTextarea({$editor_sequence});
+
+			if(typeof rx_agt_parent_input !== 'undefined') {
+				textarea.val($('<div></div>').html(rx_agt_parent_input.val()).text());
+				textarea.on("change", function() {
+					rx_agt_parent_input.val(textarea.val());
+				});
+
+				rx_agt_parent_iframe.height(textarea.parent().height());
+			}
 		});
 	</script>
 </div>

--- a/modules/member/member.admin.controller.php
+++ b/modules/member/member.admin.controller.php
@@ -262,6 +262,7 @@ class memberAdminController extends member
 				$agreement = new stdClass;
 				$agreement->title = escape(utf8_trim($args->{'agreement_' . $i . '_title'}));
 				$agreement->content = $args->{'agreement_' . $i . '_content'};
+				$agreement->content = getModel('editor')->converter($agreement, 'document');
 				$agreement->type = $args->{'agreement_' . $i . '_type'};
 				if (!in_array($agreement->type, array('required', 'optional', 'disabled')))
 				{

--- a/modules/member/tpl/agreements_edit.html
+++ b/modules/member/tpl/agreements_edit.html
@@ -1,23 +1,7 @@
 <script>
-	$(function() {
-		var editor;
-		var parent = window.opener ? window.opener : window.parent;
-		var parent_input = $("#{$parent_input_id}", parent.document);
-		var parent_iframe = parent_input.siblings("iframe.editor_iframe");
-		CKEDITOR.on('instanceReady', function(evt) {
-			editor = evt.editor;
-			editor.setData(parent_input.val());
-			editor.on("resize", function(evt){
-				var height = evt.data.outerHeight;
-				parent_iframe.height(height);
-			});
-			editor.on("change", function() {
-				var content = editor.getData();
-				parent_input.val(content);
-			});
-			parent_iframe.height($(".cke_chrome").parent().height());
-		});
-	});
+	var rx_agt_parent = window.opener ? window.opener : window.parent;
+	var rx_agt_parent_input = $("#{$parent_input_id}", rx_agt_parent.document);
+	var rx_agt_parent_iframe = rx_agt_parent_input.siblings("iframe.editor_iframe");
 </script>
 
 <style>


### PR DESCRIPTION
약관 설정의 내용 편집이 textarea 에디터 스킨도 호환 가능하도록 개선하였습니다. #1003 

### 1. 기존 문제점
라이믹스가 공식 지원하는 에디터 스킨은 ckeditor, textarea인데 약관 설정은 ckeditor를 전제로 제작되어있음. 때문에 textarea 에디터 스킨을 이용할 시에는 CKEDITOR is not defined 오류와 함께 동작하지 못합니다. 그외에도 기본적으로 textarea를 염두해두지 않고 있기 때문에 사실상 ckeditor 만 이용이 가능했습니다.

### 2. 개선 내용
공식 지원하는 에디터가 모두 동작하도록 구현해봤습니다.

#### 약관 설정에 선언된 스크립트를 각 에디터 스킨에서 선언
처음엔 agreements_edit.html 에서 모두 조치해보려 했지만 이럴 경우 ckeditor, textarea의 단 두 조건만 컨트롤이 가능해집니다. tinymce 등 다른 서드파티를 염두하지 않고 있기 때문에 각 에디터 단위에서 수행하도록 코드를 옮겼습니다. 라이믹스와 XE의 ckeditor가 서로 다른 점을 확인했고 결과적으로 에디터로 빼도 되겠다판단해서 그리했습니다.

다만, 약관 설정 이라는 특수한 상황에서만 동작해야하는 관계로 agreements_edit.html에서 `rx_agt(agreement)_*` 라는 예약변수를 선언하여 이것을 판단해 동작하도록 했습니다.

#### textarea는 nl2br 처리를
textarea를 사용할 경우 개행시 발생하는 <br>처리를 해야할 필요가 있어서 게시판 모듈 표준의 converter()를 이용했습니다.

#### textarea event
본문값 변경 시 발생할 이벤트를 ckeditor는 change로 되어있지만 textarea로 change를 수행하면 blur 처리 시에 이벤트가 수행합니다. keydown, keypress의 경우 마지막 입력 값이 반영이 안되는 문제가 있고 keyup를 하자나 빈번히 이벤트 수행하는것도 좀 그래서 ckeditor와 처럼 change로 했습니다. 글 저장시 PC성능이나 본문이 길이가 상당히 길경우 반영을 못하지 않을까 걱정은 되지만 그정도로 심한 경우가 아니라 일단 change로 합니다.

---

froala를 보고 있긴 한데 그보다 우선 기본적인 동작이 선행되어야겠다해서 froala는 염두하지 않고 순수하게 라이믹스 코어의 확장성을 높일 수 있는 방법을 생각해봤습니다. 반영이 문제가 있는지 검토해주시기 바라며 동작에 큰 문제가 없다면 반영 해주시기 바랍니다.