### PR TITLE
첨부파일 폴더 구조 단순화

### DIFF
--- a/common/defaults/config.php
+++ b/common/defaults/config.php
@@ -63,6 +63,7 @@ return array(
 		'refresh' => 300,
 	),
 	'file' => array(
+		'folder_structure' => 2,
 		'umask' => '0022',
 	),
 	'mail' => array(

--- a/common/framework/parsers/configparser.php
+++ b/common/framework/parsers/configparser.php
@@ -247,6 +247,7 @@ class ConfigParser
 		}
 		
 		// Convert miscellaneous configuration.
+		$config['file']['folder_structure'] = 1;
 		$config['file']['umask'] = Storage::recommendUmask();
 		$config['mobile']['enabled'] = $db_info->use_mobile_view === 'N' ? false : true;
 		$config['use_prepared_statements'] = $db_info->use_prepared_statements === 'Y' ? true : false;

--- a/modules/admin/admin.admin.view.php
+++ b/modules/admin/admin.admin.view.php
@@ -79,6 +79,11 @@ class adminAdminView extends admin
 			config('crypto.session_key', Rhymix\Framework\Security::getRandom(64, 'alnum'));
 			$changed = true;
 		}
+		if (config('file.folder_structure') === null)
+		{
+			config('file.folder_structure', 1);
+			$changed = true;
+		}
 		
 		// Save new configuration.
 		if ($changed)


### PR DESCRIPTION
첨부파일이 저장되는 `files/attach/images` 및 `files/attach/binaries` 폴더 아래의 서브폴더 구조를 단순화하여 불필요하게 많은 서브폴더가 생성되는 것을 방지합니다.

기존 방식은 `upload_target_srl`마다 최소 1개씩의 서브폴더를 생성하고, 글 번호가 길어지면 이것이 3\~4단계로 늘어나기 때문에 장기간 사이트를 운영하다 보면 수십\~수백만 개의 서브폴더가 생성되어 백업이나 파일 관리를 할 때 불편이 많았습니다.

    ./files/attach/images/모듈번호/글번호/3자리식/자름/랜덤파일명.확장자
    ./files/attach/binaries/모듈번호/글번호/3자리식/자름/랜덤파일명

이런 식이었지요.

특정 게시물이나 특정 모듈에 소속된 파일들을 일괄 삭제해야 할 때는 이 방식이 편리할 수도 있으나, 그런 작업은 대개 관리자 화면에서 처리할 수 있으므로 수동으로 파일을 삭제하는 희귀한 상황에 대비하여 평소에 많은 불편과 비효율성을 감수할 필요는 없다고 생각됩니다. 글을 지웠는데 파일이 남아 있는 등의 자잘한 버그도 이제는 대부분 해결되었고요. 게다가 몇 달 전부터는 글을 다른 모듈로 이동시키더라도 파일은 이동하지 않도록 변경되었기 때문에, 특정 모듈에 소속된 파일이 반드시 해당 모듈 폴더에 들어 있다는 보장도 없습니다.

새 방식은 아래와 같습니다.

    ./files/attach/images/년/월/일/랜덤파일명.확장자
    ./files/attach/binaries/년/월/일/랜덤파일명

이렇게 하면 하루에 1개씩만 서브폴더가 생성되므로, 10년간 사이트를 운영하더라도 서브폴더 갯수는 수천 개에 그칩니다. 폴더 하나에 저장되는 파일 수는 늘어나겠지만, ext4, xfs, ntfs 등 흔히 사용하는 파일시스템에서는 폴더당 수천 개의 파일이 들어가더라도 아무 문제가 되지 않습니다. 지금처럼 폴더 하나에 겨우 몇 개의 파일만 저장하는 것은 낭비입니다.

참고로 워드프레스는 `년/월` 단위까지만 구분합니다. 그러나 소수의 사람들만이 글을 쓰는 블로그에 최적화된 워드프레스와 달리, 라이믹스는 다수의 유저들이 직접 파일을 업로드할 수 있는 커뮤니티 사이트에 많이 사용되므로 `년/월/일`까지 구분하는 것이 더 균형잡힌 솔루션을 제공할 수 있다고 생각됩니다. 하루에 수만 개씩 새 파일이 업로드되는 초대형 사이트라면 `FileController->_getStoragePath()` 함수를 커스터마이징하여 더 세부적인 구분을 추가하면 되고요.

폴더 구조는 `file.folder_structure` 시스템 설정에 따라 결정됩니다.

- 라이믹스로 신규 설치한 사이트는 이 설정이 `2`가 됩니다. 이 경우 새 방식을 사용합니다.
- 기존 라이믹스 사이트 및 XE에서 업그레이드한 사이트는 이 설정이 없거나 `1`로 되어 있을 것입니다. 이 경우 기존 방식을 그대로 사용합니다.
- 기존 사이트에서 새 방식을 사용하고 싶다면 `files/config/config.php`에서 해당 설정을 `2`로 변경하면 됩니다. 새로 업로드하는 첨부파일에만 적용됩니다.
- 어떤 경우에도 기존 방식으로 저장된 첨부파일의 경로를 강제 변경하지는 않습니다.

썸네일 저장 경로, 포인트 캐시파일 경로 등은 변경하지 않습니다.