### PR TITLE
Add Soundcloud as a sharing service provider

### DIFF
--- a/common/defaults/whitelist.php
+++ b/common/defaults/whitelist.php
@@ -78,5 +78,7 @@ return array(
 		'player.vimeo.com/',
 		// Afreeca
 		'afree.ca/',
+		// Soundcloud
+		'w.soundcloud.com/',
 	),
 );


### PR DESCRIPTION
Add Soundcloud as a sharing music service provider.

사운드클라우드는 수익이 많이 나고 있는 서비스는 아니지만, 유투브 만큼이나 음악을 공유하기에 좋은 플랫폼입니다. KBS나 SBS 만큼의 사용자 수는 충분히 되는 사이트라는 생각이 들어서 iframe 기본 값에 추가되는 것을 제안합니다.