### PR TITLE
세션 도메인 관련 정리

### DIFF
--- a/classes/context/Context.class.php
+++ b/classes/context/Context.class.php
@@ -328,7 +328,7 @@ class Context
 		$lang_type = preg_replace('/[^a-zA-Z0-9_-]/', '', $lang_type);
 		if ($set_lang_cookie)
 		{
-			setcookie('lang_type', $lang_type, time() + 86400 * 365, '/', null, !!config('session.use_ssl_cookies'));
+			setcookie('lang_type', $lang_type, time() + 86400 * 365, \RX_BASEURL, null, !!config('session.use_ssl_cookies'));
 		}
 		
 		if(!$lang_type || !isset($enabled_langs[$lang_type]))

--- a/classes/mobile/Mobile.class.php
+++ b/classes/mobile/Mobile.class.php
@@ -73,7 +73,7 @@ class Mobile
 		$uatype = $uahash . ':' . (self::$_ismobile ? '1' : '0');
 		if ($cookie !== $uatype)
 		{
-			setcookie('rx_uatype', $uatype, 0, null, null, !!config('session.use_ssl_cookies'));
+			setcookie('rx_uatype', $uatype, 0, \RX_BASEURL, null, !!config('session.use_ssl_cookies'));
 			$_COOKIE['rx_uatype'] = $uatype;
 		}
 		

--- a/common/framework/session.php
+++ b/common/framework/session.php
@@ -800,7 +800,7 @@ class Session
 		}
 		else
 		{
-			self::$_domain = ltrim(ini_get('session.cookie_domain'), '.') ?: preg_replace('/:\\d+$/', '', strtolower($_SERVER['HTTP_HOST']));
+			self::$_domain = ltrim(ini_get('session.cookie_domain'), '.') ?: null;
 			return self::$_domain;
 		}
 	}

--- a/common/framework/session.php
+++ b/common/framework/session.php
@@ -202,9 +202,10 @@ class Session
 		}
 		
 		// If this is a new session, remove conflicting cookies.
-		if ($domain === null && !isset($_SESSION['conflict_clean']))
+		if ($cookie_exists && $domain === null && !isset($_SESSION['conflict_clean']))
 		{
 			self::destroyCookiesFromConflictingDomains(array(session_name(), 'rx_autologin', 'rx_sesskey1', 'rx_sesskey2'), true);
+			session_regenerate_id();
 			$_SESSION['conflict_clean'] = true;
 		}
 		


### PR DESCRIPTION
세션 도메인과 관련하여 최근 몇몇 사이트에서 문제가 제보되고 있기에 관련 코드를 정리해 봅니다.

1. 세션 도메인을 지정하면 PHP에서 무조건 앞에 점을 붙여 버립니다.
2. 대부분의 브라우저는 도메인 앞에 점이 붙은 쿠키와 점이 붙지 않은 쿠키를 동일하게 취급합니다. (즉, 점이 없는 쿠키도 모든 서브도메인에 전송되는 것은 마찬가지입니다.) ~따라서 점을 뗀다고 서브도메인 관련하여 무언가가 달라지지는 않을 전망입니다.~ 아래 댓글 참고
3. 문제는, 대부분의 브라우저가 점 있는 쿠키와 없는 쿠키를 동일하게 취급함에도 불구하고 실제로는 두 쿠키가 각각 따로 저장되며, 나중에 저장된 쿠키는 무시된다는 점입니다. [이뭐병?](https://www.phpschool.com/gnuboard4/bbs/board.php?bo_table=tipntech&wr_id=82507)
4. 따라서 `example.com`으로 지정된 세션 쿠키와 `.example.com`으로 지정된 세션 쿠키가 동시에 존재하는 경우, 먼저 저장된 쿠키만 유효하고 나중에 저장된 쿠키는 그냥 무시됩니다.
5. PHP에서 `example.com`으로 (점 없는) 세션 쿠키를 저장하려면 도메인에 NULL을 넣는 방법밖에 없습니다.
6. 얼마 전까지 라이믹스에서도 이렇게 하고 있었으나, 도메인을 무조건 NULL로 넣어 버리니까 여러 서브도메인을 멀티도메인을 연결하여 사용하는 사이트에서 세션 쿠키를 공유할 수 없게 되어 문제가 발생했습니다. 그래서 도메인을 지정하도록 변경했습니다.
7. 이 변경사항으로 인해 또다른 사이트에서 문제가 발생하고 있는 것 같습니다.
8. 따라서 아래와 같이 다시 변경합니다.
    - php.ini에서 `session.cookie_domain`을 설정하지도 않았고, 라이믹스 config.php에서 `session.domain`을 설정하지도 않은 사이트에서는 세션 쿠키 도메인을 NULL로 합니다. 즉, 세션 쿠키 도메인을 `example.com` 형태로 환원합니다.
    - 둘 중 하나라도 설정한 사이트에서는 세션 쿠키 도메인을 `.example.com` 형태로 합니다.
    - 점이 없는 세션 쿠키 도메인을 사용해야 하는 사이트임에도 불구하고 점이 있는 도메인으로 구워진 기존의 세션 쿠키, 보안키, 자동 로그인 쿠키 등이 있는 경우에는 다음 갱신 시점에 모두 삭제하고 점이 없는 도메인으로 교체됩니다.
    - 충돌하는 쿠키를 미리 인식하여 삭제하는 방법을 계속 연구 중입니다.