### PR TITLE
권한 설정에서 "가입한 사용자" 옵션 제거

### DIFF
--- a/modules/communication/tpl/index.html
+++ b/modules/communication/tpl/index.html
@@ -104,11 +104,8 @@
 		<label class="x_control-label" for="grant_send">{$lang->communication_send_message_grant}</label>
 		<div class="x_controls">
 			<select name="grant_send_default" class="grant_default" id="grant_send">
-				<option value="member" selected="selected"|cond="$config->grant_send['default'] == 'member'">
+				<option value="member" selected="selected"|cond="$config->grant_send['default'] == 'member' || $config->grant_send['default'] == 'site'">
 					{$lang->grant_to_login_user}
-				</option>
-				<option value="site" selected="selected"|cond="$config->grant_send['default'] == 'site'">
-					{$lang->grant_to_site_user}
 				</option>
 				<option value="manager" selected="selected"|cond="$config->grant_send['default'] == 'manager'">
 					{$lang->grant_to_admin}

--- a/modules/menu/tpl/sitemap.html
+++ b/modules/menu/tpl/sitemap.html
@@ -620,7 +620,6 @@
 						<select id="auth${PermId}">
 							<option class="_group_all" value="0">{$lang->grant_to_all}</option>
 							<option class="_group_loggedin" value="-1">{$lang->grant_to_login_user}</option>
-							<option class="_group_signedup" value="-2">{$lang->grant_to_site_user}</option>
 							<option class="_group_manager" value="-3">{$lang->grant_to_admin}</option>
 							<option class="_group_selected" value="-10">{$lang->grant_to_group}</option>
 						</select>
@@ -2210,21 +2209,6 @@ jQuery(function($){
 		var htInfo, sDefault, $node, $groupNode, aGroup, sGrant;
 		for(var i=0, nLen=aPerms.length; i<nLen; i++){
 			htInfo = aPerms[i];
-			//console.log(3, i, nLen, htInfo);
-			/*
-			<li>
-				<label for="auth${PermId}">${PermTitle}</label>
-				<select id="auth${PermId}">
-					<option class="_group_all" value="0">모든 사용자</option>
-					<option class="_group_loggedin" value="-1">로그인 사용자</option>
-					<option class="_group_signedup" value="-2">가입한 사용자</option>
-					<option class="_group_manager" value="-3">관리자만</option>
-					<option class="_group_selected" value="-10">선택그룹 사용자</option>
-				</select>
-				<div class="selected x_hide">
-				</div>
-			</li>
-			*/
 
 			sDefault = htInfo.sDefault;
 			//aGroup = htInfo.aGroup;

--- a/modules/module/module.model.php
+++ b/modules/module/module.model.php
@@ -2125,22 +2125,9 @@ class moduleModel extends module
 				// Log-in member only
 				if($member_info->member_srl)
 				{
-					if($val->group_srl == -1)
+					if($val->group_srl == -1 || $val->group_srl == -2)
 					{
 						$grant->{$val->name} = true;
-					}
-					// Site-joined member only
-					else if($val->group_srl == -2)
-					{
-						// Grant if no information of the currently connected site exists
-						if(!Context::get('site_module_info')->site_srl)
-						{
-							$grant->{$val->name} = true;
-						}
-						else if(count($member_group))
-						{
-							$grant->{$val->name} = true;
-						}
 					}
 					// Manager only
 					else if($val->group_srl == -3)

--- a/modules/module/tpl/include.module_grant_setup.html
+++ b/modules/module/tpl/include.module_grant_setup.html
@@ -9,14 +9,12 @@
 	<input type="hidden" name="module_srls" value="{$module_srls}" />
 	<input type="hidden" name="xe_validator_id" value="modules/module/tpl/manage_selected" />
     <h1>{$lang->permission_setting}</h1>
-    <p>{$lang->about_grant_deatil}</p>
 	<div loop="$grant_list => $grant_name, $grant_item" class="x_control-group">
 		<label class="x_control-label" for="{$grant_name}_default">{$grant_item->title}</label>
 		<div class="x_controls">
 			<select name="{$grant_name}_default" id="{$grant_name}_default" class="grant_default">
 				<option value="0" cond="$grant_item->default == 'guest'">{$lang->grant_to_all}</option>
 				<option value="-1" cond="$grant_item->default != 'manager'">{$lang->grant_to_login_user}</option>
-				<option value="-2" cond="$grant_item->default != 'manager'" selected="selected"|cond="$default_grant[$grant_name]=='site'">{$lang->grant_to_site_user}</option>
 				<option value="-3">{$lang->grant_to_admin}</option>
 				<option value="">{$lang->grant_to_group}</option>
 			</select>

--- a/modules/module/tpl/module_grant_setup.html
+++ b/modules/module/tpl/module_grant_setup.html
@@ -20,11 +20,9 @@
 				<select name="{$grant_name}_default" class="grant_default">
 					<option value="0" cond="$grant_item->default == 'guest'">{$lang->grant_to_all}</option>
 					<option value="-1" cond="$grant_item->default != 'manager'">{$lang->grant_to_login_user}</option>
-					<option value="-2" cond="$grant_item->default != 'manager'" selected="selected"|cond="$default_grant[$grant_name]=='site'">{$lang->grant_to_site_user}</option>
 					<option value="-3">{$lang->grant_to_admin}</option>
 					<option value="">{$lang->grant_to_group}</option>
 				</select>
-				<p class="x_help-block" id="aboutGrantDetail" cond="$grant_name=='access'">{$lang->about_grant_deatil}</p>
 				<div id="zone_{$grant_name}" hidden style="margin:8px 0 0 0">
 					<label loop="$group_list => $group_srl, $group_item" for="grant_{$grant_name}_{$group_srl}">
 						<input type="checkbox" class="checkbox" name="{$grant_name}" value="{$group_item->group_srl}" id="grant_{$grant_name}_{$group_srl}" />

--- a/modules/module/tpl/module_grants.html
+++ b/modules/module/tpl/module_grants.html
@@ -45,12 +45,10 @@
 				<div class="x_controls">
 					<select name="{$grant_name}_default" id="{$grant_name}_default" class="grant_default">
 						<!--@if($grant_item->default == 'guest')--><option value="0" <!--@if($default_grant[$grant_name]=='all')-->selected="selected"<!--@end-->>{$lang->grant_to_all}</option><!--@end-->
-						<!--@if($grant_item->default != 'manager')--><option value="-1" <!--@if($default_grant[$grant_name]=='member')-->selected="selected"<!--@end-->>{$lang->grant_to_login_user}</option><!--@end-->
-						<!--@if($grant_item->default != 'manager')--><option value="-2" <!--@if($default_grant[$grant_name]=='site')-->selected="selected"<!--@end-->>{$lang->grant_to_site_user}</option><!--@end-->
+						<!--@if($grant_item->default != 'manager')--><option value="-1" <!--@if($default_grant[$grant_name]=='member' || $default_grant[$grant_name]=='site')-->selected="selected"<!--@end-->>{$lang->grant_to_login_user}</option><!--@end-->
 						<option value="-3" <!--@if($default_grant[$grant_name]=='manager')-->selected="selected"<!--@end-->>{$lang->grant_to_admin}</option>
 						<option value="" <!--@if($default_grant[$grant_name]=='group')-->selected="selected"<!--@end-->>{$lang->grant_to_group}</option>
 					</select>
-					<p class="x_help-block" cond="$grant_name == 'access'">{$lang->about_grant_deatil}</p>
 					<div id="zone_{$grant_name}" hidden style="margin:8px 0 0 0">
 						<!--@foreach($group_list as $group_srl => $group_item)-->
 						<label for="grant_{$grant_name}_{$group_srl}" class="x_inline"><input type="checkbox" class="checkbox" name="{$grant_name}" value="{$group_item->group_srl}" id="grant_{$grant_name}_{$group_srl}" checked="checked"|cond="is_array($selected_group[$grant_name])&&in_array($group_srl,$selected_group[$grant_name])" /> {$group_item->title}</label>


### PR DESCRIPTION
멀티사이트(카페XE) 기능을 지원하지 않은 지 한참 되었는데 아직 "로그인 사용자"와 (특정 카페에) "가입한 사용자"를 구분하도록 되어 있어 사용자들이 혼란을 겪을 수 있습니다. 이미 오래 전부터 두 옵션 모두 100% 동일한 효과였습니다. (site_srl 값이 항상 0으로 고정되므로, 로그인만 하면 module.model.php 2136줄의 조건이 참이 됩니다.)

따라서 "가입한 사용자" 옵션을 템플릿에서 제거하고, 기존에 "가입한 사용자"를 선택했던 모듈들은 "로그인 사용자"를 선택한 것으로 취급합니다. 기능 면에서 바뀌는 것은 전혀 없습니다.