### PR TITLE
모듈 클래스 인스턴스를 직접 생성할 수 있도록 개선

### DIFF
--- a/classes/context/Context.class.php
+++ b/classes/context/Context.class.php
@@ -266,7 +266,7 @@ class Context
 					define('RX_BASEURL', parse_url($default_url, PHP_URL_PATH));
 				}
 			}
-			$oModuleModel = getModel('module');
+			$oModuleModel = ModuleModel::getInstance();
 			$site_module_info = $oModuleModel->getDefaultMid() ?: new stdClass;
 			self::set('site_module_info', $site_module_info);
 			self::set('_default_timezone', ($site_module_info->settings && $site_module_info->settings->timezone) ? $site_module_info->settings->timezone : null);
@@ -358,8 +358,8 @@ class Context
 		// set session handler
 		if(self::isInstalled() && config('session.use_db'))
 		{
-			$oSessionModel = getModel('session');
-			$oSessionController = getController('session');
+			$oSessionModel = SessionModel::getInstance();
+			$oSessionController = SessionController::getInstance();
 			ini_set('session.serialize_handler', 'php');
 			session_set_save_handler(
 					array(&$oSessionController, 'open'), array(&$oSessionController, 'close'), array(&$oSessionModel, 'read'), array(&$oSessionController, 'write'), array(&$oSessionController, 'destroy'), array(&$oSessionController, 'gc')
@@ -380,12 +380,11 @@ class Context
 		// set authentication information in Context and session
 		if (self::isInstalled())
 		{
-			$oModuleModel = getModel('module');
 			$oModuleModel->loadModuleExtends();
 
 			if (Rhymix\Framework\Session::getMemberSrl())
 			{
-				getController('member')->setSessionInfo();
+				MemberController::getInstance()->setSessionInfo();
 			}
 			else
 			{
@@ -803,7 +802,7 @@ class Context
 		{
 			return '';
 		}
-		getController('module')->replaceDefinedLangCode(self::$_instance->browser_title);
+		ModuleController::getInstance()->replaceDefinedLangCode(self::$_instance->browser_title);
 		return htmlspecialchars(self::$_instance->browser_title, ENT_QUOTES, 'UTF-8', FALSE);
 	}
 
@@ -818,7 +817,7 @@ class Context
 		if ($domain_info && $domain_info->settings && $domain_info->settings->title)
 		{
 			$title = trim($domain_info->settings->title);
-			getController('module')->replaceDefinedLangCode($title);
+			ModuleController::getInstance()->replaceDefinedLangCode($title);
 			return $title;
 		}
 		else
@@ -838,7 +837,7 @@ class Context
 		if ($domain_info && $domain_info->settings && $domain_info->settings->subtitle)
 		{
 			$subtitle = trim($domain_info->settings->subtitle);
-			getController('module')->replaceDefinedLangCode($subtitle);
+			ModuleController::getInstance()->replaceDefinedLangCode($subtitle);
 			return $subtitle;
 		}
 		else
@@ -1863,7 +1862,7 @@ class Context
 		{
 			if (!isset($domain_infos[$domain]))
 			{
-				$domain_infos[$domain] = getModel('module')->getSiteInfoByDomain($domain);
+				$domain_infos[$domain] = ModuleModel::getInstance()->getSiteInfoByDomain($domain);
 			}
 			$site_module_info = $domain_infos[$domain] ?: $site_module_info;
 		}
@@ -2744,7 +2743,7 @@ class Context
 	 */
 	public static function addMetaTag($name, $content, $is_http_equiv = false)
 	{
-		getController('module')->replaceDefinedLangCode($content);
+		ModuleController::getInstance()->replaceDefinedLangCode($content);
 		self::$_instance->meta_tags[$name] = array('is_http_equiv' => (bool)$is_http_equiv, 'content' => $content);
 	}
 	

--- a/classes/display/DisplayHandler.class.php
+++ b/classes/display/DisplayHandler.class.php
@@ -82,7 +82,7 @@ class DisplayHandler extends Handler
 
 		// execute add-on
 		$called_position = 'before_display_content';
-		$oAddonController = getController('addon');
+		$oAddonController = AddonController::getInstance();
 		$addon_file = $oAddonController->getCacheFilePath(Mobile::isFromMobilePhone() ? "mobile" : "pc");
 		if(file_exists($addon_file)) include($addon_file);
 		if($output === false || $output === null || $output instanceof BaseObject)

--- a/classes/module/ModuleHandler.class.php
+++ b/classes/module/ModuleHandler.class.php
@@ -135,7 +135,7 @@ class ModuleHandler extends Handler
 
 		// execute addon (before module initialization)
 		$called_position = 'before_module_init';
-		$oAddonController = getController('addon');
+		$oAddonController = AddonController::getInstance();
 		$addon_file = $oAddonController->getCacheFilePath(Mobile::isFromMobilePhone() ? 'mobile' : 'pc');
 		if(file_exists($addon_file)) include($addon_file);
 	}
@@ -146,13 +146,13 @@ class ModuleHandler extends Handler
 	 * */
 	public function init()
 	{
-		$oModuleModel = getModel('module');
+		$oModuleModel = ModuleModel::getInstance();
 		$site_module_info = Context::get('site_module_info');
 		
 		// Check unregistered domain action.
 		if (!$site_module_info || !isset($site_module_info->domain_srl) || $site_module_info->is_default_replaced)
 		{
-			$site_module_info = getModel('module')->getDefaultDomainInfo();
+			$site_module_info = $oModuleModel->getDefaultDomainInfo();
 			if ($site_module_info)
 			{
 				$domain_action = config('url.unregistered_domain_action') ?: 'redirect_301';
@@ -208,7 +208,7 @@ class ModuleHandler extends Handler
 		// Convert document alias (entry) to document_srl
 		if(!$this->document_srl && $this->mid && $this->entry)
 		{
-			$oDocumentModel = getModel('document');
+			$oDocumentModel = DocumentModel::getInstance();
 			$this->document_srl = $oDocumentModel->getDocumentSrlByAlias($this->mid, $this->entry);
 			if($this->document_srl)
 			{
@@ -248,7 +248,7 @@ class ModuleHandler extends Handler
 			// Block access to secret or temporary documents.
 			if(Context::getRequestMethod() == 'GET')
 			{
-				$oDocumentModel = getModel('document');
+				$oDocumentModel = DocumentModel::getInstance();
 				$oDocument = $oDocumentModel->getDocument($this->document_srl);
 				if($oDocument->isExists() && !$oDocument->isAccessible())
 				{
@@ -304,7 +304,7 @@ class ModuleHandler extends Handler
 				$seo_title = config('seo.subpage_title') ?: '$SITE_TITLE - $SUBPAGE_TITLE';
 			}
 			
-			getController('module')->replaceDefinedLangCode($seo_title);
+			ModuleController::getInstance()->replaceDefinedLangCode($seo_title);
 			Context::setBrowserTitle($seo_title, array(
 				'site_title' => Context::getSiteTitle(),
 				'site_subtitle' => Context::getSiteSubtitle(),
@@ -415,7 +415,7 @@ class ModuleHandler extends Handler
 	 * */
 	public function procModule()
 	{
-		$oModuleModel = getModel('module');
+		$oModuleModel = ModuleModel::getInstance();
 		$display_mode = Mobile::isFromMobilePhone() ? 'mobile' : 'view';
 
 		// If error occurred while preparation, return a message instance
@@ -1061,14 +1061,14 @@ class ModuleHandler extends Handler
 			// if layout_srl is rollback by module, set default layout
 			if($layout_srl == -1)
 			{
-				$oLayoutAdminModel = getAdminModel('layout');
+				$oLayoutAdminModel = LayoutAdminModel::getInstance();
 				$layout_srl = $oLayoutAdminModel->getSiteDefaultLayout($viewType, $oModule->module_info->site_srl);
 			}
 
 			if($layout_srl && !$oModule->getLayoutFile())
 			{
 				// If layout_srl exists, get information of the layout, and set the location of layout_path/ layout_file
-				$oLayoutModel = getModel('layout');
+				$oLayoutModel = LayoutModel::getInstance();
 				$layout_info = $oLayoutModel->getLayout($layout_srl);
 				if($layout_info)
 				{
@@ -1234,7 +1234,7 @@ class ModuleHandler extends Handler
 			return new BaseObject();
 		}
 
-		$oModuleModel = getModel('module');
+		$oModuleModel = ModuleModel::getInstance();
 		$triggers = $oModuleModel->getTriggers($trigger_name, $called_position);
 		if(!$triggers)
 		{

--- a/classes/module/ModuleHandler.class.php
+++ b/classes/module/ModuleHandler.class.php
@@ -1229,9 +1229,10 @@ class ModuleHandler extends Handler
 			}
 			
 			// Populate default properties
-			if($oModule->user === false)
+			$oModule->user = Context::get('logged_info') ?: new Rhymix\Framework\Helpers\SessionHelper;
+			if(!($oModule->user instanceof Rhymix\Framework\Helpers\SessionHelper))
 			{
-				$oModule->user = Context::get('logged_info') ?: new Rhymix\Framework\Helpers\SessionHelper;
+				$oModule->user = Rhymix\Framework\Session::getMemberInfo();
 			}
 
 			// Load language files for the class

--- a/classes/module/ModuleObject.class.php
+++ b/classes/module/ModuleObject.class.php
@@ -201,7 +201,7 @@ class ModuleObject extends BaseObject
 		$this->origin_module_info = $module_info;
 		$this->xml_info = $xml_info;
 		$this->skin_vars = $module_info->skin_vars;
-		$this->module_config = getModel('module')->getModuleConfig($this->module, $module_info->site_srl);
+		$this->module_config = ModuleModel::getInstance()->getModuleConfig($this->module, $module_info->site_srl);
 		
 		// Set privileges(granted) information
 		if($this->setPrivileges() !== true)
@@ -277,7 +277,7 @@ class ModuleObject extends BaseObject
 				foreach($check_module_srl as $target_srl)
 				{
 					// Get privileges(granted) information of current user for target module
-					if(($grant = getModel('module')->getPrivilegesBySrl($target_srl, $permission_check->type)) === false)
+					if(($grant = ModuleModel::getInstance()->getPrivilegesBySrl($target_srl, $permission_check->type)) === false)
 					{
 						return false;
 					}
@@ -296,7 +296,7 @@ class ModuleObject extends BaseObject
 		if(!isset($grant))
 		{
 			// Get privileges(granted) information of current user for current module
-			$grant = getModel('module')->getGrant($this->module_info, Context::get('logged_info'), $this->xml_info);
+			$grant = ModuleModel::getInstance()->getGrant($this->module_info, Context::get('logged_info'), $this->xml_info);
 			
 			// Check permission
 			if($this->checkPermission($grant) !== true)
@@ -335,9 +335,10 @@ class ModuleObject extends BaseObject
 		}
 		
 		// Get privileges(granted) information of the member for current module
+		$oModuleModel = ModuleModel::getInstance();
 		if(!$grant)
 		{
-			$grant = getModel('module')->getGrant($this->module_info, $member_info, $this->xml_info);
+			$grant = $oModuleModel->getGrant($this->module_info, $member_info, $this->xml_info);
 		}
 		
 		// If an administrator, Pass
@@ -380,17 +381,17 @@ class ModuleObject extends BaseObject
 			if(Context::get('is_logged') && isset($type[2]))
 			{
 				// Manager privilege of the member is found by search all modules, Pass
-				if($type[2] == 'all' && getModel('module')->findManagerPrivilege($member_info) !== false)
+				if($type[2] == 'all' && $oModuleModel->findManagerPrivilege($member_info) !== false)
 				{
 					return true;
 				}
 				// Manager privilege of the member is found by search same module as this module, Pass
-				else if($type[2] == 'same' && getModel('module')->findManagerPrivilege($member_info, $this->module) !== false)
+				elseif($type[2] == 'same' && $oModuleModel->findManagerPrivilege($member_info, $this->module) !== false)
 				{
 					return true;
 				}
 				// Manager privilege of the member is found by search same module as the module, Pass
-				else if(getModel('module')->findManagerPrivilege($member_info, $type[2]) !== false)
+				elseif($oModuleModel->findManagerPrivilege($member_info, $type[2]) !== false)
 				{
 					return true;
 				}
@@ -629,7 +630,7 @@ class ModuleObject extends BaseObject
 
 		// execute an addon(call called_position as before_module_proc)
 		$called_position = 'before_module_proc';
-		$oAddonController = getController('addon');
+		$oAddonController = AddonController::getInstance();
 		$addon_file = $oAddonController->getCacheFilePath($is_mobile ? "mobile" : "pc");
 		if(FileHandler::exists($addon_file)) include($addon_file);
 		
@@ -649,7 +650,7 @@ class ModuleObject extends BaseObject
 			// Set module skin
 			if(isset($this->module_info->skin) && $this->module_info->module === $this->module && strpos($this->act, 'Admin') === false)
 			{
-				$oModuleModel = getModel('module');
+				$oModuleModel = ModuleModel::getInstance();
 				$skin_type = $is_mobile ? 'M' : 'P';
 				$skin_key = $is_mobile ? 'mskin' : 'skin';
 				$skin_dir = $is_mobile ? 'm.skins' : 'skins';
@@ -733,7 +734,7 @@ class ModuleObject extends BaseObject
 
 		// execute an addon(call called_position as after_module_proc)
 		$called_position = 'after_module_proc';
-		$oAddonController = getController('addon');
+		$oAddonController = AddonController::getInstance();
 		$addon_file = $oAddonController->getCacheFilePath($is_mobile ? "mobile" : "pc");
 		if(FileHandler::exists($addon_file)) include($addon_file);
 

--- a/classes/module/ModuleObject.class.php
+++ b/classes/module/ModuleObject.class.php
@@ -5,28 +5,38 @@
  * @class ModuleObject
  * @author NAVER (developers@xpressengine.com)
  * base class of ModuleHandler
- * */
+ */
 class ModuleObject extends BaseObject
 {
+	// Variables about the current module
+	public $module;
+	public $module_info;
+	public $origin_module_info;
+	public $module_config;
+	public $module_path;
+	public $xml_info;
 
-	var $mid = NULL; ///< string to represent run-time instance of Module (XE Module)
-	var $module = NULL; ///< Class name of Xe Module that is identified by mid
-	var $module_srl = NULL; ///< integer value to represent a run-time instance of Module (XE Module)
-	var $module_info = NULL; ///< an object containing the module information
-	var $origin_module_info = NULL;
-	var $xml_info = NULL; ///< an object containing the module description extracted from XML file
-	var $module_path = NULL; ///< a path to directory where module source code resides
-	var $act = NULL; ///< a string value to contain the action name
-	var $template_path = NULL; ///< a path of directory where template files reside
-	var $template_file = NULL; ///< name of template file
-	var $layout_path = ''; ///< a path of directory where layout files reside
-	var $layout_file = ''; ///< name of layout file
-	var $edited_layout_file = ''; ///< name of temporary layout files that is modified in an admin mode
-	var $stop_proc = FALSE; ///< a flag to indicating whether to stop the execution of code.
-	var $module_config = NULL;
-	var $ajaxRequestMethod = array('XMLRPC', 'JSON');
-	var $gzhandler_enable = TRUE;
-	var $user = FALSE;
+	// Variables about the current module instance and the current request
+	public $module_srl;
+	public $mid;
+	public $act;
+
+	// Variables about the layout and/or template
+	public $template_path;
+	public $template_file;
+	public $layout_path;
+	public $layout_file;
+	public $edited_layout_file;
+
+	// Variables to control processing
+	public $stop_proc = false;
+
+	// Variables for convenience
+	public $user;
+
+	// Other variables for compatibility
+	public $ajaxRequestMethod = array('XMLRPC', 'JSON');
+	public $gzhandler_enable = true;
 
 	/**
 	 * Constructor
@@ -35,7 +45,7 @@ class ModuleObject extends BaseObject
 	 * @param string $message Error message
 	 * @return void
 	 */
-	function __construct($error = 0, $message = 'success')
+	public function __construct($error = 0, $message = 'success')
 	{
 		$this->user = Context::get('logged_info') ?: new Rhymix\Framework\Helpers\SessionHelper;
 		if(!($this->user instanceof Rhymix\Framework\Helpers\SessionHelper))
@@ -47,35 +57,39 @@ class ModuleObject extends BaseObject
 
 	/**
 	 * setter to set the name of module
+	 * 
 	 * @param string $module name of module
-	 * @return void
-	 * */
-	function setModule($module)
+	 * @return $this
+	 */
+	public function setModule($module)
 	{
 		$this->module = $module;
+		return $this;
 	}
 
 	/**
 	 * setter to set the name of module path
+	 * 
 	 * @param string $path the directory path to a module directory
-	 * @return void
-	 * */
-	function setModulePath($path)
+	 * @return $this
+	 */
+	public function setModulePath($path)
 	{
 		if(substr_compare($path, '/', -1) !== 0)
 		{
 			$path.='/';
 		}
 		$this->module_path = $path;
+		return $this;
 	}
 
 	/**
 	 * setter to set an url for redirection
+	 * 
 	 * @param string $url url for redirection
-	 * @remark redirect_url is used only for ajax requests
-	 * @return void
-	 * */
-	function setRedirectUrl($url = './', $output = NULL)
+	 * @return $this
+	 */
+	public function setRedirectUrl($url = './', $output = NULL)
 	{
 		$this->add('redirect_url', $url);
 
@@ -83,13 +97,18 @@ class ModuleObject extends BaseObject
 		{
 			return $output;
 		}
+		else
+		{
+			return $this;
+		}
 	}
 
 	/**
 	 * get url for redirection
-	 * @return string redirect_url
-	 * */
-	function getRedirectUrl()
+	 * 
+	 * @return string
+	 */
+	public function getRedirectUrl()
 	{
 		return $this->get('redirect_url');
 	}
@@ -98,31 +117,36 @@ class ModuleObject extends BaseObject
 	 * Set the template path for refresh.html
 	 * refresh.html is executed as a result of method execution
 	 * Tpl as the common run of the refresh.html ..
-	 * @return void
-	 * */
-	function setRefreshPage()
+	 * 
+	 * @return $this
+	 */
+	public function setRefreshPage()
 	{
 		$this->setTemplatePath('./common/tpl');
 		$this->setTemplateFile('refresh');
+		return $this;
 	}
 
 	/**
 	 * Set the action name
+	 * 
 	 * @param string $act
-	 * @return void
-	 * */
-	function setAct($act)
+	 * @return $this
+	 */
+	public function setAct($act)
 	{
 		$this->act = $act;
+		return $this;
 	}
 	
 	/**
 	 * Set module information
+	 * 
 	 * @param object $module_info object containing module information
 	 * @param object $xml_info object containing module description
-	 * @return void
-	 * */
-	function setModuleInfo($module_info, $xml_info)
+	 * @return $this
+	 */
+	public function setModuleInfo($module_info, $xml_info)
 	{
 		// Set default variables
 		$this->mid = $module_info->mid;
@@ -167,13 +191,16 @@ class ModuleObject extends BaseObject
 				$this->stop($e->getMessage());
 			}
 		}
+
+		return $this;
 	}
 	
 	/**
 	 * Set privileges(granted) information of current user and check permission of current module
-	 * @return boolean success : true, fail : false
-	 * */
-	function setPrivileges()
+	 * 
+	 * @return bool
+	 */
+	public function setPrivileges()
 	{
 		if(Context::get('logged_info')->is_admin !== 'Y')
 		{
@@ -248,11 +275,12 @@ class ModuleObject extends BaseObject
 	
 	/**
 	 * Check permission
+	 * 
 	 * @param object $grant privileges(granted) information of user
 	 * @param object $member_info member information
-	 * @return boolean success : true, fail : false
-	 * */
-	function checkPermission($grant = null, $member_info = null)
+	 * @return bool
+	 */
+	public function checkPermission($grant = null, $member_info = null)
 	{
 		// Get logged-in member information
 		if(!$member_info)
@@ -348,11 +376,12 @@ class ModuleObject extends BaseObject
 	}
 	
 	/**
-	 * set the stop_proc and approprate message for msg_code
+	 * Stop processing this module instance.
+	 * 
 	 * @param string $msg_code an error code
 	 * @return ModuleObject $this
-	 * */
-	function stop($msg_code)
+	 */
+	public function stop($msg_code)
 	{
 		if($this->stop_proc !== true)
 		{
@@ -385,35 +414,39 @@ class ModuleObject extends BaseObject
 
 	/**
 	 * set the file name of the template file
+	 * 
 	 * @param string name of file
-	 * @return void
-	 * */
-	function setTemplateFile($filename)
+	 * @return $this
+	 */
+	public function setTemplateFile($filename)
 	{
 		if(isset($filename) && substr_compare($filename, '.html', -5) !== 0)
 		{
 			$filename .= '.html';
 		}
 		$this->template_file = $filename;
+		return $this;
 	}
 
 	/**
 	 * retrieve the directory path of the template directory
+	 * 
 	 * @return string
-	 * */
-	function getTemplateFile()
+	 */
+	public function getTemplateFile()
 	{
 		return $this->template_file;
 	}
 
 	/**
 	 * set the directory path of the template directory
+	 * 
 	 * @param string path of template directory.
-	 * @return void
-	 * */
-	function setTemplatePath($path)
+	 * @return $this
+	 */
+	public function setTemplatePath($path)
 	{
-		if(!$path) return;
+		if(!$path) return $this;
 
 		if((strlen($path) >= 1 && substr_compare($path, '/', 0, 1) !== 0) && (strlen($path) >= 2 && substr_compare($path, './', 0, 2) !== 0))
 		{
@@ -425,70 +458,80 @@ class ModuleObject extends BaseObject
 			$path .= '/';
 		}
 		$this->template_path = $path;
+		return $this;
 	}
 
 	/**
 	 * retrieve the directory path of the template directory
+	 * 
 	 * @return string
-	 * */
-	function getTemplatePath()
+	 */
+	public function getTemplatePath()
 	{
 		return $this->template_path;
 	}
 
 	/**
 	 * set the file name of the temporarily modified by admin
+	 * 
 	 * @param string name of file
-	 * @return void
-	 * */
-	function setEditedLayoutFile($filename)
+	 * @return $this
+	 */
+	public function setEditedLayoutFile($filename)
 	{
-		if(!$filename) return;
+		if(!$filename) return $this;
 
 		if(substr_compare($filename, '.html', -5) !== 0)
 		{
 			$filename .= '.html';
 		}
 		$this->edited_layout_file = $filename;
+		return $this;
 	}
 
 	/**
 	 * retreived the file name of edited_layout_file
+	 * 
 	 * @return string
-	 * */
-	function getEditedLayoutFile()
+	 */
+	public function getEditedLayoutFile()
 	{
 		return $this->edited_layout_file;
 	}
 
 	/**
 	 * set the file name of the layout file
+	 * 
 	 * @param string name of file
-	 * @return void
-	 * */
-	function setLayoutFile($filename)
+	 * @return $this
+	 */
+	public function setLayoutFile($filename)
 	{
 		if($filename && substr_compare($filename, '.html', -5) !== 0)
 		{
 			$filename .= '.html';
 		}
 		$this->layout_file = $filename;
+		return $this;
 	}
 
 	/**
 	 * get the file name of the layout file
+	 * 
 	 * @return string
-	 * */
-	function getLayoutFile()
+	 */
+	public function getLayoutFile()
 	{
 		return $this->layout_file;
 	}
 
 	/**
 	 * set the directory path of the layout directory
+	 * 
 	 * @param string path of layout directory.
-	 * */
-	function setLayoutPath($path)
+	 * @return $this
+	 */
+	public function setLayoutPath($path)
 	{
 		if(!$path) return;
 
@@ -501,22 +544,24 @@ class ModuleObject extends BaseObject
 			$path .= '/';
 		}
 		$this->layout_path = $path;
+		return $this;
 	}
 
 	/**
 	 * set the directory path of the layout directory
+	 * 
 	 * @return string
-	 * */
-	function getLayoutPath($layout_name = "", $layout_type = "P")
+	 */
+	public function getLayoutPath($layout_name = "", $layout_type = "P")
 	{
 		return $this->layout_path;
 	}
 
 	/**
 	 * excute the member method specified by $act variable
-	 * @return boolean true : success false : fail
-	 * */
-	function proc()
+	 * @return bool
+	 */
+	public function proc()
 	{
 		// pass if stop_proc is true
 		if($this->stop_proc)

--- a/classes/module/ModuleObject.class.php
+++ b/classes/module/ModuleObject.class.php
@@ -47,11 +47,6 @@ class ModuleObject extends BaseObject
 	 */
 	public function __construct($error = 0, $message = 'success')
 	{
-		$this->user = Context::get('logged_info') ?: new Rhymix\Framework\Helpers\SessionHelper;
-		if(!($this->user instanceof Rhymix\Framework\Helpers\SessionHelper))
-		{
-			$this->user = Rhymix\Framework\Session::getMemberInfo();
-		}
 		parent::__construct($error, $message);
 	}
 

--- a/classes/object/Object.class.php
+++ b/classes/object/Object.class.php
@@ -8,30 +8,29 @@
  */
 class BaseObject
 {
-
 	/**
 	 * Error code. If `0`, it is not an error.
 	 * @var int
 	 */
-	var $error = 0;
+	public $error = 0;
 
 	/**
 	 * Error message. If `success`, it is not an error.
 	 * @var string
 	 */
-	var $message = 'success';
+	public $message = 'success';
 
 	/**
 	 * An additional variable
 	 * @var array
 	 */
-	var $variables = array();
+	public $variables = array();
 
 	/**
 	 * http status code.
 	 * @var int
 	 */
-	var $httpStatusCode = 200;
+	public $httpStatusCode = 200;
 
 	/**
 	 * Constructor
@@ -40,7 +39,7 @@ class BaseObject
 	 * @param string $message Error message
 	 * @return void
 	 */
-	function __construct($error = 0, $message = 'success')
+	public function __construct($error = 0, $message = 'success')
 	{
 		$this->setError($error);
 		$this->setMessage($message);
@@ -81,7 +80,7 @@ class BaseObject
 	 * @param int|strong $error error code or message
 	 * @return $this
 	 */
-	function setError($error = 0)
+	public function setError($error = 0)
 	{
 		// If the first argument is an integer, treat it as an error code. Otherwise, treat it as an error message.
 		$args = func_get_args();
@@ -113,7 +112,7 @@ class BaseObject
 	 *
 	 * @return int Returns an error code
 	 */
-	function getError()
+	public function getError()
 	{
 		return $this->error;
 	}
@@ -124,9 +123,9 @@ class BaseObject
 	 * @param int $code HTTP status code. Default value is `200` that means successful
 	 * @return $this
 	 */
-	function setHttpStatusCode($code = 200)
+	public function setHttpStatusCode($code = 200)
 	{
-		$this->httpStatusCode = (int) $code;
+		$this->httpStatusCode = (int)$code;
 		return $this;
 	}
 
@@ -135,7 +134,7 @@ class BaseObject
 	 *
 	 * @return int Returns HTTP status code
 	 */
-	function getHttpStatusCode()
+	public function getHttpStatusCode()
 	{
 		return $this->httpStatusCode;
 	}
@@ -147,7 +146,7 @@ class BaseObject
 	 * @param string $type type of message (error, info, update)
 	 * @return $this
 	 */
-	function setMessage($message = 'success', $type = null)
+	public function setMessage($message = 'success', $type = null)
 	{
 		$this->message = lang($message);
 		if($type !== null)
@@ -162,7 +161,7 @@ class BaseObject
 	 *
 	 * @return string Returns message
 	 */
-	function getMessage()
+	public function getMessage()
 	{
 		return $this->message;
 	}
@@ -172,9 +171,9 @@ class BaseObject
 	 * @param string $type type of message (error, info, update)
 	 * @return $this
 	 * */
-	function setMessageType($type)
+	public function setMessageType($type)
 	{
-		$this->add('message_type', $type);
+		$this->variables['message_type'] = strval($type);
 		return $this;
 	}
 
@@ -182,7 +181,7 @@ class BaseObject
 	 * get type of message
 	 * @return string $type
 	 * */
-	function getMessageType()
+	public function getMessageType()
 	{
 		$type = $this->get('message_type');
 		$typeList = array('error' => 1, 'info' => 1, 'update' => 1);
@@ -200,19 +199,28 @@ class BaseObject
 	 * @param mixed $val A value for the variable
 	 * @return $this
 	 */
-	function add($key, $val)
+	public function set($key, $val)
 	{
 		$this->variables[$key] = $val;
 		return $this;
 	}
 
 	/**
-	 * Method to set multiple key/value pairs as an additional variables
+	 * Alias to set().
+	 */
+	public function add($key, $val)
+	{
+		$this->variables[$key] = $val;
+		return $this;
+	}
+
+	/**
+	 * Method to set multiple key/value pairs as additional variables
 	 *
 	 * @param object|array $vars Either object or array containg key/value pairs to be added
 	 * @return $this
 	 */
-	function adds($vars)
+	public function sets($vars)
 	{
 		if(is_object($vars))
 		{
@@ -229,12 +237,20 @@ class BaseObject
 	}
 
 	/**
+	 * Alias to sets().
+	 */
+	public function adds($vars)
+	{
+		return $this->sets($vars);
+	}
+
+	/**
 	 * Method to retrieve a corresponding value to a given key
 	 *
 	 * @param string $key
 	 * @return string Returns value to a given key
 	 */
-	function get($key)
+	public function get($key)
 	{
 		return $this->variables[$key];
 	}
@@ -244,7 +260,7 @@ class BaseObject
 	 *
 	 * @return object Returns an object containing key/value pairs
 	 */
-	function gets()
+	public function gets()
 	{
 		$args = func_get_args();
 		$output = new stdClass();
@@ -260,7 +276,7 @@ class BaseObject
 	 *
 	 * @return array
 	 */
-	function getVariables()
+	public function getVariables()
 	{
 		return $this->variables;
 	}
@@ -270,14 +286,9 @@ class BaseObject
 	 *
 	 * @return object
 	 */
-	function getObjectVars()
+	public function getObjectVars()
 	{
-		$output = new stdClass();
-		foreach($this->variables as $key => $val)
-		{
-			$output->{$key} = $val;
-		}
-		return $output;
+		return get_object_vars($this->variables);
 	}
 
 	/**
@@ -285,7 +296,7 @@ class BaseObject
 	 *
 	 * @return void
 	 */
-	function unset($key)
+	public function unset($key)
 	{
 		unset($this->variables[$key]);
 	}
@@ -295,7 +306,7 @@ class BaseObject
 	 *
 	 * @return bool Retruns true : error isn't 0 or false : otherwise.
 	 */
-	function toBool()
+	public function toBool()
 	{
 		// TODO This method is misleading in that it returns true if error is 0, which should be true in boolean representation.
 		return ($this->error == 0);
@@ -306,7 +317,7 @@ class BaseObject
 	 *
 	 * @return bool
 	 */
-	function toBoolean()
+	public function toBoolean()
 	{
 		return $this->toBool();
 	}

--- a/common/framework/helpers/confighelper.php
+++ b/common/framework/helpers/confighelper.php
@@ -68,7 +68,7 @@ class ConfigHelper
 			{
 				if (!isset(self::$_config_cache[$option[0]]))
 				{
-					self::$_config_cache[$option[0]] = getModel('module')->getModuleConfig($option[0]) ?: new stdClass;
+					self::$_config_cache[$option[0]] = \ModuleModel::getInstance()->getModuleConfig($option[0]) ?: new \stdClass;
 				}
 				$options = explode('.', $option[1]);
 				$temp = self::$_config_cache[$option[0]];

--- a/common/framework/helpers/sessionhelper.php
+++ b/common/framework/helpers/sessionhelper.php
@@ -27,7 +27,7 @@ class SessionHelper
 		$member_srl = intval($member_srl);
 		if ($member_srl)
 		{
-			$oMemberModel = getModel('member');
+			$oMemberModel = \MemberModel::getInstance();
 			$member_info = $oMemberModel->getMemberInfoByMemberSrl($member_srl);
 			if (intval($member_info->member_srl) === $member_srl)
 			{
@@ -69,7 +69,7 @@ class SessionHelper
 	 */
 	public function isModuleAdmin($module_srl = null)
 	{
-		return $this->is_admin === 'Y' || getModel('module')->isModuleAdmin($this, $module_srl);
+		return $this->is_admin === 'Y' || \ModuleModel::getInstance()->isModuleAdmin($this, $module_srl);
 	}
 	
 	/**

--- a/common/framework/password.php
+++ b/common/framework/password.php
@@ -112,9 +112,9 @@ class Password
 	 */
 	public static function getDefaultAlgorithm()
 	{
-		if (function_exists('getModel'))
+		if (class_exists('\MemberModel'))
 		{
-			$config = getModel('member')->getMemberConfig();
+			$config = \MemberModel::getInstance()->getMemberConfig();
 			$algorithm = $config->password_hashing_algorithm;
 			if (strval($algorithm) === '')
 			{
@@ -135,9 +135,9 @@ class Password
 	 */
 	public static function getWorkFactor()
 	{
-		if (function_exists('getModel'))
+		if (class_exists('\MemberModel'))
 		{
-			$config = getModel('member')->getMemberConfig();
+			$config = \MemberModel::getInstance()->getMemberConfig();
 			$work_factor = $config->password_hashing_work_factor;
 			if (!$work_factor || $work_factor < 4 || $work_factor > 31)
 			{

--- a/common/framework/session.php
+++ b/common/framework/session.php
@@ -313,7 +313,7 @@ class Session
 		{
 			$current_domain = $site_module_info->domain;
 			$current_url = URL::getCurrentUrl();
-			$default_domain = getModel('module')->getDefaultDomainInfo();
+			$default_domain = \ModuleModel::getInstance()->getDefaultDomainInfo();
 			$default_url = \Context::getDefaultUrl($default_domain);
 		}
 		
@@ -431,7 +431,7 @@ class Session
 		// Try autologin.
 		if (!$member_srl && self::$_autologin_key)
 		{
-			$member_srl = getController('member')->doAutologin(self::$_autologin_key);
+			$member_srl = \MemberController::getInstance()->doAutologin(self::$_autologin_key);
 			if ($member_srl && self::isValid($member_srl))
 			{
 				self::login($member_srl, false);
@@ -697,7 +697,7 @@ class Session
 		}
 		
 		// Check member information to see if denied or limited.
-		$member_info = getModel('member')->getMemberInfoByMemberSrl($member_srl);
+		$member_info = \MemberModel::getInstance()->getMemberInfoByMemberSrl($member_srl);
 		if ($member_info->denied === 'Y')
 		{
 			trigger_error('Session is invalid for member_srl=' . intval($_SESSION['RHYMIX']['login']) . ' (denied)', \E_USER_WARNING);

--- a/common/framework/url.php
+++ b/common/framework/url.php
@@ -99,7 +99,7 @@ class URL
 			return true;
 		}
 		
-		if (getModel('module')->getSiteInfoByDomain($domain))
+		if (\ModuleModel::getInstance()->getSiteInfoByDomain($domain))
 		{
 			return true;
 		}

--- a/common/legacy.php
+++ b/common/legacy.php
@@ -27,7 +27,7 @@ function getModule($module_name, $type = 'view', $kind = '')
  */
 function getController($module_name)
 {
-	return getModule($module_name, 'controller');
+	return ModuleHandler::getModuleInstance($module_name, 'controller');
 }
 
 /**
@@ -38,7 +38,7 @@ function getController($module_name)
  */
 function getAdminController($module_name)
 {
-	return getModule($module_name, 'controller', 'admin');
+	return ModuleHandler::getModuleInstance($module_name, 'controller', 'admin');
 }
 
 /**
@@ -49,7 +49,7 @@ function getAdminController($module_name)
  */
 function getView($module_name)
 {
-	return getModule($module_name, 'view');
+	return ModuleHandler::getModuleInstance($module_name, 'view');
 }
 
 /**
@@ -60,7 +60,7 @@ function getView($module_name)
  */
 function getAdminView($module_name)
 {
-	return getModule($module_name, 'view', 'admin');
+	return ModuleHandler::getModuleInstance($module_name, 'view', 'admin');
 }
 
 /**
@@ -71,7 +71,7 @@ function getAdminView($module_name)
  */
 function getModel($module_name)
 {
-	return getModule($module_name, 'model');
+	return ModuleHandler::getModuleInstance($module_name, 'model');
 }
 
 /**
@@ -82,7 +82,7 @@ function getModel($module_name)
  */
 function getAdminModel($module_name)
 {
-	return getModule($module_name, 'model', 'admin');
+	return ModuleHandler::getModuleInstance($module_name, 'model', 'admin');
 }
 
 /**
@@ -93,7 +93,7 @@ function getAdminModel($module_name)
  */
 function getAPI($module_name)
 {
-	return getModule($module_name, 'api');
+	return ModuleHandler::getModuleInstance($module_name, 'api');
 }
 
 /**
@@ -104,7 +104,7 @@ function getAPI($module_name)
  */
 function getMobile($module_name)
 {
-	return getModule($module_name, 'mobile');
+	return ModuleHandler::getModuleInstance($module_name, 'mobile');
 }
 
 /**
@@ -115,7 +115,7 @@ function getMobile($module_name)
  */
 function getWAP($module_name)
 {
-	return getModule($module_name, 'wap');
+	return ModuleHandler::getModuleInstance($module_name, 'wap');
 }
 
 /**
@@ -126,7 +126,7 @@ function getWAP($module_name)
  */
 function getClass($module_name)
 {
-	return getModule($module_name, 'class');
+	return ModuleHandler::getModuleInstance($module_name, 'class');
 }
 
 /**

--- a/modules/admin/admin.admin.view.php
+++ b/modules/admin/admin.admin.view.php
@@ -27,6 +27,7 @@ class adminAdminView extends admin
 	function __construct()
 	{
 		Context::set('xe_default_url', Context::getDefaultUrl());
+		parent::__construct();
 	}
 
 	/**

--- a/modules/autoinstall/autoinstall.class.php
+++ b/modules/autoinstall/autoinstall.class.php
@@ -70,15 +70,6 @@ class autoinstall extends ModuleObject
 	var $tmp_dir = './files/cache/autoinstall/';
 
 	/**
-	 * Constructor
-	 *
-	 * @return void
-	 */
-	function __construct()
-	{
-	}
-
-	/**
 	 * For additional tasks required when installing
 	 *
 	 * @return Object

--- a/modules/board/board.class.php
+++ b/modules/board/board.class.php
@@ -36,6 +36,8 @@ class board extends ModuleObject
 		{
 			Context::addSSLAction('dispTempSavedList');
 		}
+
+		parent::__construct();
 	}
 
 	/**

--- a/modules/member/member.class.php
+++ b/modules/member/member.class.php
@@ -22,15 +22,14 @@ class member extends ModuleObject {
 	{
 		if(!Context::isInstalled()) return;
 
-		$oModuleModel = getModel('module');
-		$member_config = $oModuleModel->getModuleConfig('member');
-
 		// Set to use SSL upon actions related member join/information/password and so on. 2013.02.15
 		if(!Context::isExistsSSLAction('dispMemberModifyPassword') && Context::getSslStatus() == 'optional')
 		{
 			$ssl_actions = array('dispMemberModifyPassword', 'dispMemberSignUpForm', 'dispMemberModifyInfo', 'dispMemberModifyEmailAddress', 'dispMemberResendAuthMail', 'dispMemberLoginForm', 'dispMemberFindAccount', 'dispMemberLeave', 'procMemberLogin', 'procMemberModifyPassword', 'procMemberInsert', 'procMemberModifyInfo', 'procMemberFindAccount', 'procMemberModifyEmailAddress', 'procMemberResendAuthMail', 'procMemberLeave'/*, 'getMemberMenu'*/, 'procMemberFindAccountByQuestion');
 			Context::addSSLActions($ssl_actions);
 		}
+
+		parent::__construct();
 	}
 
 	/**

--- a/modules/menu/menu.admin.controller.php
+++ b/modules/menu/menu.admin.controller.php
@@ -57,6 +57,7 @@ class menuAdminController extends menu
 
 	function __construct() {
 		$this->homeMenuCacheFile = _XE_PATH_ . $this->homeMenuCacheFile;
+		parent::__construct();
 	}
 
 	/**

--- a/modules/session/session.class.php
+++ b/modules/session/session.class.php
@@ -16,6 +16,7 @@ class session extends ModuleObject
 	function __construct()
 	{
 		if(Context::isInstalled()) $this->session_started= true;
+		parent::__construct();
 	}
 
 	/**


### PR DESCRIPTION
`getModel()`, `getController()` 등의 함수를 통해서만 생성할 수 있었던 모듈 클래스의 싱글턴 인스턴스를 아래와 같이 클래스명을 통해 직접 생성할 수 있도록 개선합니다.

```
MemberModel::getInstance();
```

autoload가 적용되어 어느 클래스든지 직접 끌어다 쓸 수 있도록 바뀐 지 몇 년이 지났음에도 여전히 간접적으로 모듈 클래스에 접근하고 있는 실정입니다. 이것은 싱글턴 인스턴스 생성에 `getInstance()`를 사용한다는 일반적인 관례에 맞지 않음은 물론, `Context`처럼 이미 `getInstance()`를 사용하고 있는 클래스와도 일관성이 없는 처사입니다.

또한 기존 방식은 `getModel()`과 같은 함수가 어떤 타입을 반환할지 알 수 없기 때문에 PHP스톰, VS Code 등의 에디터가 메소드명이나 파라미터 목록 등을 인식하지 못하는 불편도 있었습니다. 기능적인 변화는 없으나, 좀더 깔끔한 문법을 지원함으로써 개발 작업이 편리해질 것으로 기대합니다.

※ 성능상의 차이는 거의 없는 것으로 보입니다.

※ `new MemberModel();`과 같이 싱글턴이 아닌 인스턴스를 생성하는 것은 권장하지 않습니다. 데이터 구조를 중복으로 생성하여 비효율이 발생하는 것은 물론, 지난 13년간 RXE의 모든 모듈 인스턴스는 싱글턴이라는 가정 하에 많은 자료가 생산되어 왔으므로 싱글턴이 아닌 인스턴스를 사용하면 어딘가에서 애매한 오류가 발생할 가능성이 높습니다. 그러나 생성자를 직접 호출하는 것을 강제로 막으면 또다른 자료에서 호환성이 깨질 수 있으므로 그렇게는 하지 않겠습니다.