### PR TITLE
알림 더미 테스트시 ajax으로 알림을 생성하지 않고 XE에 직접 요청하도록 개선

### DIFF
--- a/modules/ncenterlite/ncenterlite.admin.controller.php
+++ b/modules/ncenterlite/ncenterlite.admin.controller.php
@@ -127,11 +127,24 @@ class ncenterliteAdminController extends ncenterlite
 			$args->type = $this->_TYPE_TEST;
 			$args->target_type = $this->_TYPE_TEST;
 			$args->target_url = getUrl('');
-			$args->target_summary = Context::getLang('ncenterlite_thisistest') . rand();
+			$args->target_summary = Context::getLang('ncenterlite_thisistest');
 			$args->target_nick_name = $logged_info->nick_name;
 			$args->regdate = date('YmdHis');
 			$args->notify = $oNcenterliteController->_getNotifyId($args);
-			$oNcenterliteController->_insertNotify($args);
+			$output = $oNcenterliteController->_insertNotify($args);
+			if(!$output->toBool())
+			{
+				return $output;
+			}
+		}
+
+		if (Context::get('success_return_url'))
+		{
+			$this->setRedirectUrl(Context::get('success_return_url'));
+		}
+		else
+		{
+			$this->setRedirectUrl(getNotEncodedUrl('', 'module', 'admin', 'act', 'dispNcenterliteAdminTest'));
 		}
 	}
 
@@ -154,7 +167,20 @@ class ncenterliteAdminController extends ncenterlite
 		$args->target_nick_name = $logged_info->nick_name;
 		$args->regdate = date('YmdHis');
 		$args->notify = $oNcenterliteController->_getNotifyId($args);
-		$oNcenterliteController->_insertNotify($args);
+		$output = $oNcenterliteController->_insertNotify($args);
+		if(!$output->toBool())
+		{
+			return $output;
+		}
+
+		if (Context::get('success_return_url'))
+		{
+			$this->setRedirectUrl(Context::get('success_return_url'));
+		}
+		else
+		{
+			$this->setRedirectUrl(getNotEncodedUrl('', 'module', 'admin', 'act', 'dispNcenterliteAdminTest'));
+		}
 	}
 
 	function procNcenterliteAdminDeleteNofity()

--- a/modules/ncenterlite/tpl/js/ncenter_admin.js
+++ b/modules/ncenterlite/tpl/js/ncenter_admin.js
@@ -29,14 +29,3 @@ function completeGetSkinColorset(ret_obj, response_tags, params, fo_obj)
 
 	sel.selectedIndex = selected_index;
 }
-
-function doDummyDataInsert()
-{
-	jQuery.exec_json('ncenterlite.procNcenterliteAdminInsertDummyData', {}, function completeGetDummyInfo(ret_obj){alert(ret_obj.message)});
-}
-
-function doDummyPushDataInsert()
-{
-	jQuery.exec_json('ncenterlite.procNcenterliteAdminInsertPushData', {}, function completeGetDummyPushInfo(ret_obj){alert(ret_obj.message)});
-}
-

--- a/modules/ncenterlite/tpl/test.html
+++ b/modules/ncenterlite/tpl/test.html
@@ -8,14 +8,28 @@
 		<div class="x_control-group">
 			<label class="x_control-label">{$lang->ncenterlite_test_mention}</label>
 			<div class="x_controls">
-				<label><input type="button" name="dummy" onClick="doDummyDataInsert();" class="x_btn" value="{$lang->ncenterlite_test_make_dummy}"> {$lang->ncenterlite_test_mention_about}</label>
+				<form action="./" method="post">
+					<fieldset>
+						<input type="hidden" name="module" value="ncenterlite" />
+						<input type="hidden" name="act" value="procNcenterliteAdminInsertDummyData" />
+						<button type="submit" class="x_btn">{$lang->ncenterlite_test_make_dummy}</button>
+					</fieldset>
+				</form>
+				<p>{$lang->ncenterlite_test_mention_about}</p>
 			</div>
 		</div>
 
 		<div class="x_control-group">
 			<label class="x_control-label">{$lang->ncenterlite_test_push}</label>
 			<div class="x_controls">
-				<label><input type="button" name="dummy" onClick="doDummyPushDataInsert();" class="x_btn" value="{$lang->ncenterlite_test_make_dummy}"> {$lang->ncenterlite_test_push_about}</label>
+				<form action="./" method="post">
+					<fieldset>
+						<input type="hidden" name="module" value="ncenterlite" />
+						<input type="hidden" name="act" value="procNcenterliteAdminInsertPushData" />
+						<button type="submit" class="x_btn">{$lang->ncenterlite_test_make_dummy}</button>
+					</fieldset>
+				</form>
+				<p>{$lang->ncenterlite_test_push_about}</p>
 			</div>
 		</div>
 	</section>


### PR DESCRIPTION
현재 알림센터 방식에서 테스트알림 발송시 다음과 같이 문제 발생시 해당 문제를 파악할 수 없습니다.

문제 : https://xetown.com/questions/1212317

이는 JS의 ajax전송 방식을 사용함에 따라 알림 생성시 백그라운드에서 실행이후 새로고침 하는 형태이다 보니 해당 알림과정에서 에러가 발생시 해당 에러를 확인하는 부분이 js에 요청한 쪽에서 받게 됩니다. 이 경우 사용자가 테스트가 정상적으로 되지 않앗을 때 왜 오류가 발생되는지 알기 어렵습니다.

따라서 테스트 목적에 부합한 방법으로 수정합니다.