### PR TITLE
변경됨을 알리는 rhymix_alert 추가

### DIFF
--- a/common/css/rhymix.less
+++ b/common/css/rhymix.less
@@ -163,7 +163,8 @@ a img {
 	position: fixed;
 	left: 50%;
 	bottom: 20%;
-	width: 350px;
+	min-width: 250px;
+	max-width: 500px;
 	background-color: #000;
 	color: #fff;
 	font-size: 16px;

--- a/common/css/rhymix.less
+++ b/common/css/rhymix.less
@@ -171,6 +171,7 @@ a img {
 	text-align: center;
 	opacity: 0.6;
 	padding: 12px 20px;
+	border: 1px solid #fff;
 	border-radius: 10px;
 	transform: translateX(-50%);
 	z-index: 999999999;

--- a/common/css/rhymix.less
+++ b/common/css/rhymix.less
@@ -157,6 +157,24 @@ a img {
 	background: #333 url("../../common/img/msg.loading.gif") no-repeat center 15px;
 }
 
+/* alert */
+#rhymix_alert {
+	display: none;
+	position: fixed;
+	left: 50%;
+	bottom: 20%;
+	width: 350px;
+	background-color: #000;
+	color: #fff;
+	font-size: 16px;
+	text-align: center;
+	opacity: 0.6;
+	padding: 12px 20px;
+	border-radius: 10px;
+	transform: translateX(-50%);
+	z-index: 999999999;
+}
+
 /* Debug */
 #rhymix_debug_button {
 	display: none;

--- a/common/js/common.js
+++ b/common/js/common.js
@@ -82,6 +82,15 @@
 		}
 	};
 	
+	window.rhymix_alert_close = function() {
+		if($('#rhymix_alert').is(':hidden')) {
+			return;
+		}
+		$('#rhymix_alert').fadeOut(500, function() {
+			$(this).empty();
+		});
+	};
+	
 	/**
 	 * @brief display alert
 	 */
@@ -91,11 +100,7 @@
 		}
 		if(!redirect_url) {
 			$('#rhymix_alert').text(message).show();
-			setTimeout(function() {
-				$('#rhymix_alert').fadeOut(1000, function() {
-					$(this).empty();
-				});
-			}, delay);
+			setTimeout(rhymix_alert_close, delay);
 		}
 		else if(isSameOrigin(location.href, redirect_url)) {
 			Cookies.set('rhymix_alert_message', message, { expires: 1 / 1440, path: '' });
@@ -112,6 +117,7 @@
 			Cookies.remove('rhymix_alert_message', { path: '' });
 			Cookies.remove('rhymix_alert_delay', { path: '' });
 		}
+		$('#rhymix_alert').click(rhymix_alert_close);
 	});
 	
 	/* Array for pending debug data */

--- a/common/js/common.js
+++ b/common/js/common.js
@@ -82,6 +82,38 @@
 		}
 	};
 	
+	/**
+	 * @brief display alert
+	 */
+	window.rhymix_alert = function(message, redirect_url, delay) {
+		if(!delay) {
+			delay = 2500;
+		}
+		if(!redirect_url) {
+			$('#rhymix_alert').text(message).show();
+			setTimeout(function() {
+				$('#rhymix_alert').fadeOut(1000, function() {
+					$(this).empty();
+				});
+			}, delay);
+		}
+		else if(isSameOrigin(location.href, redirect_url)) {
+			Cookies.set('rhymix_alert_message', message, { expires: 1 / 1440, path: '' });
+			Cookies.set('rhymix_alert_delay', delay, { expires: 1 / 1440, path: '' });
+		}
+		else {
+			alert(message);
+		}
+	};
+	
+	$(document).ready(function() {
+		if(Cookies.get('rhymix_alert_message')) {
+			rhymix_alert(Cookies.get('rhymix_alert_message'), null, Cookies.get('rhymix_alert_delay'));
+			Cookies.remove('rhymix_alert_message', { path: '' });
+			Cookies.remove('rhymix_alert_delay', { path: '' });
+		}
+	});
+	
 	/* Array for pending debug data */
 	window.rhymix_debug_pending_data = [];
 
@@ -531,15 +563,19 @@ function sendMailTo(to) {
  * @brief url이동 (Rhymix 개선된 버전)
  */
 function redirect(url) {
-	var absolute_url = window.location.href;
-	var relative_url = window.location.pathname + window.location.search;
-	if (url === absolute_url || url.indexOf(absolute_url.replace(/#.+$/, "") + "#") === 0 ||
-		url === relative_url || url.indexOf(relative_url.replace(/#.+$/, "") + "#") === 0) {
+	if (isCurrentPageUrl(url)) {
 		window.location.href = url;
 		window.location.reload();
 	} else {
 		window.location.href = url;
 	}
+}
+
+function isCurrentPageUrl(url) {
+	var absolute_url = window.location.href;
+	var relative_url = window.location.pathname + window.location.search;
+	return  url === absolute_url || url.indexOf(absolute_url.replace(/#.+$/, "") + "#") === 0 ||
+			url === relative_url || url.indexOf(relative_url.replace(/#.+$/, "") + "#") === 0;
 }
 
 /**

--- a/common/js/xml_handler.js
+++ b/common/js/xml_handler.js
@@ -377,11 +377,11 @@
 			callback_success = window[callback_success];
 		} else {
 			callback_success = function(data) {
-				if (data['message'] === 'success') {
+				if (data.message === 'success') {
 					return;
 				}
-				rhymix_alert(data['message'], data['redirect_url']);
-				if (data['redirect_url']) {
+				rhymix_alert(data.message, data.redirect_url);
+				if (data.redirect_url) {
 					redirect(data.redirect_url);
 				}
 			};

--- a/common/js/xml_handler.js
+++ b/common/js/xml_handler.js
@@ -376,7 +376,15 @@
 		if (callback_success && window[callback_success] && $.isFunction(window[callback_success])) {
 			callback_success = window[callback_success];
 		} else {
-			callback_success = null;
+			callback_success = function(data) {
+				if (data['message'] === 'success') {
+					return;
+				}
+				rhymix_alert(data['message'], data['redirect_url']);
+				if (data['redirect_url']) {
+					redirect(data.redirect_url);
+				}
+			};
 		}
 		var callback_error = form.data('callback-error');
 		if (callback_error && window[callback_error] && $.isFunction(window[callback_error])) {

--- a/common/tpl/common_layout.html
+++ b/common/tpl/common_layout.html
@@ -72,6 +72,7 @@
 
 <!-- ETC -->
 <div id="rhymix_waiting" class="wfsr" cond="!$m">{$lang->msg_call_server}</div>
+<div id="rhymix_alert"></div>
 <div id="rhymix_debug_panel"></div>
 <div id="rhymix_debug_button"></div>
 


### PR DESCRIPTION
변경됨을 알리는 용도로 사용할 수 있는 rhymix_alert 기능을 추가하였습니다.

## 개요
기존에는 오류 표시와 같이 `alert()`이나 `$XE_VALIDATOR_MESSAGE` 세션을 이용해 '변경되었음'을 알렸습니다. 하지만 너무 귀찮았습니다.  고작 '변경되었다'는 메세지인데 `alert()`은 엔터 또는 [확인] 버튼을 누르는 일을 요구했고, `$XE_VALIDATOR_MESSAGE`은 페이지 이동이 필요했습니다.

이 기능은 페이지 하단에 약 2.5초 동안 메세지를 띄우고 사라집니다.

## 동작
- `rx_ajax` 기능 사용시 기본적으로(success 콜백 함수가 없는 경우) 동작합니다. 물론, `$this->setMessage()` 전달된 메세지가 없는 경우에는 동작하지 않습니다.
- `$this->setRedirectUrl()`로 redirect 하는 경우에는 다음 페이지에서 표시됩니다. 단, 다른 사이트로 redirect 하는 경우에는 기본 `alert()`으로 알립니다.

## 스샷
![1](https://user-images.githubusercontent.com/8565457/71475535-f9e93c80-2823-11ea-811c-37800ec5b81d.png)
*단지 예시일뿐, 실제로는 위 관리자 페이지 폼에는 `rx_ajax` 기능이 적용되어 있지 않습니다.