### PR TITLE
www를 붙이거나 삭제해주는 애드온류를 블랙리스트에 추가

### DIFF
--- a/common/defaults/blacklist.php
+++ b/common/defaults/blacklist.php
@@ -18,4 +18,7 @@ return array(
 	'session_shield' => true,
 	'smartphone' => true,
 	'zipperupper' => true,
+	'elkha_www' => true,
+	'autowww' => true,
+	'fix_domain' => true,
 );


### PR DESCRIPTION
엘카님의 www제거 애드온을 사용시 워닝에러가 라이믹스에서 발생하는것을 발견하고 라이믹스에서는 더 이상 필요가 없는 기능이기 때문에 이용자들이 불편하지 않도록 삭제를 진행하였습니다. (도메인 주소를 검사해서 기본 주소로 301 리디렉트 해주는 기능이 이미 내장되어있기 때문에 다른 처리할 필요가 없을 것 같습니다.)