### PR TITLE
select 쿼리에 list_count=0 파라미터 전달시 LIMIT 해제

### DIFF
--- a/classes/db/queryparts/limit/Limit.class.php
+++ b/classes/db/queryparts/limit/Limit.class.php
@@ -44,17 +44,18 @@ class Limit
 	function __construct($list_count, $page = NULL, $page_count = NULL, $offset = NULL)
 	{
 		$this->list_count = $list_count;
-		if($page)
+		if($list_count->getValue())
 		{
-			$list_count_value = $list_count->getValue();
-			$page_value = $page->getValue();
-			$this->start = ($page_value - 1) * $list_count_value;
-			$this->page_count = $page_count;
-			$this->page = $page;
-		}
-		elseif($offset)
-		{
-			$this->start = $offset->getValue();
+			if($page)
+			{
+				$this->start = ($page->getValue() - 1) * $list_count->getValue();
+				$this->page_count = $page_count;
+				$this->page = $page;
+			}
+			elseif($offset)
+			{
+				$this->start = $offset->getValue();
+			}
 		}
 	}
 
@@ -86,16 +87,15 @@ class Limit
 
 	function toString()
 	{
-		if($this->page || $this->start)
+		if($this->start)
 		{
 			return $this->start . ' , ' . $this->list_count->getValue();
 		}
 		else
 		{
-			return $this->list_count->getValue();
+			return $this->list_count->getValue() ?: '';
 		}
 	}
-
 }
 /* End of file Limit.class.php */
 /* Location: ./classes/db/limit/Limit.class.php */

--- a/classes/db/queryparts/limit/Limit.class.php
+++ b/classes/db/queryparts/limit/Limit.class.php
@@ -46,7 +46,7 @@ class Limit
 		$this->list_count = $list_count;
 		if($list_count->getValue())
 		{
-			if($page)
+			if($page && $page->getValue())
 			{
 				$this->start = ($page->getValue() - 1) * $list_count->getValue();
 				$this->page_count = $page_count;

--- a/modules/document/document.admin.controller.php
+++ b/modules/document/document.admin.controller.php
@@ -602,7 +602,7 @@ class documentAdminController extends document
 	function deleteModuleDocument($module_srl)
 	{
 		$args = new stdClass;
-		$args->page = 0;
+		$args->list_count = 0;
 		$args->module_srl = intval($module_srl);
 		$document_list = executeQueryArray('document.getDocumentList', $args, array('document_srl'))->data;
 		


### PR DESCRIPTION
`<page>` `<list_count>` 태그가 있는 select 쿼리 사용시 `list_count=0` 파라미터로 LIMIT를 해제할 수 있도록 변경하였습니다.

## Before
이전에는 `<list_count>` `<page>` 태그가 없는 select 쿼리를 새로 만들거나 다음과 같은 편법(?)을 사용해야 했습니다.
```
$args->list_count = 99999;
```
* 근데 이러면 여전히 total count 계산을 위한 count query가 쓸데없이 실행된다는 문제가 있습니다.

## After
이제는 0으로 당당히 LIMIT를 해제할 수 있습니다.
```
$args->list_count = 0;
```
* `<list_count>` `<page>` `<page_count>` `<offset>` 태그가 무시됩니다.