### PR TITLE
Context 클래스에서 static 속성과 인스턴스 속성을 분명히 구분

### DIFF
--- a/classes/context/Context.class.php
+++ b/classes/context/Context.class.php
@@ -244,7 +244,7 @@ class Context
 		}
 		
 		// Set global variables for backward compatibility.
-		$GLOBALS['__Context__'] = $this;
+		$GLOBALS['__Context__'] = &self::$_tpl_vars;
 		
 		// Set information about the current request.
 		$this->setRequestMethod();

--- a/classes/context/Context.class.php
+++ b/classes/context/Context.class.php
@@ -258,7 +258,7 @@ class Context
 		}
 		
 		// Set information about the current request.
-		self::$_instance->setRequestMethod();
+		self::setRequestMethod();
 		self::$_instance->_checkGlobalVars();
 		self::$_instance->_setXmlRpcArgument();
 		self::$_instance->_setJSONRequestArgument();
@@ -273,7 +273,7 @@ class Context
 		}
 		
 		// Load system configuration.
-		self::$_instance->loadDBInfo();
+		self::loadDBInfo();
 		
 		// If Rhymix is installed, get virtual site information.
 		if(self::isInstalled())
@@ -1121,7 +1121,7 @@ class Context
 	 */
 	public static function setRequestMethod($type = '')
 	{
-		self::$_instance->js_callback_func = self::$_instance->getJSCallbackFunc();
+		self::$_instance->js_callback_func = self::getJSCallbackFunc();
 		
 		if ($type)
 		{

--- a/classes/context/Context.class.php
+++ b/classes/context/Context.class.php
@@ -21,16 +21,16 @@ class Context
 	public $request_method = 'GET';
 
 	/**
-	 * js callback function name.
-	 * @var string
-	 */
-	public $js_callback_func = '';
-
-	/**
 	 * Response method.If it's not set, it follows request method.
 	 * @var string HTML|XMLRPC|JSON|JS_CALLBACK
 	 */
 	public $response_method = '';
+
+	/**
+	 * js callback function name.
+	 * @var string
+	 */
+	public $js_callback_func = '';
 
 	/**
 	 * DB info
@@ -45,12 +45,6 @@ class Context
 	public $ftp_info = NULL;
 
 	/**
-	 * object oFrontEndFileHandler()
-	 * @var object
-	 */
-	public $oFrontEndFileHandler;
-
-	/**
 	 * site's browser title
 	 * @var string
 	 */
@@ -60,7 +54,7 @@ class Context
 	 * script codes in <head>..</head>
 	 * @var string
 	 */
-	public $html_header = NULL;
+	public $html_header = '';
 
 	/**
 	 * class names of <body>
@@ -72,13 +66,13 @@ class Context
 	 * codes after <body>
 	 * @var string
 	 */
-	public $body_header = NULL;
+	public $body_header = '';
 
 	/**
 	 * class names before </body>
 	 * @var string
 	 */
-	public $html_footer = NULL;
+	public $html_footer = '';
 
 	/**
 	 * Meta tags
@@ -140,10 +134,16 @@ class Context
 	private static $_init_called = false;
 
 	/**
+	 * object oFrontEndFileHandler()
+	 * @var object
+	 */
+	private static $_oFrontEndFileHandler = null;
+
+	/**
 	 * SSL action cache file
 	 * @var array
 	 */
-	private static $_ssl_actions_cache_file = './files/cache/common/ssl_actions.php';
+	private static $_ssl_actions_cache_file = 'files/cache/common/ssl_actions.php';
 
 	/**
 	 * SSL action cache
@@ -191,7 +191,7 @@ class Context
 	private static $_tpl_vars = NULL;
 
 	/**
-	 * returns static context object (Singleton). It's to use Context without declaration of an object
+	 * Obtain a singleton instance of Context.
 	 *
 	 * @return object Instance
 	 */
@@ -199,7 +199,18 @@ class Context
 	{
 		if(self::$_instance === null)
 		{
+			// Create a singleton instance and initialize static properties.
 			self::$_instance = new Context();
+			self::$_oFrontEndFileHandler = self::$_instance->oFrontEndFileHandler = new FrontEndFileHandler();
+			self::$_get_vars = self::$_get_vars ?: new stdClass;
+			self::$_tpl_vars = self::$_tpl_vars ?: new stdClass;
+
+			// Include SSL action cache file.
+			self::$_ssl_actions_cache_file = RX_BASEDIR . self::$_ssl_actions_cache_file;
+			if(Rhymix\Framework\Storage::exists(self::$_ssl_actions_cache_file))
+			{
+				self::$_ssl_actions = (include self::$_ssl_actions_cache_file) ?: array();
+			}
 		}
 		return self::$_instance;
 	}
@@ -211,16 +222,7 @@ class Context
 	 */
 	private function __construct()
 	{
-		$this->oFrontEndFileHandler = new FrontEndFileHandler();
-		self::$_get_vars = self::$_get_vars ?: new stdClass;
-		self::$_tpl_vars = self::$_tpl_vars ?: new stdClass;
-
-		// include ssl action cache file
-		self::$_ssl_actions_cache_file = FileHandler::getRealPath(self::$_ssl_actions_cache_file);
-		if(is_readable(self::$_ssl_actions_cache_file))
-		{
-			self::$_ssl_actions = (include self::$_ssl_actions_cache_file) ?: array();
-		}
+		
 	}
 
 	/**
@@ -2067,7 +2069,7 @@ class Context
 	 */
 	public static function loadFile($args)
 	{
-		self::$_instance->oFrontEndFileHandler->loadFile($args);
+		self::$_oFrontEndFileHandler->loadFile($args);
 	}
 
 	/**
@@ -2080,7 +2082,7 @@ class Context
 	 */
 	public static function unloadFile($file, $targetIe = '', $media = 'all')
 	{
-		self::$_instance->oFrontEndFileHandler->unloadFile($file, $targetIe, $media);
+		self::$_oFrontEndFileHandler->unloadFile($file, $targetIe, $media);
 	}
 
 	/**
@@ -2091,7 +2093,7 @@ class Context
 	 */
 	public static function unloadAllFiles($type = 'all')
 	{
-		self::$_instance->oFrontEndFileHandler->unloadAllFiles($type);
+		self::$_oFrontEndFileHandler->unloadAllFiles($type);
 	}
 
 	/**
@@ -2124,7 +2126,7 @@ class Context
 			$file = $validator->getJsPath();
 		}
 
-		self::$_instance->oFrontEndFileHandler->loadFile(array($file, $type, $targetie, $index));
+		self::$_oFrontEndFileHandler->loadFile(array($file, $type, $targetie, $index));
 	}
 
 	/**
@@ -2138,7 +2140,7 @@ class Context
 	 */
 	public static function unloadJsFile($file, $optimized = FALSE, $targetie = '')
 	{
-		self::$_instance->oFrontEndFileHandler->unloadFile($file, $targetie);
+		self::$_oFrontEndFileHandler->unloadFile($file, $targetie);
 	}
 
 	/**
@@ -2148,7 +2150,7 @@ class Context
 	 */
 	public static function unloadAllJsFiles()
 	{
-		self::$_instance->oFrontEndFileHandler->unloadAllFiles('js');
+		self::$_oFrontEndFileHandler->unloadAllFiles('js');
 	}
 
 	/**
@@ -2197,7 +2199,7 @@ class Context
 	 */
 	public static function getJsFile($type = 'head', $finalize = false)
 	{
-		return self::$_instance->oFrontEndFileHandler->getJsFileList($type, $finalize);
+		return self::$_oFrontEndFileHandler->getJsFileList($type, $finalize);
 	}
 
 	/**
@@ -2214,7 +2216,7 @@ class Context
 	 */
 	public static function addCSSFile($file, $optimized = FALSE, $media = 'all', $targetie = '', $index = 0)
 	{
-		self::$_instance->oFrontEndFileHandler->loadFile(array($file, $media, $targetie, $index));
+		self::$_oFrontEndFileHandler->loadFile(array($file, $media, $targetie, $index));
 	}
 
 	/**
@@ -2229,7 +2231,7 @@ class Context
 	 */
 	public static function unloadCSSFile($file, $optimized = FALSE, $media = 'all', $targetie = '')
 	{
-		self::$_instance->oFrontEndFileHandler->unloadFile($file, $targetie, $media);
+		self::$_oFrontEndFileHandler->unloadFile($file, $targetie, $media);
 	}
 
 	/**
@@ -2239,7 +2241,7 @@ class Context
 	 */
 	public static function unloadAllCSSFiles()
 	{
-		self::$_instance->oFrontEndFileHandler->unloadAllFiles('css');
+		self::$_oFrontEndFileHandler->unloadAllFiles('css');
 	}
 
 	/**
@@ -2250,7 +2252,7 @@ class Context
 	 */
 	public static function getCSSFile($finalize = false)
 	{
-		return self::$_instance->oFrontEndFileHandler->getCssFileList($finalize);
+		return self::$_oFrontEndFileHandler->getCssFileList($finalize);
 	}
 
 	/**

--- a/classes/template/TemplateHandler.class.php
+++ b/classes/template/TemplateHandler.class.php
@@ -344,7 +344,7 @@ class TemplateHandler
 	 */
 	private function _fetch($filename)
 	{
-		$__Context = Context::getInstance();
+		$__Context = Context::getAll();
 		$__Context->tpl_path = $this->path;
 
 		$__ob_level_before_fetch = ob_get_level();

--- a/classes/template/TemplateHandler.class.php
+++ b/classes/template/TemplateHandler.class.php
@@ -983,6 +983,10 @@ class TemplateHandler
 			{
 				return '$' . $matches[1];
 			}
+			elseif ($matches[1] === 'lang')
+			{
+				return '$GLOBALS[\'lang\']';
+			}
 			else
 			{
 				return '$__Context->' . $matches[1];

--- a/classes/template/TemplateHandler.class.php
+++ b/classes/template/TemplateHandler.class.php
@@ -344,22 +344,27 @@ class TemplateHandler
 	 */
 	private function _fetch($filename)
 	{
+		// Import Context and lang as local variables.
 		$__Context = Context::getAll();
 		$__Context->tpl_path = $this->path;
-
+		global $lang;
+		
+		// Start the output buffer.
 		$__ob_level_before_fetch = ob_get_level();
 		ob_start();
 		
+		// Include the compiled template.
 		include $filename;
 		
+		// Fetch contents of the output buffer until the buffer level is the same as before.
 		$contents = '';
 		while (ob_get_level() > $__ob_level_before_fetch)
 		{
 			$contents .= ob_get_clean();
 		}
 		
-		// insert template path comment tag
-		if(config('debug.enabled') && Rhymix\Framework\Debug::isEnabledForCurrentUser())
+		// Insert template path comment tag.
+		if(config('debug.enabled') && Rhymix\Framework\Debug::isEnabledForCurrentUser() && !starts_with('<!DOCTYPE', $contents))
 		{
 			$sign = PHP_EOL . '<!-- Template %s : ' . $this->web_path . $this->filename . ' -->' . PHP_EOL;
 			$contents = sprintf($sign, 'start') . $contents . sprintf($sign, 'end');
@@ -979,13 +984,9 @@ class TemplateHandler
 		}
 		
 		return preg_replace_callback('@(?<!::|\\\\|(?<!eval\()\')\$([a-z_][a-z0-9_]*)@i', function($matches) {
-			if (preg_match('/^(?:GLOBALS|_SERVER|_COOKIE|_GET|_POST|_REQUEST|__Context|this)$/', $matches[1]))
+			if (preg_match('/^(?:GLOBALS|_SERVER|_COOKIE|_GET|_POST|_REQUEST|__Context|this|lang)$/', $matches[1]))
 			{
 				return '$' . $matches[1];
-			}
-			elseif ($matches[1] === 'lang')
-			{
-				return '$GLOBALS[\'lang\']';
 			}
 			else
 			{

--- a/index.php
+++ b/index.php
@@ -43,8 +43,7 @@ require dirname(__FILE__) . '/common/autoload.php';
  * @brief Initialize by creating Context object
  * Set all Request Argument/Environment variables
  **/
-$oContext = Context::getInstance();
-$oContext->init();
+Context::init();
 
 /**
  * @brief Initialize and execute Module Handler

--- a/tests/unit/classes/TemplateHandlerTest.php
+++ b/tests/unit/classes/TemplateHandlerTest.php
@@ -205,7 +205,7 @@ class TemplateHandlerTest extends \Codeception\TestCase\Test
             // issue 512 - ignores <marquee>
             array(
                 '<div class="topimgContex"><marquee direction="up" scrollamount="1" height="130" loop="infinity" behavior="lscro">{$lang->sl_show_topimgtext}</marquee></div>',
-                '?><div class="topimgContex"><marquee direction="up" scrollamount="1" height="130" loop="infinity" behavior="lscro"><?php echo $__Context->lang->sl_show_topimgtext ?></marquee></div>'
+                '?><div class="topimgContex"><marquee direction="up" scrollamount="1" height="130" loop="infinity" behavior="lscro"><?php echo $lang->sl_show_topimgtext ?></marquee></div>'
             ),
             // issue 584
             array(


### PR DESCRIPTION
Context 클래스의 기능은 대부분 static으로 사용하고 있음에도 불구하고, static이 아닌 속성과 메소드를 혼용하고 있어 실행 구조도 지저분하고 성능도 떨어지며 용도에 따른 구분이 되지 않아 문제가 발생합니다.

Context 클래스의 모든 메소드를 static으로 변경하고, getInstance() 메소드를 통해 인스턴스를 생성하여 쓰는 부분은 구 버전 호환성을 최대한 유지하면서 완전히 격리시켰습니다. 그 밖에도 XMLRPC, JSON, POST 등의 요청 데이터를 받아오는 함수가 여기저기 흩어져 있던 것을 정리하고, SSL 액션 캐시 처리 방식을 개선하는 등 눈에 띄는 곳마다 단순화시키려고 노력했습니다.

이 PR에는 아래의 버그 수정도 포함되어 있습니다.

- 일부 Context 속성과 GET/POST 요청 데이터가 격리되지 않아 발생한 XSS 취약점을 해결했습니다. @conory 님이 알려주셨으며, XE에는 해당되지 않습니다.
- 디버그 사용시 HTML 출력 내용 맨 꼭대기에 레이아웃 파일 경로를 알리는 주석이 붙어서 `<!DOCTYPE>`을 인식하지 못하는 문제를 해결했습니다.