### PR TITLE
Fix #997 비로그인 사용자가 추천시 추천 취소버튼이 활성화 되지 않는 문제 고침

### DIFF
--- a/modules/document/document.item.php
+++ b/modules/document/document.item.php
@@ -484,19 +484,21 @@ class documentItem extends BaseObject
 		}
 		
 		$logged_info = Context::get('logged_info');
-		if(!$logged_info->member_srl)
-		{
-			return false;
-		}
-		
 		if(isset($_SESSION['voted_document'][$this->document_srl]))
 		{
 			return $_SESSION['voted_document'][$this->document_srl];
 		}
-		
+
 		$args = new stdClass;
-		$args->member_srl = $logged_info->member_srl;
 		$args->document_srl = $this->document_srl;
+		if($logged_info->member_srl)
+		{
+			$args->member_srl = $logged_info->member_srl;
+		}
+		else
+		{
+			$args->ipaddress = RX_CLIENT_IP;
+		}
 		$output = executeQuery('document.getDocumentVotedLog', $args);
 		if($output->data->point)
 		{


### PR DESCRIPTION
비로그인 사용자가 추천시 취소버튼이 활성화 되지 않는 문제 고쳤습니다.

다만 한국 유선 인터넷 특성상 유동 아이피가 많고 모바일에서도 장소에 따라 아이피가 달라지는 등 여러가지 요인으로 인해서 접속이 많은 사이트의 경우 아이피가 중복되었을 경우 취소에 대한 중복이 이루어질 수 있고 로그인 사용자가 추천한 것을 바탕으로 취소 나올 수 있는 부분의 문제가 우려되고 있습니다.

꼼꼼히 검사하는 기능을 추가해야할 것 같아요.