### PR TITLE
윈도우서버에서 ffmpge 호환성 개선

### DIFF
--- a/modules/file/file.admin.controller.php
+++ b/modules/file/file.admin.controller.php
@@ -77,8 +77,16 @@ class fileAdminController extends file
 		$config->image_remove_exif_data = Context::get('image_remove_exif_data') === 'Y' ? true : false;
 		$config->video_thumbnail = Context::get('video_thumbnail') === 'Y' ? true : false;
 		$config->video_mp4_gif_time = intval(Context::get('video_mp4_gif_time'));
-		$config->ffmpeg_command = escape(utf8_trim(Context::get('ffmpeg_command'))) ?: '/usr/bin/ffmpeg';
-		$config->ffprobe_command = escape(utf8_trim(Context::get('ffprobe_command'))) ?: '/usr/bin/ffprobe';
+		if(strtoupper(substr(\PHP_OS, 0, 3)) === 'WIN')
+		{
+			$config->ffmpeg_command = escape(Context::get('ffmpeg_command')) ?: 'C:\Program Files\ffmpeg\bin\ffmpeg.exe';
+			$config->ffprobe_command = escape(Context::get('ffprobe_command')) ?: 'C:\Program Files\ffmpeg\bin\ffprobe.exe';
+		}
+		else
+		{
+			$config->ffmpeg_command = escape(utf8_trim(Context::get('ffmpeg_command'))) ?: '/usr/bin/ffmpeg';
+			$config->ffprobe_command = escape(utf8_trim(Context::get('ffprobe_command'))) ?: '/usr/bin/ffprobe';
+		}
 		
 		// Check maximum file size
 		if (PHP_INT_SIZE < 8)

--- a/modules/file/file.controller.php
+++ b/modules/file/file.controller.php
@@ -1180,7 +1180,7 @@ class fileController extends file
 				// Convert using ffmpeg
 				if(strtoupper(substr(\PHP_OS, 0, 3)) === 'WIN')
 				{
-					$command = '"'.$config->ffmpeg_command.'"';
+					$command = escapeshellarg($config->ffmpeg_command);
 				}
 				else
 				{

--- a/modules/file/file.controller.php
+++ b/modules/file/file.controller.php
@@ -1178,8 +1178,15 @@ class fileController extends file
 				$adjusted['height'] -= $adjusted['height'] % 2;
 				
 				// Convert using ffmpeg
-				$command = $config->ffmpeg_command;
-				$command .= ' -i ' . escapeshellarg($file_info['tmp_name']);
+				if(strtoupper(substr(\PHP_OS, 0, 3)) === 'WIN')
+				{
+					$command = '"'.$config->ffmpeg_command.'"';
+				}
+				else
+				{
+					$command = $config->ffmpeg_command;
+				}
+				$command .= ' -nostdin -i ' . escapeshellarg($file_info['tmp_name']);
 				$command .= ' -movflags +faststart -pix_fmt yuv420p -c:v libx264 -crf 23';
 				$command .= sprintf(' -vf "scale=%d:%d"', $adjusted['width'], $adjusted['height']);
 				$command .= ' ' . escapeshellarg($output_name);


### PR DESCRIPTION
1. ffmpge 실행파일의 경로명에 공백이 들어가는 경우에도 실행가능하도록 수정

2. ffmpeg 실행시 상호작용을 명시적으로 비활성하는 옵션을 추가하여, gif->mp4변환시 500에러가 발생하던 것을 수정