### PR TITLE
IDN 을 사용하는 경우, 자바스크립트에서 도메인을 정확히 비교하지 못하는 문제 수정

### DIFF
--- a/common/tpl/common_layout.html
+++ b/common/tpl/common_layout.html
@@ -48,9 +48,9 @@
 
 <!-- COMMON JS VARIABLES -->
 <script>
-	var default_url = "{Context::getDefaultUrl()}";
-	var current_url = "{$current_url}";
-	var request_uri = "{$request_uri}";
+	var default_url = "{Context::encodeIdna(Context::getDefaultUrl())}";
+	var current_url = "{Context::encodeIdna($current_url)}";
+	var request_uri = "{Context::encodeIdna($request_uri)}";
 	var current_lang = xe.current_lang = "{$lang_type}";
 	var current_mid = {json_encode($mid ?: null)};
 	var http_port = {Context::get("_http_port") ?: 'null'};


### PR DESCRIPTION
자바스크립트에 `UTF-8` 인코딩된 주소를 넘겨줄 경우, `location.href` 와의 비교조차 정확히 해내지 못하는 경우가 발생합니다.

기왕 자바스크립트 변수로 넘겨준다면, punycode 인코딩 된 값으로 넘겨주도록 합니다.

IDN 이 아닌 일반 영문 알파벳 도메인인 경우에는 별도로 변환되는 일이 일어나지 않기 때문에 이 커밋으로 인한 영향은 거의 없습니다.