### PR TITLE
하이퍼링크 href값이 javascript나 mailto로 시작될 경우 target=_blank 속성을 추가하지 않게 수정

### DIFF
--- a/addons/autolink/autolink.js
+++ b/addons/autolink/autolink.js
@@ -92,10 +92,15 @@
 	});
 
 	xe.registerPlugin(new AutoLink());
-	
+
 	$(document).on('click', '.xe_content a', function() {
-		if (!$(this).attr("target")) {
-			$(this).attr("target", "_blank");
+		var $this = $(this);
+		var href = $this.attr('href');
+		if(!href || /^(?:javascript|mailto):/.test(href)) {
+			return;
+		}
+		if (!$this.attr("target")) {
+			$this.attr("target", "_blank");
 		}
 	});
 	


### PR DESCRIPTION
서드파티 모듈(애드온)에서 본문에 a href="javascript:;" 와 같은 태그를 생성하였을때 target="_blank"가 적용되는 문제가 있습니다.
또한 mailto:와 같은 링크에서도 불필요하게 새창이 뜹니다.

하이퍼링크 href값이 javascript나 mailto로 시작될 경우, 또는 href값이 없을 경우 target="_blank" 속성을 추가하지 않게 수정하였습니다.