### PR TITLE
모듈 매니저 페이지에서 디자인이 깨지는 문제 수정

### DIFF
--- a/classes/module/ModuleObject.class.php
+++ b/classes/module/ModuleObject.class.php
@@ -140,6 +140,13 @@ class ModuleObject extends BaseObject
 			return;
 		}
 		
+		// Set admin layout
+		if(preg_match('/^disp[A-Z][a-z0-9\_]+Admin/', $this->act))
+		{
+			$this->setLayoutPath('modules/admin/tpl');
+			$this->setLayoutFile('layout');
+		}
+		
 		// Execute init
 		if(method_exists($this, 'init'))
 		{

--- a/modules/admin/tpl/_footer.html
+++ b/modules/admin/tpl/_footer.html
@@ -1,6 +1,6 @@
 	</div>
 	<!-- /BODY -->
-	<footer class="footer">
+	<footer class="footer" cond="$logged_info->is_admin === 'Y'">
 		<p class="power">
 			Powered by <strong>Rhymix {__XE_VERSION__}</strong>
 			<!--@if(isset($released_version))-->
@@ -8,13 +8,14 @@
 			<!--@end-->
 		</p>
 		<p class="cache">
-			<button type="button" class="x_btn-link" onclick="doResetAdminMenu();">{$lang->cmd_admin_menu_reset}</button> <span class="vr">|</span>  
-			<button type="button" class="x_btn-link" onclick="doRecompileCacheFile();">{$lang->cmd_remake_cache}</button> <span class="vr">|</span> 
-			<button type="button" class="x_btn-link" onclick="doClearSession();">{$lang->cmd_clear_session}</button> <span class="vr">|</span> 
-			<a href="./index.php?module=admin&act=dispAdminViewServerEnv" style="vertical-align:middle">{$lang->cmd_view_server_env}</a> <span class="vr">|</span> 
-			<a href="https://github.com/rhymix/rhymix/issues" target="_blank" style="vertical-align:middle">{$lang->bug_report}</a>
+			<button type="button" class="x_btn-link" onclick="doResetAdminMenu();">{lang('admin.cmd_admin_menu_reset')}</button> <span class="vr">|</span>  
+			<button type="button" class="x_btn-link" onclick="doRecompileCacheFile();">{lang('common.cmd_remake_cache')}</button> <span class="vr">|</span> 
+			<button type="button" class="x_btn-link" onclick="doClearSession();">{lang('admin.cmd_clear_session')}</button> <span class="vr">|</span> 
+			<a href="./index.php?module=admin&act=dispAdminViewServerEnv" style="vertical-align:middle">{lang('admin.cmd_view_server_env')}</a> <span class="vr">|</span> 
+			<a href="https://github.com/rhymix/rhymix/issues" target="_blank" style="vertical-align:middle">{lang('admin.bug_report')}</a>
 		</p>
+		<load target="../../session/tpl/js/session.js" />
 	</footer>
 </div>
-<load target="./js/config.js" usecdn="true" />
-<load target="../../session/tpl/js/session.js" usecdn="true" />
+<load target="./js/config.js" />
+

--- a/modules/admin/tpl/_footer.html
+++ b/modules/admin/tpl/_footer.html
@@ -1,6 +1,6 @@
 	</div>
 	<!-- /BODY -->
-	<footer class="footer" cond="$logged_info->is_admin === 'Y'">
+	<footer class="footer" cond="$this->user->isAdmin()">
 		<p class="power">
 			Powered by <strong>Rhymix {__XE_VERSION__}</strong>
 			<!--@if(isset($released_version))-->

--- a/modules/admin/tpl/_header.html
+++ b/modules/admin/tpl/_header.html
@@ -17,10 +17,17 @@
 <div class="x">
 <p class="skipNav"><a href="#content">{$lang->skip_to_content}</a></p>
 	<header class="header">
+		<!--@if($module === 'admin')-->
 		<h1>
 			<a href="{getUrl('','module','admin')}"><img cond="$gnb_title_info->adminLogo" src="{getUrl('')}{$gnb_title_info->adminLogo}" alt="{$gnb_title_info->adminTitle}" /> {$gnb_title_info->adminTitle}</a>
 		</h1>
 		<p class="site"><a href="{$xe_default_url}">{$xe_default_url}</a></p>
+		<!--@else-->
+		<h1>
+			module manager
+		</h1>
+		<a href="{getUrl('', 'module', 'admin', 'act', $act, 'module_srl', $module_info->module_srl)}" cond="$logged_info->is_admin === 'Y'">Admin Panel</a>
+		<!--@end-->
 		<div class="account">
 			<ul>
 				<li><a href="{getUrl('', 'module', 'admin', 'act', 'dispMemberAdminInfo', 'is_admin', 'Y', 'member_srl', $logged_info->member_srl)}">{$logged_info->email_address}</a></li>
@@ -34,9 +41,9 @@
 		</div>
 	</header>
 	<!-- BODY -->
-	<div class="body <!--@if($_COOKIE['__xe_admin_gnb_status'] == 'close')-->wide<!--@end-->">
+	<div class="body <!--@if($_COOKIE['__xe_admin_gnb_status'] == 'close')-->wide<!--@end-->" style="padding-left:0"|cond="$module !== 'admin'">
 		<!-- GNB -->
-		<nav class="gnb <!--@if($_COOKIE['__xe_admin_gnb_status'] == 'open')-->open<!--@end-->" id="gnb">
+		<nav class="gnb <!--@if($_COOKIE['__xe_admin_gnb_status'] == 'open')-->open<!--@end-->" id="gnb" cond="$module === 'admin'">
 			<a href="#gnbNav"><i class="x_icon-align-justify x_icon-white"></i><b></b> Menu Open/Close</a>
 			<ul id="gnbNav" class="ex">
 			<script>

--- a/modules/admin/tpl/_header.html
+++ b/modules/admin/tpl/_header.html
@@ -14,12 +14,13 @@
 	xe.lang.confirm_run = "{$lang->confirm_run}";
 	xe.lang.confirm_reset_admin_menu = "{$lang->confirm_reset_admin_menu}";
 </script>
+{@ $module_manager = $current_module_info->module !== 'admin'}
 <div class="x">
 <p class="skipNav"><a href="#content">{$lang->skip_to_content}</a></p>
 	<header class="header">
-		<!--@if($mid)-->
+		<!--@if($module_manager)-->
 		<h1>module manager</h1>
-		<a href="{getUrl('', 'module', 'admin', 'act', $act, 'module_srl', $module_info->module_srl)}" cond="$logged_info->is_admin === 'Y'">Admin Panel</a>
+		<a href="{getUrl('module', 'admin', 'act', $act, 'module_srl', $module_info->module_srl, 'mid', '')}" cond="$this->user->isAdmin()">Admin Panel</a>
 		<!--@else-->
 		<h1>
 			<a href="{getUrl('','module','admin')}"><img cond="$gnb_title_info->adminLogo" src="{getUrl('')}{$gnb_title_info->adminLogo}" alt="{$gnb_title_info->adminTitle}" /> {$gnb_title_info->adminTitle}</a>
@@ -28,7 +29,7 @@
 		<!--@end-->
 		<div class="account">
 			<ul>
-				<!--@if($mid)-->
+				<!--@if($module_manager)-->
 				<li><a href="{getUrl('', 'mid', $mid, 'act', 'dispMemberInfo')}">{$logged_info->email_address}</a></li>
 				<li><a href="{getUrl('', 'mid', $mid, 'act', 'dispMemberLogout')}">{$lang->cmd_logout}</a></li>
 				<!--@else-->
@@ -44,9 +45,9 @@
 		</div>
 	</header>
 	<!-- BODY -->
-	<div class="body <!--@if($_COOKIE['__xe_admin_gnb_status'] == 'close')-->wide<!--@end-->" style="padding-left:0"|cond="$mid">
+	<div class="body <!--@if($_COOKIE['__xe_admin_gnb_status'] == 'close')-->wide<!--@end-->" style="padding-left:0"|cond="$module_manager">
 		<!-- GNB -->
-		<nav class="gnb <!--@if($_COOKIE['__xe_admin_gnb_status'] == 'open')-->open<!--@end-->" id="gnb" cond="!$mid">
+		<nav class="gnb <!--@if($_COOKIE['__xe_admin_gnb_status'] == 'open')-->open<!--@end-->" id="gnb" cond="!$module_manager">
 			<a href="#gnbNav"><i class="x_icon-align-justify x_icon-white"></i><b></b> Menu Open/Close</a>
 			<ul id="gnbNav" class="ex">
 			<script>

--- a/modules/admin/tpl/_header.html
+++ b/modules/admin/tpl/_header.html
@@ -28,8 +28,13 @@
 		<!--@end-->
 		<div class="account">
 			<ul>
-				<li><a href="{getUrl('', 'module', 'admin', 'act', 'dispMemberAdminInfo', 'is_admin', 'Y', 'member_srl', $logged_info->member_srl)}">{$logged_info->email_address}</a></li>
-				<li><a href="{getUrl('', 'module','admin','act','procAdminLogout')}">{$lang->cmd_logout}</a></li>
+				<!--@if($mid)-->
+				<li><a href="{getUrl('', 'mid', $mid, 'act', 'dispMemberInfo')}">{$logged_info->email_address}</a></li>
+				<li><a href="{getUrl('', 'mid', $mid, 'act', 'dispMemberLogout')}">{$lang->cmd_logout}</a></li>
+				<!--@else-->
+				<li><a href="{getUrl('', 'module', 'admin', 'act', 'dispMemberAdminInfo', 'member_srl', $logged_info->member_srl)}">{$logged_info->email_address}</a></li>
+				<li><a href="{getUrl('', 'module', 'admin', 'act', 'procAdminLogout')}">{$lang->cmd_logout}</a></li>
+				<!--@end-->
 				<li><a href="#lang" class="lang" data-toggle>{$lang_supported[$lang_type]}</a>
 					<ul id="lang" class="x_dropdown-menu">
 						<li loop="$lang_supported=>$key,$val" class="x_active"|cond="$key==$lang_type"><a href="{getUrl('l',$key)}" data-langcode="{$key}" onclick="doChangeLangType('{$key}'); return false;">{$val}</a></li>

--- a/modules/admin/tpl/_header.html
+++ b/modules/admin/tpl/_header.html
@@ -17,16 +17,14 @@
 <div class="x">
 <p class="skipNav"><a href="#content">{$lang->skip_to_content}</a></p>
 	<header class="header">
-		<!--@if($module === 'admin')-->
+		<!--@if($mid)-->
+		<h1>module manager</h1>
+		<a href="{getUrl('', 'module', 'admin', 'act', $act, 'module_srl', $module_info->module_srl)}" cond="$logged_info->is_admin === 'Y'">Admin Panel</a>
+		<!--@else-->
 		<h1>
 			<a href="{getUrl('','module','admin')}"><img cond="$gnb_title_info->adminLogo" src="{getUrl('')}{$gnb_title_info->adminLogo}" alt="{$gnb_title_info->adminTitle}" /> {$gnb_title_info->adminTitle}</a>
 		</h1>
 		<p class="site"><a href="{$xe_default_url}">{$xe_default_url}</a></p>
-		<!--@else-->
-		<h1>
-			module manager
-		</h1>
-		<a href="{getUrl('', 'module', 'admin', 'act', $act, 'module_srl', $module_info->module_srl)}" cond="$logged_info->is_admin === 'Y'">Admin Panel</a>
 		<!--@end-->
 		<div class="account">
 			<ul>
@@ -41,9 +39,9 @@
 		</div>
 	</header>
 	<!-- BODY -->
-	<div class="body <!--@if($_COOKIE['__xe_admin_gnb_status'] == 'close')-->wide<!--@end-->" style="padding-left:0"|cond="$module !== 'admin'">
+	<div class="body <!--@if($_COOKIE['__xe_admin_gnb_status'] == 'close')-->wide<!--@end-->" style="padding-left:0"|cond="$mid">
 		<!-- GNB -->
-		<nav class="gnb <!--@if($_COOKIE['__xe_admin_gnb_status'] == 'open')-->open<!--@end-->" id="gnb" cond="$module === 'admin'">
+		<nav class="gnb <!--@if($_COOKIE['__xe_admin_gnb_status'] == 'open')-->open<!--@end-->" id="gnb" cond="!$mid">
 			<a href="#gnbNav"><i class="x_icon-align-justify x_icon-white"></i><b></b> Menu Open/Close</a>
 			<ul id="gnbNav" class="ex">
 			<script>

--- a/modules/admin/tpl/layout.html
+++ b/modules/admin/tpl/layout.html
@@ -8,5 +8,5 @@
 	</div>
 	{$content}
 </div>
-<include target="./_footer.html" />
+<include target="./_footer.html" cond="$module === 'admin'" />
 

--- a/modules/admin/tpl/layout.html
+++ b/modules/admin/tpl/layout.html
@@ -8,5 +8,5 @@
 	</div>
 	{$content}
 </div>
-<include target="./_footer.html" cond="$module === 'admin'" />
+<include target="./_footer.html" />
 


### PR DESCRIPTION
mid=board&act=dispBoardAdminBoardInfo 등
모듈 매니저 페이지의 디자인이 깨지는 문제를 해결하였습니다. 원인은 제가 부탁드린  https://github.com/rhymix/rhymix/commit/637e4f9e4670916d5d7f3ec9e870d7449166ca0f , 매니저 페이지가 있다는 걸 미처 생각하지 못했습니다;;

'disp ~ Admin ~' 이런 act에서 admin layout을 기본적으로 입히도록 하였습니다. 물론 레이아웃에 내장된 최고관리자 기능은 제외하였습니다. 호환을 위한 default이기 때문에 모듈에서 `$this->setLayoutPath('~')` 로 admin 레이아웃을 바꿀 수 있습니다.

![1](https://user-images.githubusercontent.com/8565457/43814398-2494f3e6-9b05-11e8-8c9f-947c9521094d.png)