### PR TITLE
관리자 페이지의 상단 여백 제거

### DIFF
--- a/modules/admin/tpl/css/admin.css
+++ b/modules/admin/tpl/css/admin.css
@@ -737,12 +737,14 @@ margin-bottom: 10px;
 	overflow: hidden;
 	color: #333;
 	text-decoration: none;
+	position: absolute;
 }
 .x>.skipNav>a:focus {
 	height: auto;
 	margin: 5px 0;
 	padding: 8px 0;
 	background: #fff;
+	position: static;
 }
 .x>.header {
 	position: relative;


### PR DESCRIPTION
메뉴 건너뛰기(.skipNav)로 인해 상단에 1px의 여백이 존재합니다. 관리자 페이지 디자인 개정에 따라 이 여백을 제거하였습니다.