### PR TITLE
Fix httpOnly flag by mistake....

### DIFF
--- a/classes/context/Context.class.php
+++ b/classes/context/Context.class.php
@@ -300,7 +300,7 @@ class Context
 		{
 			if($_COOKIE['lang_type'] !== $lang_type)
 			{
-				setcookie('lang_type', $lang_type, time() + 86400, '/', null, RX_SSL, true);
+				setcookie('lang_type', $lang_type, 0, '/', null, RX_SSL);
 			}
 		}
 		elseif($_COOKIE['lang_type'])
@@ -316,7 +316,7 @@ class Context
 					if(!strncasecmp($lang_code, $_SERVER['HTTP_ACCEPT_LANGUAGE'], strlen($lang_code)))
 					{
 						$lang_type = $lang_code;
-						setcookie('lang_type', $lang_type, time() + 86400, '/', null, RX_SSL, true);
+						setcookie('lang_type', $lang_type, 0, '/', null, RX_SSL);
 					}
 				}
 			}

--- a/classes/mobile/Mobile.class.php
+++ b/classes/mobile/Mobile.class.php
@@ -73,7 +73,7 @@ class Mobile
 		$uatype = $uahash . ':' . (self::$_ismobile ? '1' : '0');
 		if ($cookie !== $uatype)
 		{
-			setcookie('rx_uatype', $uatype, 0, null, null, RX_SSL, true);
+			setcookie('rx_uatype', $uatype, 0, null, null, RX_SSL);
 			$_COOKIE['rx_uatype'] = $uatype;
 		}
 		

--- a/common/framework/session.php
+++ b/common/framework/session.php
@@ -297,7 +297,7 @@ class Session
 			$ssl_only = (\RX_SSL && config('session.use_ssl')) ? true : false;
 			
 			// Set sso cookie to prevent multiple simultaneous SSO validation requests.
-			setcookie('sso', md5($current_domain), 0, '/', null, null, $ssl_only, true);
+			setcookie('sso', md5($current_domain), 0, '/', null, null, $ssl_only);
 			
 			// Redirect to the default site.
 			$sso_request = Security::encrypt($current_url);

--- a/modules/member/member.view.php
+++ b/modules/member/member.view.php
@@ -194,7 +194,7 @@ class memberView extends member
 		$ssl_only = (\RX_SSL && config('session.use_ssl')) ? true : false;
 
 		//setcookie for redirect url in case of going to member sign up
-		setcookie("XE_REDIRECT_URL", $_SERVER['HTTP_REFERER'], 0, null, null, $ssl_only, true);
+		setcookie("XE_REDIRECT_URL", $_SERVER['HTTP_REFERER'], 0, null, null, $ssl_only);
 
 		$member_config = $this->member_config;
 


### PR DESCRIPTION
https://github.com/rhymix/rhymix/commit/73da2af3935c5ceb25289891ec82224509f5be73 fix.

로컬 깃허브 설정이 잘못되어서.. 오리진이 라이믹스 develop 으로 되어 있었네요... 본의 아니게 라이믹스 develop 에 바로 커밋 해버렸던 일들 죄송합니다.

SSL 을 조금 더 적극적으로 활용하기 위해서 쿠키에 `secure` 플래그를 답니다.

SSL always 인 환경에서는 조금 더 적극적으로 `secure` 플래그를 달고, 그렇지 않은 선택적 환경에서도 `secure` 플래그를 달 수 있는 상황에서는 달아주도록 합니다.