### PR TITLE
#1107 넘겨보는 사진옵션에서 하단 내용 표시에 대한 출력 옵션 추가

### DIFF
--- a/addons/photoswipe/conf/info.xml
+++ b/addons/photoswipe/conf/info.xml
@@ -23,12 +23,12 @@
 	<extra_vars>
 		<var name="display_name" type="select">
 			<title xml:lang="ko">파일이름 출력 설정</title>
-			<description xml:lang="ko">넘겨보기 실행시 하단에 파일이름을 출력할 것인지 여부를 선택합니다.</description>
-			<options value="none">
-				<title xml:lang="ko">사용 안함</title>
-			</options>
+			<description xml:lang="ko">넘겨보기 실행시 하단에 파일이름을 출력할 것인지 여부를 선택합니다. 기본값은 사용하도록 되어있습니다.</description>
 			<options value="block">
 				<title xml:lang="ko">사용</title>
+			</options>
+			<options value="none">
+				<title xml:lang="ko">사용 안함</title>
 			</options>
 		</var>
 	</extra_vars>

--- a/addons/photoswipe/conf/info.xml
+++ b/addons/photoswipe/conf/info.xml
@@ -20,4 +20,16 @@
 		<name xml:lang="ko">Rhymix contributors</name>
 		<name xml:lang="en">Rhymix contributors</name>
 	</author>
+	<extra_vars>
+		<var name="display_name" type="select">
+			<title xml:lang="ko">파일이름 출력 설정</title>
+			<description xml:lang="ko">넘겨보기 실행시 하단에 파일이름을 출력할 것인지 여부를 선택합니다.</description>
+			<options value="none">
+				<title xml:lang="ko">사용 안함</title>
+			</options>
+			<options value="block">
+				<title xml:lang="ko">사용</title>
+			</options>
+		</var>
+	</extra_vars>
 </addon>

--- a/addons/photoswipe/photoswipe.addon.php
+++ b/addons/photoswipe/photoswipe.addon.php
@@ -21,7 +21,16 @@ if($called_position == 'after_module_proc' && Context::getResponseMethod() == "H
 	Context::loadFile(array('./addons/photoswipe/rx_photoswipe.js', 'body', '', null), true);
 
 	$footer = FileHandler::readFile('./addons/photoswipe/PhotoSwipe/pswp.html');
-	Context::addHtmlFooter($footer);
+	if(isset($addon_info->display_name))
+	{
+		$style_display = "<style>.pswp__caption__center {  display:{$addon_info->display_name} }</style>";
+	}
+	else
+	{
+		$style_display = '<style>.pswp__caption__center {  display:block }</style>';
+	}
+
+	Context::addHtmlFooter($style_display . $footer);
 }
 
 /* End of file photoswipe.addon.php */

--- a/addons/photoswipe/photoswipe.addon.php
+++ b/addons/photoswipe/photoswipe.addon.php
@@ -21,14 +21,8 @@ if($called_position == 'after_module_proc' && Context::getResponseMethod() == "H
 	Context::loadFile(array('./addons/photoswipe/rx_photoswipe.js', 'body', '', null), true);
 
 	$footer = FileHandler::readFile('./addons/photoswipe/PhotoSwipe/pswp.html');
-	if(isset($addon_info->display_name))
-	{
-		$style_display = "<style>.pswp__caption__center {  display:{$addon_info->display_name} }</style>";
-	}
-	else
-	{
-		$style_display = '<style>.pswp__caption__center {  display:block }</style>';
-	}
+
+	$style_display = isset($addon_info->display_name) ? "<style>.pswp__caption__center {  display:{$addon_info->display_name} }</style>" : '<style>.pswp__caption__center {  display:block }</style>';
 
 	Context::addHtmlFooter($style_display . $footer);
 }


### PR DESCRIPTION
넘겨보는 사진에 하단의 글자 부분에 해당 이미지의 title옵션이 없으면 파일이름을 출력하는데 이를 출력하지 않을 옵션이 존재하지 않습니다.

애드온이 출력하는 특정 구조상 전체적으로 바꾸지 않고 옵션선택한 것에 따라 display옵션을 none, block 속성으로 만들어주도록 고쳤보았습니다.