### PR TITLE
README 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ devops@rhymix.org로 알려 주시면 감사하겠습니다.
 
 ### 커뮤니티
 
-- XETOWN : https://www.xetown.com
+- XETOWN : https://xetown.com
 
 ### 저작권 및 라이선스
 
@@ -122,7 +122,7 @@ If you have found a security vulnerability, please let us know at devops@rhymix.
 
 ### Community
 
-- XETOWN (Korean) : https://www.xetown.com
+- XETOWN (Korean) : https://xetown.com
 
 ### Copyright and License
 


### PR DESCRIPTION
xetown.com이 더 이상 www 서브도메인을 통한 접속을 지원하지 않아 README 파일의 주소에서 www를 제거하였습니다.