### PR TITLE
관리자 페이지 로고 출력오류 수정

### DIFF
--- a/modules/admin/tpl/admin_setup.html
+++ b/modules/admin/tpl/admin_setup.html
@@ -17,7 +17,7 @@
 				<!--@if($config_object->adminLogo)-->
 				<img src="{getUrl('').$config_object->adminLogo}" />
 				<button type="submit" value="procAdminDeleteLogo" name="act" class="x_btn">{$lang->cmd_delete}</button>
-				<!--@else-->
+				<!--@elseif($gnb_title_info->adminLogo)-->
 				<img src="{getUrl('')}{$gnb_title_info->adminLogo}" />
 				<!--@end-->
 				<input type="file" name="adminLogo" id="adminLogo" />


### PR DESCRIPTION
관리자 페이지 로고가 등록되지 않았을 경우 이미지를 출력하지 않음.
#1076 