### PR TITLE
OpenGraph 메타 정보에 문서 태그 및 해시태그 추가

### DIFF
--- a/classes/display/HTMLDisplayHandler.php
+++ b/classes/display/HTMLDisplayHandler.php
@@ -523,11 +523,36 @@ class HTMLDisplayHandler
 			}
 		}
 		
+		// Add tags and hashtags for articles.
+		if ($page_type === 'article')
+		{
+			$tags = array_unique(array_map('utf8_trim', explode(',', $oDocument->get('tags'))));
+			foreach ($tags as $tag)
+			{
+				if ($tag !== '')
+				{
+					Context::addOpenGraphData('og:article:tag', escape($tag, false));
+				}
+			}
+			
+			if (config('seo.og_extract_hashtags'))
+			{
+				preg_match_all('/#([\pL\pN_]+)/u', strip_tags($oDocument->get('content')), $hashtags);
+				foreach ($hashtags[1] as $hashtag)
+				{
+					if (!in_array($hashtag, $tags))
+					{
+						Context::addOpenGraphData('og:article:tag', escape($hashtag, false));
+					}
+				}
+			}
+		}
+		
 		// Add datetime for articles.
 		if ($page_type === 'article' && config('seo.og_use_timestamps'))
 		{
-			Context::addOpenGraphData('article:published_time', $oDocument->getRegdate('c'));
-			Context::addOpenGraphData('article:modified_time', $oDocument->getUpdate('c'));
+			Context::addOpenGraphData('og:article:published_time', $oDocument->getRegdate('c'));
+			Context::addOpenGraphData('og:article:modified_time', $oDocument->getUpdate('c'));
 		}
 	}
 

--- a/classes/display/HTMLDisplayHandler.php
+++ b/classes/display/HTMLDisplayHandler.php
@@ -526,19 +526,19 @@ class HTMLDisplayHandler
 		// Add tags and hashtags for articles.
 		if ($page_type === 'article')
 		{
-			$tags = array_unique(array_map('utf8_trim', explode(',', $oDocument->get('tags'))));
+			$tags = $oDocument->getTags();
 			foreach ($tags as $tag)
 			{
 				if ($tag !== '')
 				{
-					Context::addOpenGraphData('og:article:tag', escape($tag, false));
+					Context::addOpenGraphData('og:article:tag', $tag, false);
 				}
 			}
 			
 			if (config('seo.og_extract_hashtags'))
 			{
-				preg_match_all('/#([\pL\pN_]+)/u', strip_tags($oDocument->get('content')), $hashtags);
-				foreach ($hashtags[1] as $hashtag)
+				$hashtags = $oDocument->getHashtags();
+				foreach ($hashtags as $hashtag)
 				{
 					if (!in_array($hashtag, $tags))
 					{

--- a/common/defaults/config.php
+++ b/common/defaults/config.php
@@ -103,6 +103,7 @@ return array(
 		'og_enabled' => false,
 		'og_extract_description' => false,
 		'og_extract_images' => false,
+		'og_extract_hashtags' => false,
 		'og_use_timestamps' => false,
 	),
 	'mediafilter' => array(

--- a/modules/admin/admin.admin.controller.php
+++ b/modules/admin/admin.admin.controller.php
@@ -924,6 +924,7 @@ class adminAdminController extends admin
 		Rhymix\Framework\Config::set('seo.og_enabled', $vars->og_enabled === 'Y');
 		Rhymix\Framework\Config::set('seo.og_extract_description', $vars->og_extract_description === 'Y');
 		Rhymix\Framework\Config::set('seo.og_extract_images', $vars->og_extract_images === 'Y');
+		Rhymix\Framework\Config::set('seo.og_extract_hashtags', $vars->og_extract_hashtags === 'Y');
 		Rhymix\Framework\Config::set('seo.og_use_timestamps', $vars->og_use_timestamps === 'Y');
 		
 		// Save

--- a/modules/admin/admin.admin.view.php
+++ b/modules/admin/admin.admin.view.php
@@ -596,6 +596,7 @@ class adminAdminView extends admin
 		Context::set('og_enabled', Rhymix\Framework\Config::get('seo.og_enabled'));
 		Context::set('og_extract_description', Rhymix\Framework\Config::get('seo.og_extract_description'));
 		Context::set('og_extract_images', Rhymix\Framework\Config::get('seo.og_extract_images'));
+		Context::set('og_extract_hashtags', Rhymix\Framework\Config::get('seo.og_extract_hashtags'));
 		Context::set('og_use_timestamps', Rhymix\Framework\Config::get('seo.og_use_timestamps'));
 		
 		$this->setTemplateFile('config_seo');

--- a/modules/admin/lang/en.php
+++ b/modules/admin/lang/en.php
@@ -239,6 +239,7 @@ $lang->og_extract_description = 'Extract Description from Document';
 $lang->og_extract_description_fallback = 'Use general description only';
 $lang->og_extract_images = 'Extract Images from Document';
 $lang->og_extract_images_fallback = 'Use site default image only';
+$lang->og_extract_hashtags = 'Extract Hashtags from Document';
 $lang->og_use_timestamps = 'Include Timestamps';
 $lang->autoinstall = 'EasyInstall';
 $lang->last_week = 'Last Week';

--- a/modules/admin/lang/ko.php
+++ b/modules/admin/lang/ko.php
@@ -235,6 +235,7 @@ $lang->og_extract_description = '본문에서 설명 추출';
 $lang->og_extract_description_fallback = '모듈 또는 사이트 전체 설명만 사용';
 $lang->og_extract_images = '본문에서 이미지 추출';
 $lang->og_extract_images_fallback = '사이트 대표 이미지 사용';
+$lang->og_extract_hashtags = '본문에서 해시태그 추출';
 $lang->og_use_timestamps = '글 작성/수정 시각 표시';
 $lang->autoinstall = '쉬운 설치';
 $lang->last_week = '지난주';

--- a/modules/admin/tpl/config_seo.html
+++ b/modules/admin/tpl/config_seo.html
@@ -64,6 +64,13 @@
 			</div>
 		</div>
 		<div class="x_control-group">
+			<label class="x_control-label">{$lang->og_extract_hashtags}</label>
+			<div class="x_controls">
+				<label for="og_extract_hashtags_y" class="x_inline"><input type="radio" name="og_extract_hashtags" id="og_extract_hashtags_y" value="Y" checked="checked"|cond="$og_extract_hashtags" /> {$lang->cmd_yes}</label>
+				<label for="og_extract_hashtags_n" class="x_inline"><input type="radio" name="og_extract_hashtags" id="og_extract_hashtags_n" value="N" checked="checked"|cond="!$og_extract_hashtags" /> {$lang->cmd_no}</label>
+			</div>
+		</div>
+		<div class="x_control-group">
 			<label class="x_control-label">{$lang->og_use_timestamps}</label>
 			<div class="x_controls">
 				<label for="og_use_timestamps_y" class="x_inline"><input type="radio" name="og_use_timestamps" id="og_use_timestamps_y" value="Y" checked="checked"|cond="$og_use_timestamps" /> {$lang->cmd_yes}</label>

--- a/modules/document/document.item.php
+++ b/modules/document/document.item.php
@@ -148,9 +148,7 @@ class documentItem extends BaseObject
 		// Tags
 		if($this->get('tags'))
 		{
-			$tag_list = explode(',', $this->get('tags'));
-			$tag_list = array_map('utf8_trim', $tag_list);
-			$this->add('tag_list', $tag_list);
+			$this->add('tag_list', $this->getTags());
 		}
 		
 		if($load_extra_vars)
@@ -774,6 +772,20 @@ class documentItem extends BaseObject
 		}
 	}
 
+	public function getTags()
+	{
+		$tag_list = array_map(function($str) { return escape(utf8_trim($str), false); }, explode(',', $this->get('tags')));
+		$tag_list = array_filter($tag_list, function($str) { return $str !== ''; });
+		return array_unique($tag_list);
+	}
+	
+	public function getHashtags()
+	{
+		preg_match_all('/(?<!&)#([\pL\pN_]+)/u', strip_tags($this->get('content')), $hashtags);
+		$hashtags[1] = array_map(function($str) { return escape($str, false); }, $hashtags[1]);
+		return array_unique($hashtags[1]);
+	}
+	
 	/**
 	 * Update readed count
 	 * @return void


### PR DESCRIPTION
XE SEO 모듈과 달리 라이믹스는 OpenGraph 메타 태그에 문서 태그 `og:article:tag`를 추가하지 않는다는 지적이 있어서 수정합니다. @wookho

또한 SEO 설정 화면에 "본문에서 해시태그 추출" 옵션을 추가하여, 태그를 따로 입력하지 않더라도 #본문에 #포함된 #해시태그를 자동으로 인식하여 `og:article:tag`로 추가할 수도 있도록 했습니다. (따로 입력한 태그와 중복되는 것은 한 번만 추가합니다.)

`documentItem` 클래스에 `getTags()` 및 `getHashtags()` 메소드를 추가하여 코어 및 서드파티 자료에서 태그와 해시태그를 일관성있게 참조할 수 있도록 했습니다.

해시태그 추출시 사용하는 정규식이 일치하지 않으면 서드파티 자료마다 각각 다른 해시태그를 추출하거나, `&#39;` 등의 HTML entity를 태그로 잘못 인식하거나, 해시태그 중간에 폰트가 바뀌는 경우 인식하지 못하거나, XSS 필터링을 빠뜨리는 등 여러 가지 문제가 생길 수 있습니다. 따라서 가능하면 코어에서 일관성있는 작동을 보장하는 `getHashtags()` 메소드를 사용하시기 바랍니다. (만약 이 메소드에서 해시태그를 잘못 추출하고 있다면 알려주세요.)
