### PR TITLE
정보를 불러오는 메소드들 대부분을 static으로 변경

### DIFF
--- a/modules/comment/comment.controller.php
+++ b/modules/comment/comment.controller.php
@@ -41,16 +41,14 @@ class commentController extends comment
 			throw new Rhymix\Framework\Exceptions\InvalidRequest;
 		}
 
-		$oCommentModel = getModel('comment');
-		$oComment = $oCommentModel->getComment($comment_srl, FALSE, FALSE);
+		$oComment = CommentModel::getComment($comment_srl, FALSE, FALSE);
 		$module_srl = $oComment->get('module_srl');
 		if(!$module_srl)
 		{
 			throw new Rhymix\Framework\Exceptions\InvalidRequest;
 		}
 
-		$oModuleModel = getModel('module');
-		$comment_config = $oModuleModel->getModulePartConfig('comment', $module_srl);
+		$comment_config = ModuleModel::getModulePartConfig('comment', $module_srl);
 		if($comment_config->use_vote_up == 'N')
 		{
 			throw new Rhymix\Framework\Exceptions\FeatureDisabled;
@@ -75,8 +73,7 @@ class commentController extends comment
 		$comment_srl = Context::get('target_srl');
 		if(!$comment_srl) throw new Rhymix\Framework\Exceptions\InvalidRequest;
 
-		$oCommentModel = getModel('comment');
-		$oComment = $oCommentModel->getComment($comment_srl, FALSE, FALSE);
+		$oComment = CommentModel::getComment($comment_srl, FALSE, FALSE);
 		if($oComment->get('voted_count') <= 0)
 		{
 			throw new Rhymix\Framework\Exception('failed_voted_canceled');
@@ -111,16 +108,14 @@ class commentController extends comment
 			throw new Rhymix\Framework\Exceptions\InvalidRequest;
 		}
 
-		$oCommentModel = getModel('comment');
-		$oComment = $oCommentModel->getComment($comment_srl, FALSE, FALSE);
+		$oComment = CommentModel::getComment($comment_srl, FALSE, FALSE);
 		$module_srl = $oComment->get('module_srl');
 		if(!$module_srl)
 		{
 			throw new Rhymix\Framework\Exceptions\InvalidRequest;
 		}
 
-		$oModuleModel = getModel('module');
-		$comment_config = $oModuleModel->getModulePartConfig('comment', $module_srl);
+		$comment_config = ModuleModel::getModulePartConfig('comment', $module_srl);
 		if($comment_config->use_vote_down == 'N')
 		{
 			throw new Rhymix\Framework\Exceptions\FeatureDisabled;
@@ -145,8 +140,7 @@ class commentController extends comment
 		$comment_srl = Context::get('target_srl');
 		if(!$comment_srl) throw new Rhymix\Framework\Exceptions\InvalidRequest;
 
-		$oCommentModel = getModel('comment');
-		$oComment = $oCommentModel->getComment($comment_srl, FALSE, FALSE);
+		$oComment = CommentModel::getComment($comment_srl, FALSE, FALSE);
 		if($oComment->get('blamed_count') >= 0)
 		{
 			throw new Rhymix\Framework\Exception('failed_blamed_canceled');
@@ -300,7 +294,7 @@ class commentController extends comment
 	 */
 	function addGrant($comment_srl)
 	{
-		$comment = getModel('comment')->getComment($comment_srl);
+		$comment = CommentModel::getComment($comment_srl);
 		if ($comment->isExists())
 		{
 			$comment->setGrant();
@@ -320,9 +314,8 @@ class commentController extends comment
 			return FALSE;
 		}
 
-		$oModuleModel = getModel('module');
-		$module_info = $oModuleModel->getModuleInfoByModuleSrl($module_srl);
-		$module_part_config = $oModuleModel->getModulePartConfig('comment', $module_info->module_srl);
+		$module_info = ModuleModel::getModuleInfoByModuleSrl($module_srl);
+		$module_part_config = ModuleModel::getModulePartConfig('comment', $module_info->module_srl);
 		$use_validation = FALSE;
 		if(isset($module_part_config->use_comment_validation) && $module_part_config->use_comment_validation == "Y")
 		{
@@ -412,22 +405,17 @@ class commentController extends comment
 		{
 			return new BaseObject(-1, 'msg_invalid_document');
 		}
-		
-		// creat the comment model object
-		$oCommentModel = getModel('comment');
-		// get a object of document model
-		$oDocumentModel = getModel('document');
 
 		// even for manual_inserted if password exists, hash it.
 		if($obj->password)
 		{
-			$obj->password = getModel('member')->hashPassword($obj->password);
+			$obj->password = MemberModel::hashPassword($obj->password);
 		}
 
 		// get the original posting
 		if(!$manual_inserted)
 		{
-			$oDocument = $oDocumentModel->getDocument($document_srl);
+			$oDocument = DocumentModel::getDocument($document_srl);
 
 			if($document_srl != $oDocument->document_srl)
 			{
@@ -599,7 +587,7 @@ class commentController extends comment
 		$oDocumentController = getController('document');
 
 		// Update the number of comments in the post
-		$comment_count = $oCommentModel->getCommentCount($document_srl);
+		$comment_count = CommentModel::getCommentCount($document_srl);
 		if($comment_count && (!$using_validation || $is_admin))
 		{
 			$output = $oDocumentController->updateCommentCount($document_srl, $comment_count, $obj->nick_name, $update_document);
@@ -625,7 +613,7 @@ class commentController extends comment
 			// send a message if notify_message option in enabled in the original comment
 			if($obj->parent_srl)
 			{
-				$oParent = $oCommentModel->getComment($obj->parent_srl);
+				$oParent = CommentModel::getComment($obj->parent_srl);
 				if($oParent->get('member_srl') != $oDocument->get('member_srl'))
 				{
 					$oParent->notify(lang('comment'), $obj->content);
@@ -650,14 +638,10 @@ class commentController extends comment
 	{
 		$using_validation = $this->isModuleUsingPublishValidation($obj->module_srl);
 
-		$oDocumentModel = getModel('document');
-		$oDocument = $oDocumentModel->getDocument($obj->document_srl);
-
-		$oMemberModel = getModel("member");
-		$is_logged = Context::get('is_logged');
+		$oDocument = DocumentModel::getDocument($obj->document_srl);
 		if(isset($obj->member_srl) && !is_null($obj->member_srl))
 		{
-			$member_info = $oMemberModel->getMemberInfoByMemberSrl($obj->member_srl);
+			$member_info = MemberModel::getMemberInfoByMemberSrl($obj->member_srl);
 		}
 		else
 		{
@@ -668,9 +652,7 @@ class commentController extends comment
 			$member_info->email_address = $obj->email_address;
 		}
 
-		$oCommentModel = getModel("comment");
-		$oModuleModel = getModel("module");
-		$module_info = $oModuleModel->getModuleInfoByDocumentSrl($obj->document_srl);
+		$module_info = ModuleModel::getModuleInfoByDocumentSrl($obj->document_srl);
 
 		// If there is no problem to register comment then send an email to all admin were set in module admin panel
 		if($module_info->admin_mail && $member_info->is_admin != 'Y')
@@ -681,7 +663,7 @@ class commentController extends comment
 			$url_comment = getFullUrl('','document_srl',$obj->document_srl).'#comment_'.$obj->comment_srl;
 			if($using_validation)
 			{
-				$nr_comments_not_approved = $oCommentModel->getCommentAllCount(NULL, FALSE);
+				$nr_comments_not_approved = CommentModel::getCommentAllCount(NULL, FALSE);
 				$url_approve = getFullUrl('', 'module', 'admin', 'act', 'procCommentAdminChangePublishedStatusChecked', 'cart[]', $obj->comment_srl, 'will_publish', '1', 'search_target', 'is_published', 'search_keyword', 'N');
 				$url_trash = getFullUrl('', 'module', 'admin', 'act', 'procCommentAdminDeleteChecked', 'cart[]', $obj->comment_srl, 'search_target', 'is_trash', 'search_keyword', 'true');
 				$mail_content = "
@@ -777,11 +759,8 @@ class commentController extends comment
 			return $output;
 		}
 
-		// create a comment model object
-		$oCommentModel = getModel('comment');
-
 		// get the original data
-		$source_obj = $oCommentModel->getComment($obj->comment_srl);
+		$source_obj = CommentModel::getComment($obj->comment_srl);
 		if(!$source_obj->getMemberSrl())
 		{
 			$obj->member_srl = $source_obj->get('member_srl');
@@ -799,7 +778,7 @@ class commentController extends comment
 
 		if($obj->password)
 		{
-			$obj->password = getModel('member')->hashPassword($obj->password);
+			$obj->password = MemberModel::hashPassword($obj->password);
 		}
 
 		if($obj->homepage) 
@@ -933,8 +912,7 @@ class commentController extends comment
 		ModuleHandler::triggerCall('comment.deleteComment', 'after', $obj);
 
 		// update the number of comments
-		$oCommentModel = getModel('comment');
-		$comment_count = $oCommentModel->getCommentCount($obj->document_srl);
+		$comment_count = CommentModel::getCommentCount($obj->document_srl);
 		// only document is exists
 		if(isset($comment_count))
 		{
@@ -979,8 +957,7 @@ class commentController extends comment
 		}
 
 		// update the number of comments
-		$oCommentModel = getModel('comment');
-		$comment_count = $oCommentModel->getCommentCount($obj->document_srl);
+		$comment_count = CommentModel::getCommentCount($obj->document_srl);
 		// only document is exists
 		if(isset($comment_count))
 		{
@@ -1011,20 +988,16 @@ class commentController extends comment
 	 */
 	function deleteComment($comment_srl, $is_admin = FALSE, $isMoveToTrash = FALSE, $childs = null)
 	{
-		// create the comment model object
-		$oCommentModel = getModel('comment');
-
 		$logged_info = Context::get('logged_info');
 
 		// check if comment already exists
-		$comment = $oCommentModel->getComment($comment_srl);
+		$comment = CommentModel::getComment($comment_srl);
 		if($comment->comment_srl != $comment_srl)
 		{
 			return new BaseObject(-1, 'msg_invalid_request');
 		}
 
-		$oMemberModel = getModel('member');
-		$member_info = $oMemberModel->getMemberInfoByMemberSrl($comment->member_srl);
+		$member_info = MemberModel::getMemberInfoByMemberSrl($comment->member_srl);
 
 		$document_srl = $comment->document_srl;
 
@@ -1045,7 +1018,7 @@ class commentController extends comment
 		// check if child comment exists on the comment
 		if(!$childs)
 		{
-			$childs = $oCommentModel->getChildComments($comment_srl);
+			$childs = CommentModel::getChildComments($comment_srl);
 		}
 		if(count($childs) > 0)
 		{
@@ -1068,7 +1041,7 @@ class commentController extends comment
 				$logged_info = Context::get('logged_info');
 				foreach($childs as $val)
 				{
-					$c_member_info = $oMemberModel->getMemberInfoByMemberSrl($val->member_srl);
+					$c_member_info = MemberModel::getMemberInfoByMemberSrl($val->member_srl);
 					if($c_member_info->is_admin == 'Y' && $logged_info->is_admin != 'Y')
 					{
 						$deleteAdminComment = FALSE;
@@ -1119,7 +1092,7 @@ class commentController extends comment
 		$output = executeQuery('comment.deleteCommentList', $args);
 
 		// update the number of comments
-		$comment_count = $oCommentModel->getCommentCount($document_srl);
+		$comment_count = CommentModel::getCommentCount($document_srl);
 
 		// only document is exists
 		if(isset($comment_count))
@@ -1182,11 +1155,9 @@ class commentController extends comment
 			$trash_args->trash_srl = $obj->trash_srl;
 		}
 
-		$oCommentModel = getModel('comment');
-		$oComment = $oCommentModel->getComment($obj->comment_srl);
+		$oComment = CommentModel::getComment($obj->comment_srl);
 
-		$oMemberModel = getModel('member');
-		$member_info = $oMemberModel->getMemberInfoByMemberSrl($oComment->get('member_srl'));
+		$member_info = MemberModel::getMemberInfoByMemberSrl($oComment->get('member_srl'));
 		if($member_info->is_admin == 'Y' && $logged_info->is_admin != 'Y')
 		{
 			return new BaseObject(-1, 'msg_admin_comment_no_move_to_trash');
@@ -1244,7 +1215,7 @@ class commentController extends comment
 		$output = executeQuery('comment.deleteCommentList', $args);
 
 		// update the number of comments
-		$comment_count = $oCommentModel->getCommentCount($obj->document_srl);
+		$comment_count = CommentModel::getCommentCount($obj->document_srl);
 
 		// only document is exists
 		if(isset($comment_count))
@@ -1303,10 +1274,6 @@ class commentController extends comment
 	 */
 	function deleteComments($document_srl, $obj = NULL)
 	{
-		// create the document model object
-		$oDocumentModel = getModel('document');
-		$oCommentModel = getModel('comment');
-
 		// check if permission is granted
 		if(is_object($obj))
 		{
@@ -1315,7 +1282,7 @@ class commentController extends comment
 		}
 		else
 		{
-			$oDocument = $oDocumentModel->getDocument($document_srl);
+			$oDocument = DocumentModel::getDocument($document_srl);
 		}
 
 		if(!$oDocument->isGranted())
@@ -1414,8 +1381,7 @@ class commentController extends comment
 		}
 
 		// Get the original comment
-		$oCommentModel = getModel('comment');
-		$oComment = $oCommentModel->getComment($comment_srl, FALSE, FALSE);
+		$oComment = CommentModel::getComment($comment_srl, FALSE, FALSE);
 
 		// Pass if the author's IP address is as same as visitor's.
 		if($oComment->get('ipaddress') == $_SERVER['REMOTE_ADDR'])
@@ -1425,8 +1391,7 @@ class commentController extends comment
 		}
 
 		// Create a member model object
-		$oMemberModel = getModel('member');
-		$member_srl = $oMemberModel->getLoggedMemberSrl();
+		$member_srl = MemberModel::getLoggedMemberSrl();
 
 		// if the comment author is a member
 		if($oComment->get('member_srl'))
@@ -1559,8 +1524,7 @@ class commentController extends comment
 		}
 
 		// get the original comment
-		$oCommentModel = getModel('comment');
-		$oComment = $oCommentModel->getComment($comment_srl, FALSE, FALSE);
+		$oComment = CommentModel::getComment($comment_srl, FALSE, FALSE);
 
 		// failed if both ip addresses between author's and the current user are same.
 		if($oComment->get('ipaddress') == $_SERVER['REMOTE_ADDR'])
@@ -1639,8 +1603,7 @@ class commentController extends comment
 		// Send message to admin
 		$message_targets = array();
 		$module_srl = $oComment->get('module_srl');
-		$oModuleModel = getModel('module');
-		$comment_config = $oModuleModel->getModulePartConfig('comment', $module_srl);
+		$comment_config = ModuleModel::getModulePartConfig('comment', $module_srl);
 		if ($comment_config->declared_message && in_array('admin', $comment_config->declared_message))
 		{
 			$output = executeQueryArray('member.getAdmins', new stdClass);
@@ -1717,18 +1680,17 @@ class commentController extends comment
 		$target_module_srl = array_map('trim', explode(',', $target_module_srl));
 		$logged_info = Context::get('logged_info');
 		$module_srl = array();
-		$oModuleModel = getModel('module');
 		foreach ($target_module_srl as $srl)
 		{
 			if (!$srl) continue;
 			
-			$module_info = $oModuleModel->getModuleInfoByModuleSrl($srl);
+			$module_info = ModuleModel::getModuleInfoByModuleSrl($srl);
 			if (!$module_info->module_srl)
 			{
 				throw new Rhymix\Framework\Exceptions\InvalidRequest;
 			}
 			
-			$module_grant = $oModuleModel->getGrant($module_info, $logged_info);
+			$module_grant = ModuleModel::getGrant($module_info, $logged_info);
 			if (!$module_grant->manager)
 			{
 				throw new Rhymix\Framework\Exceptions\NotPermitted;
@@ -1821,8 +1783,7 @@ class commentController extends comment
 
 		if(count($commentSrlList) > 0)
 		{
-			$oCommentModel = getModel('comment');
-			$commentList = $oCommentModel->getComments($commentSrlList);
+			$commentList = CommentModel::getComments($commentSrlList);
 
 			if(is_array($commentList))
 			{
@@ -1885,8 +1846,7 @@ class commentController extends comment
 	
 	function triggerCopyModule(&$obj)
 	{
-		$oModuleModel = getModel('module');
-		$commentConfig = $oModuleModel->getModulePartConfig('comment', $obj->originModuleSrl);
+		$commentConfig = ModuleModel::getModulePartConfig('comment', $obj->originModuleSrl);
 
 		$oModuleController = getController('module');
 		if(is_array($obj->moduleSrlList))

--- a/modules/comment/comment.model.php
+++ b/modules/comment/comment.model.php
@@ -16,7 +16,7 @@ class commentModel extends comment
 	 * Initialization
 	 * @return void
 	 */
-	function init()
+	public function init()
 	{
 
 	}
@@ -26,7 +26,7 @@ class commentModel extends comment
 	 * Print, scrap, vote-up(recommen), vote-down(non-recommend), report features added
 	 * @return void
 	 */
-	function getCommentMenu()
+	public function getCommentMenu()
 	{
 		// get the post's id number and the current login information
 		$comment_srl = Context::get('target_srl');
@@ -119,7 +119,7 @@ class commentModel extends comment
 	 * @param int $comment_srl
 	 * @return bool
 	 */
-	function isGranted($comment_srl)
+	public static function isGranted($comment_srl)
 	{
 		return $_SESSION['granted_comment'][$comment_srl];
 	}
@@ -129,7 +129,7 @@ class commentModel extends comment
 	 * @param int $comment_srl
 	 * @return int
 	 */
-	function getChildCommentCount($comment_srl)
+	public static function getChildCommentCount($comment_srl)
 	{
 		$args = new stdClass();
 		$args->comment_srl = $comment_srl;
@@ -142,7 +142,7 @@ class commentModel extends comment
 	 * @param int $comment_srl
 	 * @return int
 	 */
-	function getChildComments($comment_srl)
+	public static function getChildComments($comment_srl)
 	{
 		$args = new stdClass();
 		$args->comment_srl = $comment_srl;
@@ -157,7 +157,7 @@ class commentModel extends comment
 	 * @param array $columnList
 	 * @return commentItem
 	 */
-	function getComment($comment_srl = 0, $is_admin = FALSE, $columnList = array())
+	public static function getComment($comment_srl = 0, $is_admin = FALSE, $columnList = array())
 	{
 		$oComment = new commentItem($comment_srl, $columnList);
 		if($is_admin)
@@ -174,7 +174,7 @@ class commentModel extends comment
 	 * @param array $columnList
 	 * @return array
 	 */
-	function getComments($comment_srl_list, $columnList = array())
+	public static function getComments($comment_srl_list, $columnList = array())
 	{
 		if (!is_array($comment_srl_list))
 		{
@@ -187,7 +187,7 @@ class commentModel extends comment
 
 		// fetch from a database
 		$args = new stdClass();
-		$args->comment_srls = $comment_srls;
+		$args->comment_srls = $comment_srl_list;
 		$output = executeQuery('comment.getComments', $args, $columnList);
 		if(!$output->toBool())
 		{
@@ -204,7 +204,6 @@ class commentModel extends comment
 			$comment_list = array($comment_list);
 		}
 
-		$comment_count = count($comment_list);
 		foreach($comment_list as $key => $attribute)
 		{
 			if(!$attribute->comment_srl)
@@ -212,7 +211,6 @@ class commentModel extends comment
 				continue;
 			}
 
-			$oComment = NULL;
 			$oComment = new commentItem();
 			$oComment->setAttribute($attribute);
 
@@ -226,16 +224,14 @@ class commentModel extends comment
 	 * @param int $document_srl
 	 * @return int
 	 */
-	function getCommentCount($document_srl)
+	public static function getCommentCount($document_srl)
 	{
 		$args = new stdClass();
 		$args->document_srl = $document_srl;
 
 		// get the number of comments on the document module
-		$oDocumentModel = getModel('document');
 		$columnList = array('document_srl', 'module_srl');
-
-		$oDocument = $oDocumentModel->getDocument($document_srl, FALSE, TRUE, $columnList);
+		$oDocument = DocumentModel::getDocument($document_srl, FALSE, TRUE, $columnList);
 
 		// return if no doc exists.
 		if(!$oDocument->isExists())
@@ -273,7 +269,7 @@ class commentModel extends comment
 	 * @param array $moduleSrlList
 	 * @return int
 	 */
-	function getCommentCountByDate($date = '', $moduleSrlList = array())
+	public static function getCommentCountByDate($date = '', $moduleSrlList = array())
 	{
 		$args = new stdClass();
 		if($date)
@@ -301,7 +297,7 @@ class commentModel extends comment
 	 * @param bool $published
 	 * @return int
 	 */
-	function getCommentAllCount($module_srl, $published = false)
+	public static function getCommentAllCount($module_srl, $published = false)
 	{
 		$args = new stdClass();
 		$args->module_srl = $module_srl;
@@ -336,9 +332,12 @@ class commentModel extends comment
 
 	/**
 	 * Get the module info without duplication
+	 * 
+	 * @deprecated
+	 * 
 	 * @return array
 	 */
-	function getDistinctModules()
+	public static function getDistinctModules()
 	{
 		return array();
 
@@ -366,7 +365,7 @@ class commentModel extends comment
 	 * @param array $columnList
 	 * @return array
 	 */
-	function getNewestCommentList($obj, $columnList = array())
+	public static function getNewestCommentList($obj, $columnList = array())
 	{
 		$args = new stdClass();
 
@@ -377,8 +376,7 @@ class commentModel extends comment
 
 		if($obj->mid)
 		{
-			$oModuleModel = getModel('module');
-			$obj->module_srl = $oModuleModel->getModuleSrlByMid($obj->mid);
+			$obj->module_srl = ModuleModel::getModuleSrlByMid($obj->mid);
 			unset($obj->mid);
 		}
 
@@ -454,7 +452,7 @@ class commentModel extends comment
 	 * @param int $count
 	 * @return object
 	 */
-	function getCommentList($document_srl, $page = 0, $is_admin = FALSE, $count = 0)
+	public static function getCommentList($document_srl, $page = 0, $is_admin = FALSE, $count = 0)
 	{
 		if(!$document_srl)
 		{
@@ -462,9 +460,8 @@ class commentModel extends comment
 		}
 
 		// get the number of comments on the document module
-		$oDocumentModel = getModel('document');
 		$columnList = array('document_srl', 'module_srl', 'comment_count');
-		$oDocument = $oDocumentModel->getDocument($document_srl, false, false, $columnList);
+		$oDocument = DocumentModel::getDocument($document_srl, false, false, $columnList);
 
 		// return if no doc exists.
 		if(!$oDocument->isExists())
@@ -484,7 +481,7 @@ class commentModel extends comment
 
 		if(!$count)
 		{
-			$comment_config = $this->getCommentConfig($module_srl);
+			$comment_config = self::getCommentConfig($module_srl);
 			$comment_count = $comment_config->comment_count;
 			$comment_page_count = $comment_config->comment_page_count;
 		}
@@ -525,9 +522,8 @@ class commentModel extends comment
 		$trigger_output = ModuleHandler::triggerCall('comment.getCommentList', 'before', $args);
 		if($trigger_output instanceof BaseObject && !$trigger_output->toBool())
 		{
-			return $output;
+			return $trigger_output;
 		}
-		
 		
 		// If an alternate output is set, use it instead of running the default queries
 		if (isset($args->use_alternate_output) && $args->use_alternate_output instanceof BaseObject)
@@ -546,7 +542,7 @@ class commentModel extends comment
 			// insert data into CommentPageList table if the number of results is different from stored comments
 			if(!$output->data)
 			{
-				$this->fixCommentList($oDocument->get('module_srl'), $document_srl);
+				self::fixCommentList($oDocument->get('module_srl'), $document_srl);
 				$output = executeQueryArray('comment.getCommentPageList', $args);
 				if(!$output->toBool())
 				{
@@ -568,7 +564,7 @@ class commentModel extends comment
 	 * @param int $count
 	 * @return int
 	 */
-	function getCommentPage($document_srl, $comment_srl, $count = 0)
+	public static function getCommentPage($document_srl, $comment_srl, $count = 0)
 	{
 		// Check the document
 		$oDocumentModel = getModel('document');
@@ -590,7 +586,7 @@ class commentModel extends comment
 		if(!$count)
 		{
 			$module_srl = $oDocument->get('module_srl');
-			$comment_config = $this->getCommentConfig($module_srl);
+			$comment_config = self::getCommentConfig($module_srl);
 			$comment_count = $comment_config->comment_count;
 		}
 		else
@@ -642,7 +638,7 @@ class commentModel extends comment
 	 * @param int $document_srl
 	 * @return void
 	 */
-	function fixCommentList($module_srl, $document_srl)
+	public static function fixCommentList($module_srl, $document_srl)
 	{
 		// create a lock file to prevent repeated work when performing a batch job
 		$lock_file = "./files/cache/tmp/lock." . $document_srl;
@@ -702,7 +698,7 @@ class commentModel extends comment
 				$root->child[] = &$list[$comment_srl];
 			}
 		}
-		$this->_arrangeComment($comment_list, $root->child, 0, NULL);
+		self::_arrangeComment($comment_list, $root->child, 0, NULL);
 
 		// insert values to the database
 		if(count($comment_list))
@@ -734,7 +730,7 @@ class commentModel extends comment
 	 * @param object $parent
 	 * @return void
 	 */
-	function _arrangeComment(&$comment_list, $list, $depth, $parent = NULL)
+	public static function _arrangeComment(&$comment_list, $list, $depth, $parent = NULL)
 	{
 		if(!count($list))
 		{
@@ -758,7 +754,7 @@ class commentModel extends comment
 			{
 				$val->depth = $depth;
 				$comment_list[$val->comment_srl] = $val;
-				$this->_arrangeComment($comment_list, $val->child, $depth + 1, $val);
+				self::_arrangeComment($comment_list, $val->child, $depth + 1, $val);
 				unset($val->child);
 			}
 			else
@@ -775,7 +771,7 @@ class commentModel extends comment
 	 * @param array $columnList
 	 * @return object
 	 */
-	function getTotalCommentList($obj, $columnList = array())
+	public static function getTotalCommentList($obj, $columnList = array())
 	{
 		$query_id = 'comment.getTotalCommentList';
 
@@ -949,7 +945,7 @@ class commentModel extends comment
 	 * @param object $obj
 	 * @return int
 	 */
-	function getTotalCommentCount($obj)
+	public static function getTotalCommentCount($obj)
 	{
 		$query_id = 'comment.getTotalCommentCountByGroupStatus';
 
@@ -1059,10 +1055,9 @@ class commentModel extends comment
 	 * @param int $module_srl
 	 * @return object
 	 */
-	function getCommentConfig($module_srl)
+	public static function getCommentConfig($module_srl)
 	{
-		$oModuleModel = getModel('module');
-		$comment_config = $oModuleModel->getModulePartConfig('comment', $module_srl);
+		$comment_config = ModuleModel::getModulePartConfig('comment', $module_srl);
 		if(!is_object($comment_config))
 		{
 			$comment_config = new stdClass();
@@ -1084,7 +1079,7 @@ class commentModel extends comment
 	 * Return a list of voting member
 	 * @return void
 	 */
-	function getCommentVotedMemberList()
+	public function getCommentVotedMemberList()
 	{
 		$comment_srl = Context::get('comment_srl');
 		if(!$comment_srl)
@@ -1154,7 +1149,7 @@ class commentModel extends comment
 	 * Return a secret status by secret field
 	 * @return array
 	 */
-	function getSecretNameList()
+	public static function getSecretNameList()
 	{
 		global $lang;
 
@@ -1173,7 +1168,7 @@ class commentModel extends comment
 	 * @param int $member_srl
 	 * @return int
 	 */
-	function getCommentCountByMemberSrl($member_srl)
+	public static function getCommentCountByMemberSrl($member_srl)
 	{
 		$args = new stdClass();
 		$args->member_srl = $member_srl;
@@ -1191,7 +1186,7 @@ class commentModel extends comment
 	 * @param int $count
 	 * @return object
 	 */
-	function getCommentListByMemberSrl($member_srl, $columnList = array(), $page = 0, $is_admin = FALSE, $count = 0)
+	public static function getCommentListByMemberSrl($member_srl, $columnList = array(), $page = 0, $is_admin = FALSE, $count = 0)
 	{
 		$args = new stdClass();
 		$args->member_srl = $member_srl;

--- a/modules/comment/comment.model.php
+++ b/modules/comment/comment.model.php
@@ -45,14 +45,12 @@ class commentModel extends comment
 		// feature that only member can do
 		if($logged_info->member_srl)
 		{
-			$oCommentModel = getModel('comment');
 			$columnList = array('comment_srl', 'module_srl', 'member_srl', 'ipaddress');
-			$oComment = $oCommentModel->getComment($comment_srl, FALSE, $columnList);
+			$oComment = self::getComment($comment_srl, FALSE, $columnList);
 			$module_srl = $oComment->get('module_srl');
 			$member_srl = $oComment->get('member_srl');
 
-			$oModuleModel = getModel('module');
-			$comment_config = $oModuleModel->getModulePartConfig('document', $module_srl);
+			$comment_config = ModuleModel::getModulePartConfig('document', $module_srl);
 
 			if($comment_config->use_vote_up != 'N' && $member_srl != $logged_info->member_srl)
 			{
@@ -86,8 +84,7 @@ class commentModel extends comment
 		// find a comment by IP matching if an administrator.
 		if($logged_info->is_admin == 'Y')
 		{
-			$oCommentModel = getModel('comment');
-			$oComment = $oCommentModel->getComment($comment_srl);
+			$oComment = self::getComment($comment_srl);
 
 			if($oComment->isExists())
 			{
@@ -245,7 +242,7 @@ class commentModel extends comment
 		//check if module is using validation system
 		$oCommentController = getController('comment');
 		$using_validation = $oCommentController->isModuleUsingPublishValidation($module_srl);
-		$module_info = getModel('module')->getModuleInfoByDocumentSrl($document_srl);
+		$module_info = ModuleModel::getModuleInfoByDocumentSrl($document_srl);
 		$use_comment_massage = $module_info->comment_delete_message;
 
 		if($using_validation)
@@ -344,13 +341,12 @@ class commentModel extends comment
 		/*
 		$output = executeQueryArray('comment.getDistinctModules');
 		$module_srls = $output->data;
-		$oModuleModel = getModel('module');
 		$result = array();
 		if($module_srls)
 		{
 			foreach($module_srls as $module)
 			{
-				$module_info = $oModuleModel->getModuleInfoByModuleSrl($module->module_srl);
+				$module_info = ModuleModel::getModuleInfoByModuleSrl($module->module_srl);
 				$result[$module->module_srl] = $module_info->mid;
 			}
 		}
@@ -567,9 +563,8 @@ class commentModel extends comment
 	public static function getCommentPage($document_srl, $comment_srl, $count = 0)
 	{
 		// Check the document
-		$oDocumentModel = getModel('document');
 		$columnList = array('document_srl', 'module_srl', 'comment_count');
-		$oDocument = $oDocumentModel->getDocument($document_srl, false, false, $columnList);
+		$oDocument = DocumentModel::getDocument($document_srl, false, false, $columnList);
 		if(!$oDocument->isExists())
 		{
 			return 0;
@@ -1093,16 +1088,14 @@ class commentModel extends comment
 			$point = 1;
 		}
 
-		$oCommentModel = getModel('comment');
-		$oComment = $oCommentModel->getComment($comment_srl, FALSE, FALSE);
+		$oComment = self::getComment($comment_srl, FALSE, FALSE);
 		$module_srl = $oComment->get('module_srl');
 		if(!$module_srl)
 		{
 			throw new Rhymix\Framework\Exceptions\InvalidRequest;
 		}
 
-		$oModuleModel = getModel('module');
-		$comment_config = $oModuleModel->getModulePartConfig('comment', $module_srl);
+		$comment_config = ModuleModel::getModulePartConfig('comment', $module_srl);
 
 		$args = new stdClass();
 
@@ -1132,12 +1125,11 @@ class commentModel extends comment
 			return $output;
 		}
 
-		$oMemberModel = getModel('member');
 		if($output->data)
 		{
 			foreach($output->data as $k => $d)
 			{
-				$profile_image = $oMemberModel->getProfileImage($d->member_srl);
+				$profile_image = MemberModel::getProfileImage($d->member_srl);
 				$output->data[$k]->src = $profile_image->src;
 			}
 		}

--- a/modules/comment/comment.view.php
+++ b/modules/comment/comment.view.php
@@ -43,13 +43,11 @@ class commentView extends comment
 		}
 
 		// get the comment configuration
-		$oCommentModel = getModel('comment');
-		$comment_config = $oCommentModel->getCommentConfig($current_module_srl);
+		$comment_config = CommentModel::getCommentConfig($current_module_srl);
 		Context::set('comment_config', $comment_config);
 
 		// get a group list
-		$oMemberModel = getModel('member');
-		$group_list = $oMemberModel->getGroups();
+		$group_list = MemberModel::getGroups();
 		Context::set('group_list', $group_list);
 
 		// Set a template file
@@ -69,17 +67,14 @@ class commentView extends comment
 		$this->setLayoutFile('popup_layout');
 		$comment_srl = Context::get('target_srl');
 
-		$oMemberModel = getModel('member');
 		// A message appears if the user is not logged-in
-		if(!$oMemberModel->isLogged())
+		if(!$this->user->member_srl)
 		{
 			throw new Rhymix\Framework\Exceptions\MustLogin;
 		}
 
-		// Create the comment object.
-		$oCommentModel = getModel('comment');
 		// Creates an object for displaying the selected comment
-		$oComment = $oCommentModel->getComment($comment_srl);
+		$oComment = CommentModel::getComment($comment_srl);
 		if(!$oComment->isExists())
 		{
 			throw new Rhymix\Framework\Exceptions\TargetNotFound;

--- a/modules/document/document.class.php
+++ b/modules/document/document.class.php
@@ -16,12 +16,13 @@ class document extends ModuleObject
 	 * Search option to use in admin page
 	 * @var array
 	 */
-	var $search_option = array('title','content','title_content','user_name',); // /< Search options
+	public $search_option = array('title', 'content', 'title_content', 'user_name');
+
 	/**
 	 * Status list
 	 * @var array
 	 */
-	var $statusList = array('private'=>'PRIVATE', 'public'=>'PUBLIC', 'secret'=>'SECRET', 'temp'=>'TEMP');
+	public static $statusList = array('private' => 'PRIVATE', 'public' => 'PUBLIC', 'secret' => 'SECRET', 'temp' => 'TEMP');
 
 	/**
 	 * Implement if additional tasks are necessary when installing
@@ -386,27 +387,27 @@ class document extends ModuleObject
 	 * Document Status List
 	 * @return array
 	 */
-	function getStatusList()
+	public static function getStatusList()
 	{
-		return $this->statusList;
+		return self::$statusList;
 	}
 
 	/**
 	 * Return default status
 	 * @return string
 	 */
-	function getDefaultStatus()
+	public static function getDefaultStatus()
 	{
-		return $this->statusList['public'];
+		return self::$statusList['public'];
 	}
 
 	/**
 	 * Return status by key
 	 * @return string
 	 */
-	function getConfigStatus($key)
+	public static function getConfigStatus($key)
 	{
-		return $this->statusList[$key];
+		return self::$statusList[$key];
 	}
 }
 /* End of file document.class.php */

--- a/modules/document/document.controller.php
+++ b/modules/document/document.controller.php
@@ -33,7 +33,7 @@ class documentController extends document
 		$module_info = $this->module_info;
 		if(!$module_info->module_srl)
 		{
-			$module_info = getModel('module')->getModuleInfoByDocumentSrl($document_srl);
+			$module_info = ModuleModel::getModuleInfoByDocumentSrl($document_srl);
 		}
 		
 		if($module_info->non_login_vote !== 'Y')
@@ -44,13 +44,11 @@ class documentController extends document
 			}
 		}
 		
-		$oDocumentModel = getModel('document');
-		$oDocument = $oDocumentModel->getDocument($document_srl, false, false);
+		$oDocument = DocumentModel::getDocument($document_srl, false, false);
 		$module_srl = $oDocument->get('module_srl');
 		if(!$module_srl) throw new Rhymix\Framework\Exceptions\InvalidRequest;
 
-		$oModuleModel = getModel('module');
-		$document_config = $oModuleModel->getModulePartConfig('document',$module_srl);
+		$document_config = ModuleModel::getModulePartConfig('document',$module_srl);
 		if($document_config->use_vote_up=='N') throw new Rhymix\Framework\Exceptions\FeatureDisabled;
 
 		$point = 1;
@@ -74,7 +72,7 @@ class documentController extends document
 		$module_info = $this->module_info;
 		if(!$module_info->module_srl)
 		{
-			$module_info = getModel('module')->getModuleInfoByDocumentSrl($document_srl);
+			$module_info = ModuleModel::getModuleInfoByDocumentSrl($document_srl);
 		}
 
 		if($module_info->non_login_vote !== 'Y')
@@ -90,8 +88,7 @@ class documentController extends document
 			throw new Rhymix\Framework\Exception('failed_voted_cancel');
 		}
 
-		$oDocumentModel = getModel('document');
-		$oDocument = $oDocumentModel->getDocument($document_srl, false, false);
+		$oDocument = DocumentModel::getDocument($document_srl, false, false);
 		if($oDocument->get('voted_count') <= 0)
 		{
 			throw new Rhymix\Framework\Exception('failed_voted_canceled');
@@ -144,13 +141,11 @@ class documentController extends document
 		$document_srl = Context::get('target_srl');
 		if(!$document_srl) throw new Rhymix\Framework\Exceptions\InvalidRequest;
 
-		$oDocumentModel = getModel('document');
-		$oDocument = $oDocumentModel->getDocument($document_srl, false, false);
+		$oDocument = DocumentModel::getDocument($document_srl, false, false);
 		$module_srl = $oDocument->get('module_srl');
 		if(!$module_srl) throw new Rhymix\Framework\Exceptions\InvalidRequest;
 
-		$oModuleModel = getModel('module');
-		$document_config = $oModuleModel->getModulePartConfig('document',$module_srl);
+		$document_config = ModuleModel::getModulePartConfig('document',$module_srl);
 		if($document_config->use_vote_down=='N') throw new Rhymix\Framework\Exceptions\FeatureDisabled;
 
 		$point = -1;
@@ -181,8 +176,7 @@ class documentController extends document
 		$document_srl = Context::get('target_srl');
 		if(!$document_srl) throw new Rhymix\Framework\Exceptions\InvalidRequest;
 
-		$oDocumentModel = getModel('document');
-		$oDocument = $oDocumentModel->getDocument($document_srl, false, false);
+		$oDocument = DocumentModel::getDocument($document_srl, false, false);
 		if($oDocument->get('blamed_count') >= 0)
 		{
 			throw new Rhymix\Framework\Exception('failed_blamed_canceled');
@@ -328,16 +322,14 @@ class documentController extends document
 		}
 		
 		$document_srl = intval(Context::get('target_srl'));
-		
-		$oDocument = getModel('document')->getDocument($document_srl);
-		
+
+		$oDocument = DocumentModel::getDocument($document_srl);
 		if(!$oDocument->isExists())
 		{
 			throw new Rhymix\Framework\Exceptions\InvalidRequest;
 		}
 		
-		$module_info = getModel('module')->getModuleInfoByDocumentSrl($document_srl);
-		
+		$module_info = ModuleModel::getModuleInfoByDocumentSrl($document_srl);
 		if($module_info->cancel_vote !== 'Y')
 		{
 			throw new Rhymix\Framework\Exception('failed_declared_cancel');
@@ -427,7 +419,7 @@ class documentController extends document
 	 */
 	function addGrant($document_srl)
 	{
-		$oDocument = getModel('document')->getDocument($document_srl);
+		$oDocument = DocumentModel::getDocument($document_srl);
 		if ($oDocument->isExists())
 		{
 			$oDocument->setGrant();
@@ -526,10 +518,9 @@ class documentController extends document
 		}
 
 		// Set to 0 if the category_srl doesn't exist
-		$oDocumentModel = getModel('document');
 		if($obj->category_srl)
 		{
-			$category_list = $oDocumentModel->getCategoryList($obj->module_srl);
+			$category_list = DocumentModel::getCategoryList($obj->module_srl);
 			if(count($category_list) > 0 && !$category_list[$obj->category_srl]->grant)
 			{
 				return new BaseObject(-1, 'msg_not_permitted');
@@ -545,7 +536,7 @@ class documentController extends document
 		// Check the status of password hash for manually inserting. Apply hashing for otherwise.
 		if($obj->password && !$obj->password_is_hashed)
 		{
-			$obj->password = getModel('member')->hashPassword($obj->password);
+			$obj->password = MemberModel::hashPassword($obj->password);
 		}
 
 		// Insert member's information only if the member is logged-in and not manually registered.
@@ -613,7 +604,7 @@ class documentController extends document
 
 		// Insert extra variables if the document successfully inserted.
 		$extra_vars = array();
-		$extra_keys = $oDocumentModel->getExtraKeys($obj->module_srl);
+		$extra_keys = DocumentModel::getExtraKeys($obj->module_srl);
 		if(count($extra_keys))
 		{
 			foreach($extra_keys as $idx => $extra_item)
@@ -731,8 +722,7 @@ class documentController extends document
 		
 		if(!$obj->module_srl) $obj->module_srl = $source_obj->get('module_srl');
 		
-		$oModuleModel = getModel('module');
-		$document_config = $oModuleModel->getModulePartConfig('document', $obj->module_srl);
+		$document_config = ModuleModel::getModulePartConfig('document', $obj->module_srl);
 		if(!$document_config)
 		{
 			$document_config = new stdClass();
@@ -793,10 +783,9 @@ class documentController extends document
 		unset($obj->_saved_doc_message);
 
 		// Set the category_srl to 0 if the changed category is not exsiting.
-		$oDocumentModel = getModel('document');
 		if($source_obj->get('category_srl')!=$obj->category_srl)
 		{
-			$category_list = $oDocumentModel->getCategoryList($obj->module_srl);
+			$category_list = DocumentModel::getCategoryList($obj->module_srl);
 			if(!$category_list[$obj->category_srl]) $obj->category_srl = 0;
 		}
 
@@ -806,7 +795,7 @@ class documentController extends document
 		// Hash the password if it exists
 		if($obj->password)
 		{
-			$obj->password = getModel('member')->hashPassword($obj->password);
+			$obj->password = MemberModel::hashPassword($obj->password);
 		}
 
 		// If an author is identical to the modifier or history is used, use the logged-in user's information.
@@ -910,7 +899,7 @@ class documentController extends document
 		{
 			$this->deleteDocumentExtraVars($source_obj->get('module_srl'), $obj->document_srl, null, Context::getLangType());
 			// Insert extra variables if the document successfully inserted.
-			$extra_keys = $oDocumentModel->getExtraKeys($obj->module_srl);
+			$extra_keys = DocumentModel::getExtraKeys($obj->module_srl);
 			if(count($extra_keys))
 			{
 				foreach($extra_keys as $idx => $extra_item)
@@ -1037,15 +1026,12 @@ class documentController extends document
 
 		if(!$isEmptyTrash)
 		{
-			// get model object of the document
-			$oDocumentModel = getModel('document');
 			// Check if the documnet exists
-			$oDocument = $oDocumentModel->getDocument($document_srl, $is_admin);
+			$oDocument = DocumentModel::getDocument($document_srl, $is_admin);
 		}
 		else if($isEmptyTrash && $oDocument == null) return new BaseObject(-1, 'document is not exists');
 
-		$oMemberModel = getModel('member');
-		$member_info = $oMemberModel->getMemberInfoByMemberSrl($oDocument->get('member_srl'));
+		$member_info = MemberModel::getMemberInfoByMemberSrl($oDocument->get('member_srl'));
 		$logged_info = Context::get('logged_info');
 
 		if($member_info->is_admin == 'Y' && $logged_info->is_admin != 'Y')
@@ -1156,11 +1142,9 @@ class documentController extends document
 		if(!$obj->trash_srl) $trash_args->trash_srl = getNextSequence();
 		else $trash_args->trash_srl = $obj->trash_srl;
 		// Get its module_srl which the document belongs to
-		$oDocumentModel = getModel('document');
-		$oDocument = $oDocumentModel->getDocument($obj->document_srl);
+		$oDocument = DocumentModel::getDocument($obj->document_srl);
 
-		$oMemberModel = getModel('member');
-		$member_info = $oMemberModel->getMemberInfoByMemberSrl($oDocument->get('member_srl'));
+		$member_info = MemberModel::getMemberInfoByMemberSrl($oDocument->get('member_srl'));
 		if($member_info->is_admin == 'Y' && $logged_info->is_admin != 'Y')
 		{
 			return new BaseObject(-1, 'msg_admin_document_no_move_to_trash');
@@ -1283,8 +1267,7 @@ class documentController extends document
 			'none' => true,
 		);
 		
-		$oDocumentModel = getModel('document');
-		$config = $oDocumentModel->getDocumentConfig();
+		$config = DocumentModel::getDocumentConfig();
 		if (!$config->view_count_option || !isset($valid_options[$config->view_count_option]))
 		{
 			$config->view_count_option = 'once';
@@ -1524,8 +1507,7 @@ class documentController extends document
 		}
 
 		// Get the original document
-		$oDocumentModel = getModel('document');
-		$oDocument = $oDocumentModel->getDocument($document_srl, false, false);
+		$oDocument = DocumentModel::getDocument($document_srl, false, false);
 
 		// Pass if the author's IP address is as same as visitor's.
 		if($oDocument->get('ipaddress') == $_SERVER['REMOTE_ADDR'])
@@ -1534,9 +1516,8 @@ class documentController extends document
 			return new BaseObject(-1, $failed_voted);
 		}
 
-		// Create a member model object
-		$oMemberModel = getModel('member');
-		$member_srl = $oMemberModel->getLoggedMemberSrl();
+		// Get current member_srl
+		$member_srl = MemberModel::getLoggedMemberSrl();
 
 		// Check if document's author is a member.
 		if($oDocument->get('member_srl'))
@@ -1673,8 +1654,7 @@ class documentController extends document
 		}
 
 		// Get the original document
-		$oDocumentModel = getModel('document');
-		$oDocument = $oDocumentModel->getDocument($document_srl, false, false);
+		$oDocument = DocumentModel::getDocument($document_srl, false, false);
 
 		// Pass if the author's IP address is as same as visitor's.
 		if($oDocument->get('ipaddress') == $_SERVER['REMOTE_ADDR'])
@@ -1753,8 +1733,7 @@ class documentController extends document
 		// Send message to admin
 		$message_targets = array();
 		$module_srl = $oDocument->get('module_srl');
-		$oModuleModel = getModel('module');
-		$document_config = $oModuleModel->getModulePartConfig('document', $module_srl);
+		$document_config = ModuleModel::getModulePartConfig('document', $module_srl);
 		if ($document_config->declared_message && in_array('admin', $document_config->declared_message))
 		{
 			$output = executeQueryArray('member.getAdmins', new stdClass);
@@ -1809,8 +1788,7 @@ class documentController extends document
 		}
 		
 		// Get the original document
-		$oDocumentModel = getModel('document');
-		$oDocument = $oDocumentModel->getDocument($document_srl, false, false);
+		$oDocument = DocumentModel::getDocument($document_srl, false, false);
 
 		$oDB = DB::getInstance();
 		$oDB->begin();
@@ -1872,8 +1850,7 @@ class documentController extends document
 		
 		$message_targets = array();
 		$module_srl = $oDocument->get('module_srl');
-		$oModuleModel = getModel('module');
-		$document_config = $oModuleModel->getModulePartConfig('document', $module_srl);
+		$document_config = ModuleModel::getModulePartConfig('document', $module_srl);
 		if ($document_config->declared_message && in_array('admin', $document_config->declared_message))
 		{
 			$output = executeQueryArray('member.getAdmins', new stdClass);
@@ -1968,8 +1945,7 @@ class documentController extends document
 		if($obj->parent_srl)
 		{
 			// Get its parent category
-			$oDocumentModel = getModel('document');
-			$parent_category = $oDocumentModel->getCategory($obj->parent_srl);
+			$parent_category = DocumentModel::getCategory($obj->parent_srl);
 			$obj->list_order = $parent_category->list_order;
 			$this->updateCategoryListOrder($parent_category->module_srl, $parent_category->list_order+1);
 			if(!$obj->category_srl) $obj->category_srl = getNextSequence();
@@ -2013,8 +1989,10 @@ class documentController extends document
 	function updateCategoryCount($module_srl, $category_srl, $document_count = 0)
 	{
 		// Create a document model object
-		$oDocumentModel = getModel('document');
-		if(!$document_count) $document_count = $oDocumentModel->getCategoryDocumentCount($module_srl,$category_srl);
+		if(!$document_count)
+		{
+			$document_count = DocumentModel::getCategoryDocumentCount($module_srl,$category_srl);
+		}
 
 		$args = new stdClass;
 		$args->category_srl = $category_srl;
@@ -2046,8 +2024,7 @@ class documentController extends document
 	{
 		$args = new stdClass();
 		$args->category_srl = $category_srl;
-		$oDocumentModel = getModel('document');
-		$category_info = $oDocumentModel->getCategory($category_srl);
+		$category_info = DocumentModel::getCategory($category_srl);
 		// Display an error that the category cannot be deleted if it has a child
 		$output = executeQuery('document.getChildCategoryCount', $args);
 		if(!$output->toBool()) return $output;
@@ -2108,7 +2085,6 @@ class documentController extends document
 	 */
 	function moveCategoryUp($category_srl)
 	{
-		$oDocumentModel = getModel('document');
 		// Get information of the selected category
 		$args = new stdClass;
 		$args->category_srl = $category_srl;
@@ -2118,7 +2094,7 @@ class documentController extends document
 		$list_order = $category->list_order;
 		$module_srl = $category->module_srl;
 		// Seek a full list of categories
-		$category_list = $oDocumentModel->getCategoryList($module_srl);
+		$category_list = DocumentModel::getCategoryList($module_srl);
 		$category_srl_list = array_keys($category_list);
 		if(count($category_srl_list)<2) return new BaseObject();
 
@@ -2155,7 +2131,6 @@ class documentController extends document
 	 */
 	function moveCategoryDown($category_srl)
 	{
-		$oDocumentModel = getModel('document');
 		// Get information of the selected category
 		$args = new stdClass;
 		$args->category_srl = $category_srl;
@@ -2165,7 +2140,7 @@ class documentController extends document
 		$list_order = $category->list_order;
 		$module_srl = $category->module_srl;
 		// Seek a full list of categories
-		$category_list = $oDocumentModel->getCategoryList($module_srl);
+		$category_list = DocumentModel::getCategoryList($module_srl);
 		$category_srl_list = array_keys($category_list);
 		if(count($category_srl_list)<2) return new BaseObject();
 
@@ -2200,8 +2175,7 @@ class documentController extends document
 	 */
 	function addXmlJsFilter($module_srl)
 	{
-		$oDocumentModel = getModel('document');
-		$extra_keys = $oDocumentModel->getExtraKeys($module_srl);
+		$extra_keys = DocumentModel::getExtraKeys($module_srl);
 		if(!count($extra_keys)) return;
 
 		$js_code = array();
@@ -2251,10 +2225,9 @@ class documentController extends document
 			$args->module_srl = $this->module_srl;
 		}
 		// Check permissions
-		$oModuleModel = getModel('module');
 		$columnList = array('module_srl', 'module');
-		$module_info = $oModuleModel->getModuleInfoByModuleSrl($args->module_srl, $columnList);
-		$grant = $oModuleModel->getGrant($module_info, Context::get('logged_info'));
+		$module_info = ModuleModel::getModuleInfoByModuleSrl($args->module_srl, $columnList);
+		$grant = ModuleModel::getGrant($module_info, Context::get('logged_info'));
 		if(!$grant->manager) return new BaseObject(-1, 'msg_not_permitted');
 
 		if($args->expand !="Y") $args->expand = "N";
@@ -2262,14 +2235,12 @@ class documentController extends document
 		else $args->group_srls = implode(',', $args->group_srls);
 		$args->parent_srl = (int)$args->parent_srl;
 
-		$oDocumentModel = getModel('document');
-
 		$oDB = &DB::getInstance();
 		$oDB->begin();
 		// Check if already exists
 		if($args->category_srl)
 		{
-			$category_info = $oDocumentModel->getCategory($args->category_srl);
+			$category_info = DocumentModel::getCategory($args->category_srl);
 			if($category_info->category_srl != $args->category_srl) $args->category_srl = null;
 		}
 		// Update if exists
@@ -2318,20 +2289,18 @@ class documentController extends document
 		// If target_srl exists, be a sibling
 		$target_category_srl = Context::get('target_srl');
 
-		$oDocumentModel = getModel('document');
-		$source_category = $oDocumentModel->getCategory($source_category_srl);
+		$source_category = DocumentModel::getCategory($source_category_srl);
 		// Check permissions
-		$oModuleModel = getModel('module');
 		$columnList = array('module_srl', 'module');
-		$module_info = $oModuleModel->getModuleInfoByModuleSrl($source_category->module_srl, $columnList);
-		$grant = $oModuleModel->getGrant($module_info, Context::get('logged_info'));
+		$module_info = ModuleModel::getModuleInfoByModuleSrl($source_category->module_srl, $columnList);
+		$grant = ModuleModel::getGrant($module_info, Context::get('logged_info'));
 		if(!$grant->manager) return new BaseObject(-1, 'msg_not_permitted');
 
 		// First child of the parent_category_srl
 		$source_args = new stdClass;
 		if($parent_category_srl > 0 || ($parent_category_srl == 0 && $target_category_srl == 0))
 		{
-			$parent_category = $oDocumentModel->getCategory($parent_category_srl);
+			$parent_category = DocumentModel::getCategory($parent_category_srl);
 
 			$args = new stdClass;
 			$args->module_srl = $source_category->module_srl;
@@ -2352,7 +2321,7 @@ class documentController extends document
 		}
 		else if($target_category_srl > 0)
 		{
-			$target_category = $oDocumentModel->getCategory($target_category_srl);
+			$target_category = DocumentModel::getCategory($target_category_srl);
 			// Move all siblings of the $target_category down
 			$output = $this->updateCategoryListOrder($target_category->module_srl, $target_category->list_order+1);
 			if(!$output->toBool()) return $output;
@@ -2382,18 +2351,16 @@ class documentController extends document
 		$oDB = &DB::getInstance();
 		$oDB->begin();
 		// Check permissions
-		$oModuleModel = getModel('module');
 		$columnList = array('module_srl', 'module');
-		$module_info = $oModuleModel->getModuleInfoByModuleSrl($args->module_srl, $columnList);
-		$grant = $oModuleModel->getGrant($module_info, Context::get('logged_info'));
+		$module_info = ModuleModel::getModuleInfoByModuleSrl($args->module_srl, $columnList);
+		$grant = ModuleModel::getGrant($module_info, Context::get('logged_info'));
 		if(!$grant->manager) return new BaseObject(-1, 'msg_not_permitted');
 
-		$oDocumentModel = getModel('document');
 		// Get original information
-		$category_info = $oDocumentModel->getCategory($args->category_srl);
+		$category_info = DocumentModel::getCategory($args->category_srl);
 		if($category_info->parent_srl) $parent_srl = $category_info->parent_srl;
 		// Display an error that the category cannot be deleted if it has a child node
-		if($oDocumentModel->getCategoryChlidCount($args->category_srl)) return new BaseObject(-1, 'msg_cannot_delete_for_child');
+		if(DocumentModel::getCategoryChlidCount($args->category_srl)) return new BaseObject(-1, 'msg_cannot_delete_for_child');
 		// Remove from the DB
 		$output = $this->deleteCategory($args->category_srl);
 		if(!$output->toBool())
@@ -2423,10 +2390,9 @@ class documentController extends document
 		// Check input values
 		$module_srl = Context::get('module_srl');
 		// Check permissions
-		$oModuleModel = getModel('module');
 		$columnList = array('module_srl', 'module');
-		$module_info = $oModuleModel->getModuleInfoByModuleSrl($module_srl, $columnList);
-		$grant = $oModuleModel->getGrant($module_info, Context::get('logged_info'));
+		$module_info = ModuleModel::getModuleInfoByModuleSrl($module_srl, $columnList);
+		$grant = ModuleModel::getGrant($module_info, Context::get('logged_info'));
 		if(!$grant->manager) return new BaseObject(-1, 'msg_not_permitted');
 
 		$xml_file = $this->makeCategoryFile($module_srl);
@@ -2445,9 +2411,8 @@ class documentController extends document
 		$module_srl = intval($module_srl);
 		if(!$module_srl) return false;
 		// Get module information (to obtain mid)
-		$oModuleModel = getModel('module');
 		$columnList = array('module_srl', 'mid', 'site_srl');
-		$module_info = $oModuleModel->getModuleInfoByModuleSrl($module_srl, $columnList);
+		$module_info = ModuleModel::getModuleInfoByModuleSrl($module_srl, $columnList);
 		$mid = $module_info->mid;
 
 		if(!is_dir('./files/cache/document_category')) FileHandler::makeDir('./files/cache/document_category');
@@ -2784,12 +2749,11 @@ class documentController extends document
 		if(!$document_srls || !count($document_srls)) return new BaseObject();
 
 		// Check if each of module administrators exists. Top-level administator will have a permission to modify every document of all modules.(Even to modify temporarily saved or trashed documents)
-		$oModuleModel = getModel('module');
 		$module_srls = array_keys($document_srls);
 		for($i=0;$i<count($module_srls);$i++)
 		{
 			$module_srl = $module_srls[$i];
-			$module_info = $oModuleModel->getModuleInfoByModuleSrl($module_srl);
+			$module_info = ModuleModel::getModuleInfoByModuleSrl($module_srl);
 			$logged_info = Context::get('logged_info');
 			if($logged_info->is_admin != 'Y')
 			{
@@ -2798,7 +2762,7 @@ class documentController extends document
 					unset($document_srls[$module_srl]);
 					continue;
 				}
-				$grant = $oModuleModel->getGrant($module_info, $logged_info);
+				$grant = ModuleModel::getGrant($module_info, $logged_info);
 				if(!$grant->manager)
 				{
 					unset($document_srls[$module_srl]);
@@ -2843,12 +2807,12 @@ class documentController extends document
 		// Check permission of target module
 		if($obj->target_module_srl)
 		{
-			$module_info = getModel('module')->getModuleInfoByModuleSrl($obj->target_module_srl);
+			$module_info = ModuleModel::getModuleInfoByModuleSrl($obj->target_module_srl);
 			if (!$module_info->module_srl)
 			{
 				throw new Rhymix\Framework\Exceptions\InvalidRequest;
 			}
-			$module_grant = getModel('module')->getGrant($module_info, $logged_info);
+			$module_grant = ModuleModel::getGrant($module_info, $logged_info);
 			if (!$module_grant->manager)
 			{
 				throw new Rhymix\Framework\Exceptions\NotPermitted;
@@ -2864,7 +2828,7 @@ class documentController extends document
 		$obj->document_srl_list = array_unique(array_map('intval', $cart));
 		
 		// Set document list
-		$obj->document_list = getModel('document')->getDocuments($obj->document_srl_list, false, false);
+		$obj->document_list = DocumentModel::getDocuments($obj->document_srl_list, false, false);
 		if(empty($obj->document_list))
 		{
 			throw new Rhymix\Framework\Exceptions\InvalidRequest;
@@ -3015,18 +2979,17 @@ Content;
 		$target_module_srl = array_map('trim', explode(',', $target_module_srl));
 		$logged_info = Context::get('logged_info');
 		$module_srl = array();
-		$oModuleModel = getModel('module');
 		foreach ($target_module_srl as $srl)
 		{
 			if (!$srl) continue;
 			
-			$module_info = $oModuleModel->getModuleInfoByModuleSrl($srl);
+			$module_info = ModuleModel::getModuleInfoByModuleSrl($srl);
 			if (!$module_info->module_srl)
 			{
 				throw new Rhymix\Framework\Exceptions\InvalidRequest;
 			}
 			
-			$module_grant = $oModuleModel->getGrant($module_info, $logged_info);
+			$module_grant = ModuleModel::getGrant($module_info, $logged_info);
 			if (!$module_grant->manager)
 			{
 				throw new Rhymix\Framework\Exceptions\NotPermitted;
@@ -3085,8 +3048,7 @@ Content;
 			unset($obj->title_bold);
 		}
 		
-		$oDocumentModel = getModel('document');
-		$oDocument = $oDocumentModel->getDocument($obj->document_srl);
+		$oDocument = DocumentModel::getDocument($obj->document_srl);
 		
 		// Update if already exists
 		if($oDocument->isExists())
@@ -3108,7 +3070,7 @@ Content;
 		{
 			$output = $this->insertDocument($obj);
 			
-			$oDocument = $oDocumentModel->getDocument($output->get('document_srl'));
+			$oDocument = DocumentModel::getDocument($output->get('document_srl'));
 		}
 		
 		// Set the attachment to be invalid state
@@ -3140,15 +3102,13 @@ Content;
 
 		if(count($documentSrlList) > 0)
 		{
-			$oDocumentModel = getModel('document');
 			$columnList = array('document_srl', 'title', 'nick_name', 'status');
-			$documentList = $oDocumentModel->getDocuments($documentSrlList, $this->grant->is_admin, false, $columnList);
+			$documentList = DocumentModel::getDocuments($documentSrlList, $this->grant->is_admin, false, $columnList);
 		}
 		else
 		{
-			global $lang;
 			$documentList = array();
-			$this->setMessage($lang->no_documents);
+			$this->setMessage(lang(no_documents));
 		}
 		$oSecurity = new Security($documentList);
 		$oSecurity->encodeHTML('..variables.');
@@ -3201,7 +3161,6 @@ Content;
 			return;
 		}
 		
-		$oFileModel = getModel('file');
 		$document_srl_list = array_unique($document_srl_list);
 		
 		foreach($document_srl_list as $document_srl)
@@ -3213,14 +3172,14 @@ Content;
 			
 			$args = new stdClass;
 			$args->document_srl = $document_srl;
-			$args->uploaded_count = $oFileModel->getFilesCount($document_srl);
+			$args->uploaded_count = FileModel::getFilesCount($document_srl);
 			executeQuery('document.updateUploadedCount', $args);
 		}
 	}
 	
 	function triggerAfterDeleteFile($file)
 	{
-		$oDocument = getModel('document')->getDocument($file->upload_target_srl, false, false);
+		$oDocument = DocumentModel::getDocument($file->upload_target_srl, false, false);
 		if(!$oDocument->isExists())
 		{
 			return;
@@ -3236,8 +3195,7 @@ Content;
 	 */
 	function triggerCopyModuleExtraKeys(&$obj)
 	{
-		$oDocumentModel = getModel('document');
-		$documentExtraKeys = $oDocumentModel->getExtraKeys($obj->originModuleSrl);
+		$documentExtraKeys = DocumentModel::getExtraKeys($obj->originModuleSrl);
 
 		if(is_array($documentExtraKeys) && is_array($obj->moduleSrlList))
 		{
@@ -3254,8 +3212,7 @@ Content;
 
 	function triggerCopyModule(&$obj)
 	{
-		$oModuleModel = getModel('module');
-		$documentConfig = $oModuleModel->getModulePartConfig('document', $obj->originModuleSrl);
+		$documentConfig = ModuleModel::getModulePartConfig('document', $obj->originModuleSrl);
 
 		$oModuleController = getController('module');
 		if(is_array($obj->moduleSrlList))

--- a/modules/document/document.model.php
+++ b/modules/document/document.model.php
@@ -449,15 +449,13 @@ class documentModel extends document
 		// Members must be a possible feature
 		if($this->user->member_srl)
 		{
-			$oDocumentModel = getModel('document');
 			$columnList = array('document_srl', 'module_srl', 'member_srl', 'ipaddress');
-			$oDocument = $oDocumentModel->getDocument($document_srl, false, false, $columnList);
+			$oDocument = self::getDocument($document_srl, false, false, $columnList);
 			$module_srl = $oDocument->get('module_srl');
 			$member_srl = $oDocument->get('member_srl');
 			if(!$module_srl) throw new Rhymix\Framework\Exceptions\InvalidRequest;
 
-			$oModuleModel = getModel('module');
-			$document_config = $oModuleModel->getModulePartConfig('document',$module_srl);
+			$document_config = ModuleModel::getModulePartConfig('document',$module_srl);
 			$oDocumentisVoted = $oDocument->getMyVote();
 			if($document_config->use_vote_up!='N' && $member_srl!=$this->user->member_srl)
 			{
@@ -518,8 +516,7 @@ class documentModel extends document
 		// If you are managing to find posts by ip
 		if($this->user->is_admin == 'Y')
 		{
-			$oDocumentModel = getModel('document');
-			$oDocument = $oDocumentModel->getDocument($document_srl);	//before setting document recycle
+			$oDocument = self::getDocument($document_srl);	//before setting document recycle
 
 			if($oDocument->isExists())
 			{
@@ -837,8 +834,7 @@ class documentModel extends document
 	{
 		if($obj->mid)
 		{
-			$oModuleModel = getModel('module');
-			$obj->module_srl = $oModuleModel->getModuleSrlByMid($obj->mid);
+			$obj->module_srl = ModuleModel::getModuleSrlByMid($obj->mid);
 			unset($obj->mid);
 		}
 		// Module_srl passed the array may be a check whether the array
@@ -863,8 +859,7 @@ class documentModel extends document
 	{
 		if($obj->mid)
 		{
-			$oModuleModel = getModel('module');
-			$obj->module_srl = $oModuleModel->getModuleSrlByMid($obj->mid);
+			$obj->module_srl = ModuleModel::getModuleSrlByMid($obj->mid);
 			unset($obj->mid);
 		}
 		// Module_srl passed the array may be a check whether the array
@@ -949,8 +944,7 @@ class documentModel extends document
 		Context::loadJavascriptPlugin('ui.tree');
 
 		// Get a list of member groups
-		$oMemberModel = getModel('member');
-		$group_list = $oMemberModel->getGroups();
+		$group_list = MemberModel::getGroups();
 		Context::set('group_list', $group_list);
 
 		$security = new Security();
@@ -968,13 +962,11 @@ class documentModel extends document
 	 */
 	public function getDocumentCategoryTplInfo()
 	{
-		$oModuleModel = getModel('module');
-		$oMemberModel = getModel('member');
 		// Get information on the menu for the parameter settings
 		$module_srl = Context::get('module_srl');
-		$module_info = $oModuleModel->getModuleInfoByModuleSrl($module_srl);
+		$module_info = ModuleModel::getModuleInfoByModuleSrl($module_srl);
 		// Check permissions
-		$grant = $oModuleModel->getGrant($module_info, Context::get('logged_info'));
+		$grant = ModuleModel::getGrant($module_info, Context::get('logged_info'));
 		if(!$grant->manager) throw new Rhymix\Framework\Exceptions\NotPermitted;
 
 		$category_srl = Context::get('category_srl');
@@ -1168,14 +1160,12 @@ class documentModel extends document
 		$point = Context::get('point');
 		if($point != -1) $point = 1;
 
-		$oDocumentModel = getModel('document');
 		$columnList = array('document_srl', 'module_srl');
-		$oDocument = $oDocumentModel->getDocument($document_srl, false, false, $columnList);
+		$oDocument = self::getDocument($document_srl, false, false, $columnList);
 		$module_srl = $oDocument->get('module_srl');
 		if(!$module_srl) throw new Rhymix\Framework\Exceptions\InvalidRequest;
 
-		$oModuleModel = getModel('module');
-		$document_config = $oModuleModel->getModulePartConfig('document',$module_srl);
+		$document_config = ModuleModel::getModulePartConfig('document',$module_srl);
 		if($point == -1)
 		{
 			if($document_config->use_vote_down!='S') throw new Rhymix\Framework\Exceptions\FeatureDisabled;
@@ -1192,12 +1182,11 @@ class documentModel extends document
 		$output = executeQueryArray('document.getVotedMemberList',$args);
 		if(!$output->toBool()) return $output;
 
-		$oMemberModel = getModel('member');
 		if($output->data)
 		{
 			foreach($output->data as $k => $d)
 			{
-				$profile_image = $oMemberModel->getProfileImage($d->member_srl);
+				$profile_image = MemberModel::getProfileImage($d->member_srl);
 				$output->data[$k]->src = $profile_image->src;
 			}
 		}
@@ -1296,7 +1285,7 @@ class documentModel extends document
 		// get directly module_srl by mid
 		if($searchOpt->mid)
 		{
-			$args->module_srl = getModel('module')->getModuleSrlByMid($searchOpt->mid);
+			$args->module_srl = ModuleModel::getModuleSrlByMid($searchOpt->mid);
 		}
 		
 		// add subcategories
@@ -1398,8 +1387,8 @@ class documentModel extends document
 			// exclude secret documents in searching if current user does not have privilege
 			if(!$args->member_srl || !Context::get('is_logged') || $args->member_srl !== Context::get('logged_info')->member_srl)
 			{
-				$module_info = getModel('module')->getModuleInfoByModuleSrl($args->module_srl);
-				if(!getModel('module')->getGrant($module_info, Context::get('logged_info'))->manager)
+				$module_info = ModuleModel::getModuleInfoByModuleSrl($args->module_srl);
+				if(!ModuleModel::getGrant($module_info, Context::get('logged_info'))->manager)
 				{
 					$args->comment_is_secret = 'N';
 					$args->statusList = array(self::getConfigStatus('public'));

--- a/modules/document/document.model.php
+++ b/modules/document/document.model.php
@@ -10,7 +10,7 @@
  */
 class documentModel extends document
 {
-	private $documentConfig = NULL;
+	protected static $_config;
 
 	/**
 	 * Initialization
@@ -25,7 +25,7 @@ class documentModel extends document
 	 * @param int $document_srl
 	 * @return void
 	 */
-	function isGranted($document_srl)
+	public static function isGranted($document_srl)
 	{
 		return $_SESSION['granted_document'][$document_srl];
 	}
@@ -35,7 +35,7 @@ class documentModel extends document
 	 * @param array $document_srls
 	 * @return object
 	 */
-	function getDocumentExtraVarsFromDB($document_srls)
+	public static function getDocumentExtraVarsFromDB($document_srls)
 	{
 		$args = new stdClass;
 		$args->document_srl = $document_srls;
@@ -46,7 +46,7 @@ class documentModel extends document
 	 * Extra variables for each article will not be processed bulk select and apply the macro city
 	 * @return void
 	 */
-	function setToAllDocumentExtraVars()
+	public static function setToAllDocumentExtraVars()
 	{
 		// get document list
 		$_document_list = &$GLOBALS['XE_DOCUMENT_LIST'];
@@ -78,7 +78,7 @@ class documentModel extends document
 		
 		// get extra values of documents
 		$extra_values = array();
-		$output = $this->getDocumentExtraVarsFromDB($document_srls);
+		$output = self::getDocumentExtraVarsFromDB($document_srls);
 		foreach($output->data as $key => $val)
 		{
 			if(strval($val->value) === '')
@@ -104,7 +104,7 @@ class documentModel extends document
 				// get extra keys of the module
 				if(!isset($module_extra_keys[$module_srl]))
 				{
-					$module_extra_keys[$module_srl] = $this->getExtraKeys($module_srl);
+					$module_extra_keys[$module_srl] = self::getExtraKeys($module_srl);
 				}
 				
 				// set extra variables of the document
@@ -155,7 +155,7 @@ class documentModel extends document
 	 * @param array $columnList
 	 * @return documentItem
 	 */
-	function getDocument($document_srl = 0, $is_admin = false, $load_extra_vars = true, $columnList = array())
+	public static function getDocument($document_srl = 0, $is_admin = false, $load_extra_vars = true, $columnList = array())
 	{
 		if(!$document_srl)
 		{
@@ -185,7 +185,7 @@ class documentModel extends document
 	 * @param array $columnList
 	 * @return array value type is documentItem
 	 */
-	function getDocuments($document_srls, $is_admin = false, $load_extra_vars = true, $columnList = array())
+	public static function getDocuments($document_srls, $is_admin = false, $load_extra_vars = true, $columnList = array())
 	{
 		if (!is_array($document_srls))
 		{
@@ -220,7 +220,7 @@ class documentModel extends document
 		
 		if($load_extra_vars)
 		{
-			$this->setToAllDocumentExtraVars();
+			self::setToAllDocumentExtraVars();
 		}
 		
 		return $documents;
@@ -234,9 +234,9 @@ class documentModel extends document
 	 * @param array $columnList
 	 * @return Object
 	 */
-	function getDocumentList($obj, $except_notice = false, $load_extra_vars = true, $columnList = array())
+	public static function getDocumentList($obj, $except_notice = false, $load_extra_vars = true, $columnList = array())
 	{
-		$sort_check = $this->_setSortIndex($obj, $load_extra_vars);
+		$sort_check = self::_setSortIndex($obj, $load_extra_vars);
 		$obj->sort_index = $sort_check->sort_index;
 		$obj->isExtraVars = $sort_check->isExtraVars;
 		$obj->except_notice = $except_notice;
@@ -259,7 +259,7 @@ class documentModel extends document
 		// execute query
 		else
 		{
-			$this->_setSearchOption($obj, $args, $query_id, $use_division);
+			self::_setSearchOption($obj, $args, $query_id, $use_division);
 			$output = executeQueryArray($query_id, $args, $args->columnList);
 		}
 		
@@ -287,7 +287,7 @@ class documentModel extends document
 		
 		if($load_extra_vars)
 		{
-			$this->setToAllDocumentExtraVars();
+			self::setToAllDocumentExtraVars();
 		}
 		
 		// Call trigger (after)
@@ -302,7 +302,7 @@ class documentModel extends document
 	 * @param array $columnList
 	 * @return object|void
 	 */
-	function getNoticeList($obj, $columnList = array())
+	public static function getNoticeList($obj, $columnList = array())
 	{
 		$args = new stdClass();
 		$args->module_srl = $obj->module_srl;
@@ -324,7 +324,7 @@ class documentModel extends document
 			
 			$output->data[$attribute->document_srl] = $GLOBALS['XE_DOCUMENT_LIST'][$attribute->document_srl];
 		}
-		$this->setToAllDocumentExtraVars();
+		self::setToAllDocumentExtraVars();
 		
 		return $output;
 	}
@@ -335,7 +335,7 @@ class documentModel extends document
 	 * @param int $module_srl
 	 * @return array
 	 */
-	function getExtraKeys($module_srl)
+	public static function getExtraKeys($module_srl)
 	{
 		if(!isset($GLOBALS['XE_EXTRA_KEYS'][$module_srl]))
 		{
@@ -414,12 +414,12 @@ class documentModel extends document
 	 * @param int $document_srl
 	 * @return array
 	 */
-	function getExtraVars($module_srl, $document_srl)
+	public static function getExtraVars($module_srl, $document_srl)
 	{
 		if(!isset($GLOBALS['XE_EXTRA_VARS'][$document_srl]))
 		{
-			$this->getDocument($document_srl);
-			$this->setToAllDocumentExtraVars();
+			self::getDocument($document_srl);
+			self::setToAllDocumentExtraVars();
 		}
 		if(empty($GLOBALS['XE_EXTRA_VARS'][$document_srl]) || !is_array($GLOBALS['XE_EXTRA_VARS'][$document_srl]))
 		{
@@ -436,7 +436,7 @@ class documentModel extends document
 	 * Printing, scrap, recommendations and negative, reported the Add Features
 	 * @return void
 	 */
-	function getDocumentMenu()
+	public function getDocumentMenu()
 	{
 		// Post number and the current login information requested Wanted
 		$document_srl = Context::get('target_srl');
@@ -548,7 +548,7 @@ class documentModel extends document
 	 * @param object $search_obj
 	 * @return int
 	 */
-	function getDocumentCount($module_srl, $search_obj = NULL)
+	public static function getDocumentCount($module_srl, $search_obj = NULL)
 	{
 		if(is_null($search_obj)) $search_obj = new stdClass();
 		$search_obj->module_srl = $module_srl;
@@ -564,7 +564,7 @@ class documentModel extends document
 	 * @param object $search_obj
 	 * @return array
 	 */
-	function getDocumentCountByGroupStatus($search_obj = NULL)
+	public static function getDocumentCountByGroupStatus($search_obj = NULL)
 	{
 		$output = executeQuery('document.getDocumentCountByGroupStatus', $search_obj);
 		if(!$output->toBool()) return array();
@@ -572,7 +572,7 @@ class documentModel extends document
 		return $output->data;
 	}
 
-	function getDocumentExtraVarsCount($module_srl, $search_obj = NULL)
+	public static function getDocumentExtraVarsCount($module_srl, $search_obj = NULL)
 	{
 		// Additional search options
 		$args = new stdClass();
@@ -596,13 +596,13 @@ class documentModel extends document
 	 * @param object $opt
 	 * @return int
 	 */
-	function getDocumentPage($oDocument, $opt)
+	public static function getDocumentPage($oDocument, $opt)
 	{
-		$sort_check = $this->_setSortIndex($opt);
+		$sort_check = self::_setSortIndex($opt);
 		$opt->sort_index = $sort_check->sort_index;
 		$opt->isExtraVars = $sort_check->isExtraVars;
 
-		$this->_setSearchOption($opt, $args, $query_id, $use_division);
+		self::_setSearchOption($opt, $args, $query_id, $use_division);
 
 		if($sort_check->isExtraVars || !$opt->list_count)
 		{
@@ -653,7 +653,7 @@ class documentModel extends document
 	 * @param array $columnList
 	 * @return object
 	 */
-	function getCategory($category_srl, $columnList = array())
+	public static function getCategory($category_srl, $columnList = array())
 	{
 		$args =new stdClass();
 		$args->category_srl = $category_srl;
@@ -681,7 +681,7 @@ class documentModel extends document
 	 * @param int $category_srl
 	 * @return bool
 	 */
-	function getCategoryChlidCount($category_srl)
+	public static function getCategoryChlidCount($category_srl)
 	{
 		$args = new stdClass();
 		$args->category_srl = $category_srl;
@@ -697,7 +697,7 @@ class documentModel extends document
 	 * @param array $columnList
 	 * @return array
 	 */
-	function getCategoryList($module_srl, $columnList = array())
+	public static function getCategoryList($module_srl, $columnList = array())
 	{
 		// Category of the target module file swollen
 		$module_srl = intval($module_srl);
@@ -713,7 +713,7 @@ class documentModel extends document
 
 		// Cleanup of category
 		$document_category = array();
-		$this->_arrangeCategory($document_category, $menu->list, 0);
+		self::_arrangeCategory($document_category, $menu->list, 0);
 		return $document_category;
 	}
 
@@ -724,7 +724,7 @@ class documentModel extends document
 	 * @param int $depth
 	 * @return void
 	 */
-	function _arrangeCategory(&$document_category, $list, $depth)
+	public static function _arrangeCategory(&$document_category, $list, $depth)
 	{
 		if(!countobj($list)) return;
 		$idx = 0;
@@ -773,7 +773,7 @@ class documentModel extends document
 
 			$document_category[$key] = $obj;
 
-			if(count($val['list'])) $this->_arrangeCategory($document_category, $val['list'], $depth+1);
+			if(count($val['list'])) self::_arrangeCategory($document_category, $val['list'], $depth+1);
 		}
 		$document_category[$list_order[0]]->first = true;
 		$document_category[$list_order[count($list_order)-1]]->last = true;
@@ -785,7 +785,7 @@ class documentModel extends document
 	 * @param int $category_srl
 	 * @return int
 	 */
-	function getCategoryDocumentCount($module_srl, $category_srl)
+	public static function getCategoryDocumentCount($module_srl, $category_srl)
 	{
 		$args = new stdClass;
 		$args->module_srl = $module_srl;
@@ -799,7 +799,7 @@ class documentModel extends document
 	 * @param int $module_srl
 	 * @return string
 	 */
-	function getCategoryXmlFile($module_srl)
+	public static function getCategoryXmlFile($module_srl)
 	{
 		$module_srl = intval($module_srl);
 		$xml_file = sprintf('files/cache/document_category/%d.xml.php',$module_srl);
@@ -816,7 +816,7 @@ class documentModel extends document
 	 * @param int $module_srl
 	 * @return string
 	 */
-	function getCategoryPhpFile($module_srl)
+	public static function getCategoryPhpFile($module_srl)
 	{
 		$module_srl = intval($module_srl);
 		$php_file = sprintf('files/cache/document_category/%d.php',$module_srl);
@@ -833,7 +833,7 @@ class documentModel extends document
 	 * @param object $obj
 	 * @return object
 	 */
-	function getMonthlyArchivedList($obj)
+	public static function getMonthlyArchivedList($obj)
 	{
 		if($obj->mid)
 		{
@@ -859,7 +859,7 @@ class documentModel extends document
 	 * @param object $obj
 	 * @return object
 	 */
-	function getDailyArchivedList($obj)
+	public static function getDailyArchivedList($obj)
 	{
 		if($obj->mid)
 		{
@@ -885,11 +885,11 @@ class documentModel extends document
 	 * Get a list for a particular module
 	 * @return void|Object
 	 */
-	function getDocumentCategories()
+	public function getDocumentCategories()
 	{
 		if(!Context::get('is_logged')) throw new Rhymix\Framework\Exceptions\NotPermitted;
 		$module_srl = intval(Context::get('module_srl'));
-		$categories= $this->getCategoryList($module_srl);
+		$categories= self::getCategoryList($module_srl);
 		$lang = Context::get('lang');
 		// No additional category
 		$output = "0,0,{$lang->none_category}\n";
@@ -907,20 +907,13 @@ class documentModel extends document
 	 * Wanted to set document information
 	 * @return object
 	 */
-	function getDocumentConfig()
+	public static function getDocumentConfig()
 	{
-		if ($this->documentConfig === NULL)
+		if (self::$_config === null)
 		{
-			$oModuleModel = getModel('module');
-			$config = $oModuleModel->getModuleConfig('document');
-
-			if (!$config)
-			{
-				$config = new stdClass();
-			}
-			$this->documentConfig = $config;
+			self::$_config = ModuleModel::getModuleConfig('document') ?: new stdClass;;
 		}
-		return $this->documentConfig;
+		return self::$_config;
 	}
 
 	/**
@@ -929,10 +922,10 @@ class documentModel extends document
 	 * @param int $module_srl
 	 * @return string
 	 */
-	function getExtraVarsHTML($module_srl)
+	public function getExtraVarsHTML($module_srl)
 	{
 		// Bringing existing extra_keys
-		$extra_keys = $this->getExtraKeys($module_srl);
+		$extra_keys = self::getExtraKeys($module_srl);
 		Context::set('extra_keys', $extra_keys);
 		$security = new Security();
 		$security->encodeHTML('extra_keys..', 'selected_var_idx');
@@ -947,9 +940,9 @@ class documentModel extends document
 	 * @param int $module_srl
 	 * @return string
 	 */
-	function getCategoryHTML($module_srl)
+	public function getCategoryHTML($module_srl)
 	{
-		$category_xml_file = $this->getCategoryXmlFile($module_srl);
+		$category_xml_file = self::getCategoryXmlFile($module_srl);
 
 		Context::set('category_xml_file', $category_xml_file);
 
@@ -973,7 +966,7 @@ class documentModel extends document
 	 * Manager on the page to add information about a particular menu from the server after compiling tpl compiled a direct return html
 	 * @return void|Object
 	 */
-	function getDocumentCategoryTplInfo()
+	public function getDocumentCategoryTplInfo()
 	{
 		$oModuleModel = getModel('module');
 		$oMemberModel = getModel('member');
@@ -985,7 +978,7 @@ class documentModel extends document
 		if(!$grant->manager) throw new Rhymix\Framework\Exceptions\NotPermitted;
 
 		$category_srl = Context::get('category_srl');
-		$category_info = $this->getCategory($category_srl);
+		$category_info = self::getCategory($category_srl);
 		if(!$category_info)
 		{
 			throw new Rhymix\Framework\Exceptions\InvalidRequest;
@@ -1000,7 +993,7 @@ class documentModel extends document
 	 * @param string $alias
 	 * @return int|void
 	 */
-	function getDocumentSrlByAlias($mid, $alias)
+	public static function getDocumentSrlByAlias($mid, $alias)
 	{
 		if(!$mid || !$alias) return null;
 		$site_module_info = Context::get('site_module_info');
@@ -1019,7 +1012,7 @@ class documentModel extends document
 	 * @param string $title
 	 * @return int|void
 	 */
-	function getDocumentSrlByTitle($module_srl, $title)
+	public static function getDocumentSrlByTitle($module_srl, $title)
 	{
 		if(!$module_srl || !$title) return null;
 		$args = new stdClass;
@@ -1039,7 +1032,7 @@ class documentModel extends document
 	 * @param int $document_srl
 	 * @return string|void
 	 */
-	function getAlias($document_srl)
+	public static function getAlias($document_srl)
 	{
 		if(!$document_srl) return null;
 		$args = new stdClass;
@@ -1057,7 +1050,7 @@ class documentModel extends document
 	 * @param int $page
 	 * @return object
 	 */
-	function getHistories($document_srl, $list_count, $page)
+	public static function getHistories($document_srl, $list_count, $page)
 	{
 		$args = new stdClass;
 		$args->list_count = $list_count;
@@ -1072,7 +1065,7 @@ class documentModel extends document
 	 * @param int $history_srl
 	 * @return object
 	 */
-	function getHistory($history_srl)
+	public static function getHistory($history_srl)
 	{
 		$args = new stdClass;
 		$args->history_srl = $history_srl;
@@ -1085,7 +1078,7 @@ class documentModel extends document
 	 * @param object $obj
 	 * @return object
 	 */
-	function getTrashList($obj)
+	public static function getTrashList($obj)
 	{
 		// Variable check
 		$args = new stdClass;
@@ -1127,8 +1120,8 @@ class documentModel extends document
 					break;
 				case 'is_notice' :
 				case 'is_secret' :
-					if($search_keyword=='N') $args->statusList = array($this->getConfigStatus('public'));
-					elseif($search_keyword=='Y') $args->statusList = array($this->getConfigStatus('secret'));
+					if($search_keyword=='N') $args->statusList = array(self::getConfigStatus('public'));
+					elseif($search_keyword=='Y') $args->statusList = array(self::getConfigStatus('secret'));
 					break;
 				case 'member_srl' :
 				case 'readed_count' :
@@ -1166,7 +1159,7 @@ class documentModel extends document
 	 * vote up, vote down member list in Document View page
 	 * @return void|Object
 	 */
-	function getDocumentVotedMemberList()
+	public function getDocumentVotedMemberList()
 	{
 		$args = new stdClass;
 		$document_srl = Context::get('document_srl');
@@ -1216,12 +1209,17 @@ class documentModel extends document
 	 * Return status name list
 	 * @return array
 	 */
-	function getStatusNameList()
+	public static function getStatusNameList()
 	{
 		global $lang;
 		if(!isset($lang->status_name_list))
-			return array_flip($this->getStatusList());
-		else return $lang->status_name_list;
+		{
+			return array_flip(self::getStatusList());
+		}
+		else
+		{
+			return $lang->status_name_list;
+		}
 	}
 	
 	/**
@@ -1230,7 +1228,7 @@ class documentModel extends document
 	 * @param bool $load_extra_vars
 	 * @return object
 	 */
-	function _setSortIndex($obj, $load_extra_vars = true)
+	public static function _setSortIndex($obj, $load_extra_vars = true)
 	{
 		$args = new stdClass;
 		$args->sort_index = $obj->sort_index;
@@ -1244,7 +1242,7 @@ class documentModel extends document
 		}
 		
 		// check it can use extra variable
-		if(!$load_extra_vars || !$extra_keys = $this->getExtraKeys($obj->module_srl))
+		if(!$load_extra_vars || !$extra_keys = self::getExtraKeys($obj->module_srl))
 		{
 			$args->sort_index = 'list_order';
 			return $args;
@@ -1277,7 +1275,7 @@ class documentModel extends document
 	 * @param bool $use_division
 	 * @return void
 	 */
-	function _setSearchOption($searchOpt, &$args, &$query_id, &$use_division)
+	public static function _setSearchOption($searchOpt, &$args, &$query_id, &$use_division)
 	{
 		$args = new stdClass;
 		$args->module_srl = $searchOpt->module_srl;
@@ -1292,7 +1290,7 @@ class documentModel extends document
 		$args->start_date = $searchOpt->start_date ?: null;
 		$args->end_date = $searchOpt->end_date ?: null;
 		$args->s_is_notice = $searchOpt->except_notice ? 'N' : null;
-		$args->statusList = $searchOpt->statusList ?: array($this->getConfigStatus('public'), $this->getConfigStatus('secret'));
+		$args->statusList = $searchOpt->statusList ?: array(self::getConfigStatus('public'), self::getConfigStatus('secret'));
 		$args->columnList = $searchOpt->columnList ?: array();
 		
 		// get directly module_srl by mid
@@ -1304,7 +1302,7 @@ class documentModel extends document
 		// add subcategories
 		if($args->category_srl)
 		{
-			$category_list = $this->getCategoryList($args->module_srl);
+			$category_list = self::getCategoryList($args->module_srl);
 			if(isset($category_list[$args->category_srl]))
 			{
 				$categories = $category_list[$args->category_srl]->childs;
@@ -1376,15 +1374,15 @@ class documentModel extends document
 				case 'is_secret' :
 					if($search_keyword == 'N')
 					{
-						$args->statusList = array($this->getConfigStatus('public'));
+						$args->statusList = array(self::getConfigStatus('public'));
 					}
 					elseif($search_keyword == 'Y')
 					{
-						$args->statusList = array($this->getConfigStatus('secret'));
+						$args->statusList = array(self::getConfigStatus('secret'));
 					}
 					elseif($search_keyword == 'temp')
 					{
-						$args->statusList = array($this->getConfigStatus('temp'));
+						$args->statusList = array(self::getConfigStatus('temp'));
 					}
 					break;
 				default :
@@ -1404,7 +1402,7 @@ class documentModel extends document
 				if(!getModel('module')->getGrant($module_info, Context::get('logged_info'))->manager)
 				{
 					$args->comment_is_secret = 'N';
-					$args->statusList = array($this->getConfigStatus('public'));
+					$args->statusList = array(self::getConfigStatus('public'));
 				}
 			}
 		}
@@ -1484,7 +1482,7 @@ class documentModel extends document
 	 * @param int $member_srl
 	 * @return int
 	 */
-	function getDocumentCountByMemberSrl($member_srl)
+	public static function getDocumentCountByMemberSrl($member_srl)
 	{
 		$args = new stdClass();
 		$args->member_srl = $member_srl;
@@ -1501,7 +1499,7 @@ class documentModel extends document
 	 * @param int $count
 	 * @return object
 	 */
-	function getDocumentListByMemberSrl($member_srl, $columnList = array(), $page = 0, $is_admin = FALSE, $count = 0 )
+	public static function getDocumentListByMemberSrl($member_srl, $columnList = array(), $page = 0, $is_admin = FALSE, $count = 0)
 	{
 		$args = new stdClass();
 		$args->member_srl = $member_srl;
@@ -1515,7 +1513,7 @@ class documentModel extends document
 		return $document_list;	
 	}
 
-	function getDocumentUpdateLog($document_srl)
+	public static function getDocumentUpdateLog($document_srl)
 	{
 		$args = new stdClass();
 		$args->document_srl = $document_srl;
@@ -1524,17 +1522,17 @@ class documentModel extends document
 		return $output;
 	}
 
-	function getUpdateLog($update_id)
+	public static function getUpdateLog($update_id)
 	{
 		$args = new stdClass();
 		$args->update_id = $update_id;
 		$output = exeCuteQuery('document.getUpdateLog', $args);
-		$updage_log = $output->data;
+		$update_log = $output->data;
 
-		return $updage_log;
+		return $update_log;
 	}
 
-	function getUpdateLogAdminisExists($document_srl = null)
+	public static function getUpdateLogAdminisExists($document_srl = null)
 	{
 		if($document_srl == null)
 		{
@@ -1553,9 +1551,9 @@ class documentModel extends document
 		return false;
 	}
 
-	function getDocumentExtraImagePath()
+	public static function getDocumentExtraImagePath()
 	{
-		$documentConfig = getModel('document')->getDocumentConfig();
+		$documentConfig = self::getDocumentConfig();
 		if(Mobile::isFromMobilePhone())
 		{
 			$iconSkin = $documentConfig->micons;

--- a/modules/document/document.view.php
+++ b/modules/document/document.view.php
@@ -28,14 +28,8 @@ class documentView extends document
 		// Bring a list of variables needed to implement
 		$document_srl = Context::get('document_srl');
 
-		// module_info not use in UI
-		//$oModuleModel = getModel('module');
-		//$module_info = $oModuleModel->getModuleInfoByDocumentSrl($document_srl);
-
-		// Create the document object. If the document module of basic data structures, write it all works .. -_-;
-		$oDocumentModel = getModel('document');
 		// Creates an object for displaying the selected document
-		$oDocument = $oDocumentModel->getDocument($document_srl, $this->grant->manager);
+		$oDocument = DocumentModel::getDocument($document_srl, $this->grant->manager);
 		if(!$oDocument->isExists()) throw new Rhymix\Framework\Exceptions\TargetNotFound;
 		// Check permissions
 		if(!$oDocument->isAccessible()) throw new Rhymix\Framework\Exceptions\NotPermitted;
@@ -71,7 +65,7 @@ class documentView extends document
 		// Editor converter
 		$obj = new stdClass;
 		$obj->content = $content;
-		$obj->module_srl = getModel('module')->getModuleInfoByMid(Context::get('mid'))->module_srl;
+		$obj->module_srl = ModuleModel::getModuleInfoByMid(Context::get('mid'))->module_srl;
 		$content = getModel('editor')->converter($obj, 'document');
 		$content = sprintf('<div class="document_0_%d xe_content">%s</div>', Context::get('logged_info')->member_srl, $content);
 		Context::set('content', $content);
@@ -102,8 +96,7 @@ class documentView extends document
 
 		if(count($document_srl_list))
 		{
-			$oDocumentModel = getModel('document');
-			$document_list = $oDocumentModel->getDocuments($document_srl_list, $this->grant->is_admin);
+			$document_list = DocumentModel::getDocuments($document_srl_list, $this->grant->is_admin);
 			Context::set('document_list', $document_list);
 		}
 		else
@@ -113,7 +106,7 @@ class documentView extends document
 
 		$module_srl = intval(Context::get('module_srl'));
 		Context::set('module_srl',$module_srl);
-		$module_info = getModel('module')->getModuleInfoByModuleSrl($module_srl);
+		$module_info = ModuleModel::getModuleInfoByModuleSrl($module_srl);
 		Context::set('mid',$module_info->mid);
 		Context::set('browser_title',$module_info->browser_title);
 
@@ -144,10 +137,9 @@ class documentView extends document
 			if(!$current_module_srl) return new BaseObject();
 		}
 
-		$oModuleModel = getModel('module');
 		if($current_module_srl)
 		{
-			$document_config = $oModuleModel->getModulePartConfig('document', $current_module_srl);
+			$document_config = ModuleModel::getModulePartConfig('document', $current_module_srl);
 		}
 		if(!$document_config)
 		{
@@ -171,9 +163,8 @@ class documentView extends document
 	{
 		$this->setLayoutFile('popup_layout');
 
-		$oMemberModel = getModel('member');
 		// A message appears if the user is not logged-in
-		if(!$oMemberModel->isLogged())
+		if(!$this->user->member_srl)
 		{
 			throw new Rhymix\Framework\Exceptions\MustLogin;
 		}
@@ -185,8 +176,7 @@ class documentView extends document
 		$args->page = (int)Context::get('page');
 		$args->list_count = 10;
 
-		$oDocumentModel = getModel('document');
-		$output = $oDocumentModel->getDocumentList($args, true);
+		$output = DocumentModel::getDocumentList($args, true);
 		Context::set('total_count', $output->total_count);
 		Context::set('total_page', $output->total_page);
 		Context::set('page', $output->page);
@@ -206,17 +196,14 @@ class documentView extends document
 		$this->setLayoutFile('popup_layout');
 		$document_srl = Context::get('target_srl');
 
-		$oMemberModel = getModel('member');
 		// A message appears if the user is not logged-in
-		if(!$oMemberModel->isLogged())
+		if(!$this->user->member_srl)
 		{
 			throw new Rhymix\Framework\Exceptions\MustLogin;
 		}
 
-		// Create the document object. If the document module of basic data structures, write it all works .. -_-;
-		$oDocumentModel = getModel('document');
 		// Creates an object for displaying the selected document
-		$oDocument = $oDocumentModel->getDocument($document_srl, $this->grant->manager, FALSE);
+		$oDocument = DocumentModel::getDocument($document_srl, $this->grant->manager, FALSE);
 		if(!$oDocument->isExists())
 		{
 			throw new Rhymix\Framework\Exceptions\TargetNotFound;

--- a/modules/file/file.model.php
+++ b/modules/file/file.model.php
@@ -10,7 +10,7 @@ class fileModel extends file
 	 * Initialization
 	 * @return void
 	 */
-	function init()
+	public function init()
 	{
 	}
 
@@ -22,7 +22,7 @@ class fileModel extends file
 	 *
 	 * @return void
 	 */
-	function getFileList()
+	public function getFileList()
 	{
 		$file_list = [];
 		$attached_size = 0;
@@ -77,7 +77,7 @@ class fileModel extends file
 			}
 			
 			// Set file list
-			foreach($this->getFiles($upload_target_srl) as $file_info)
+			foreach(self::getFiles($upload_target_srl) as $file_info)
 			{
 				$obj = new stdClass;
 				$obj->file_srl = $file_info->file_srl;
@@ -90,9 +90,9 @@ class fileModel extends file
 				$obj->direct_download = $file_info->direct_download;
 				$obj->cover_image = ($file_info->cover_image === 'Y') ? true : false;
 				$obj->download_url = $file_info->download_url;
-				if($obj->direct_download === 'Y' && $this->isDownloadable($file_info))
+				if($obj->direct_download === 'Y' && self::isDownloadable($file_info))
 				{
-					$obj->download_url = $this->getDirectFileUrl($file_info->uploaded_filename);
+					$obj->download_url = self::getDirectFileUrl($file_info->uploaded_filename);
 				}
 				
 				$file_list[] = $obj;
@@ -107,7 +107,7 @@ class fileModel extends file
 		$this->add('upload_target_srl', $upload_target_srl);
 		
 		// Set upload config
-		$upload_config = $this->getUploadConfig();
+		$upload_config = self::getUploadConfig();
 		if($this->user->isAdmin())
 		{
 			$this->add('allowed_filesize', sprintf('%s (%s)', lang('common.unlimited'), lang('common.admin')));
@@ -123,7 +123,7 @@ class fileModel extends file
 		
 		// for compatibility
 		$this->add('allowed_filetypes', $upload_config->allowed_filetypes);
-		$this->add('upload_status', $this->getUploadStatus($attached_size));
+		$this->add('upload_status', self::getUploadStatus($attached_size));
 		$this->add('left_size', $upload_config->allowed_attach_size * 1024 * 1024 - $attached_size);
 	}
 	
@@ -134,13 +134,13 @@ class fileModel extends file
 	 * @param object $member_info
 	 * @return bool
 	 */
-	function isDownloadable($file_info, $member_info = null)
+	public static function isDownloadable($file_info, $member_info = null)
 	{
 		if(!$member_info)
 		{
-			$member_info = $this->user;
+			$member_info = Rhymix\Framework\Session::getMemberInfo();
 		}
-		if($this->isDeletable($file_info, $member_info))
+		if(self::isDeletable($file_info, $member_info))
 		{
 			return true;
 		}
@@ -152,7 +152,7 @@ class fileModel extends file
 		}
 		
 		// Check download groups
-		$config = $this->getFileConfig($file_info->module_srl);
+		$config = self::getFileConfig($file_info->module_srl);
 		if($config->download_groups)
 		{
 			if(empty($member_info->member_srl))
@@ -188,11 +188,11 @@ class fileModel extends file
 	 * @param object $member_info
 	 * @return bool
 	 */
-	function isDeletable($file_info, $member_info = null)
+	public static function isDeletable($file_info, $member_info = null)
 	{
 		if(!$member_info)
 		{
-			$member_info = $this->user;
+			$member_info = Rhymix\Framework\Session::getMemberInfo();
 		}
 		if($member_info->is_admin === 'Y' || $member_info->member_srl == $file_info->member_srl)
 		{
@@ -239,7 +239,7 @@ class fileModel extends file
 	 * @param int $upload_target_srl The sequence to get a number of files
 	 * @return int Returns a number of files
 	 */
-	function getFilesCount($upload_target_srl)
+	public static function getFilesCount($upload_target_srl)
 	{
 		$args = new stdClass();
 		$args->upload_target_srl = $upload_target_srl;
@@ -252,11 +252,12 @@ class fileModel extends file
 	 *
 	 * @param int $file_srl The sequence of file to get url
 	 * @param string $sid
+	 * @param int $module_srl
 	 * @return string Returns a url
 	 */
-	function getDownloadUrl($file_srl, $sid, $module_srl="")
+	public static function getDownloadUrl($file_srl, $sid, $module_srl = 0)
 	{
-		return sprintf('?module=%s&amp;act=%s&amp;file_srl=%s&amp;sid=%s&amp;module_srl=%s', 'file', 'procFileDownload', $file_srl, $sid, $module_srl);
+		return sprintf('?module=%s&amp;act=%s&amp;file_srl=%s&amp;sid=%s&amp;module_srl=%d', 'file', 'procFileDownload', $file_srl, $sid, $module_srl);
 	}
 	
 	/**
@@ -265,7 +266,7 @@ class fileModel extends file
 	 * @param string $path
 	 * @return string
 	 */
-	function getDirectFileUrl($path)
+	public static function getDirectFileUrl($path)
 	{
 		if(dirname($_SERVER['SCRIPT_NAME']) == '/' || dirname($_SERVER['SCRIPT_NAME']) == '\\')
 		{
@@ -281,13 +282,12 @@ class fileModel extends file
 	 * @param int $module_srl If set this, returns specific module's configuration. Otherwise returns global configuration.
 	 * @return object Returns configuration.
 	 */
-	function getFileConfig($module_srl = null)
+	public static function getFileConfig($module_srl = null)
 	{
-		$oModuleModel = getModel('module');
-		$config = clone $oModuleModel->getModuleConfig('file');
+		$config = clone ModuleModel::getModuleConfig('file');
 		if($module_srl)
 		{
-			$module_config = $oModuleModel->getModulePartConfig('file', $module_srl);
+			$module_config = ModuleModel::getModulePartConfig('file', $module_srl);
 			foreach((array)$module_config as $key => $value)
 			{
 				$config->$key = $value;
@@ -334,7 +334,7 @@ class fileModel extends file
 	 * @param array $columnList The list of columns to get from DB
 	 * @return Object|object|array If error returns an instance of Object. If result set is one returns a object that contins file information. If result set is more than one returns array of object.
 	 */
-	function getFile($file_srl, $columnList = array())
+	public static function getFile($file_srl, $columnList = array())
 	{
 		$args = new stdClass();
 		$args->file_srl = $file_srl;
@@ -345,7 +345,7 @@ class fileModel extends file
 		if(count($output->data) == 1)
 		{
 			$file = $output->data[0];
-			$file->download_url = $this->getDownloadUrl($file->file_srl, $file->sid, $file->module_srl);
+			$file->download_url = self::getDownloadUrl($file->file_srl, $file->sid, $file->module_srl);
 
 			return $file;
 		}
@@ -358,7 +358,7 @@ class fileModel extends file
 				foreach($output->data as $key=>$value)
 				{
 					$file = $value;
-					$file->download_url = $this->getDownloadUrl($file->file_srl, $file->sid, $file->module_srl);
+					$file->download_url = self::getDownloadUrl($file->file_srl, $file->sid, $file->module_srl);
 					$fileList[] = $file;
 				}
 			}
@@ -374,7 +374,7 @@ class fileModel extends file
 	 * @param string $sortIndex The column that used as sort index
 	 * @return array Returns array of object that contains file information. If no result returns null.
 	 */
-	function getFiles($upload_target_srl, $columnList = array(), $sortIndex = 'file_srl', $ckValid = false)
+	public static function getFiles($upload_target_srl, $columnList = array(), $sortIndex = 'file_srl', $ckValid = false)
 	{
 		$args = new stdClass();
 		$args->upload_target_srl = $upload_target_srl;
@@ -390,7 +390,7 @@ class fileModel extends file
 		foreach ($output->data as $file)
 		{
 			$file->source_filename = escape($file->source_filename, false);
-			$file->download_url = $this->getDownloadUrl($file->file_srl, $file->sid, $file->module_srl);
+			$file->download_url = self::getDownloadUrl($file->file_srl, $file->sid, $file->module_srl);
 			$fileList[] = $file;
 		}
 		return $fileList;
@@ -401,10 +401,10 @@ class fileModel extends file
 	 *
 	 * @return object Returns a file configuration of current module. If user is admin, returns PHP's max file size and allow all file types.
 	 */
-	function getUploadConfig()
+	public static function getUploadConfig()
 	{
-		$config = $this->getFileConfig(Context::get('module_srl') ?: Context::get('current_module_info')->module_srl);
-		if($this->user->is_admin === 'Y')
+		$config = self::getFileConfig(Context::get('module_srl') ?: Context::get('current_module_info')->module_srl);
+		if (Rhymix\Framework\Session::isAdmin())
 		{
 			$module_config = getModel('module')->getModuleConfig('file');
 			$config->allowed_filesize = max($config->allowed_filesize, $module_config->allowed_filesize);
@@ -421,9 +421,9 @@ class fileModel extends file
 	 * @param int $attached_size
 	 * @return string
 	 */
-	function getUploadStatus($attached_size = 0)
+	public static function getUploadStatus($attached_size = 0)
 	{
-		$file_config = $this->getUploadConfig();
+		$file_config = self::getUploadConfig();
 		if (Context::get('allow_chunks') === 'Y')
 		{
 			$allowed_filesize = $file_config->allowed_filesize * 1024 * 1024;
@@ -450,17 +450,17 @@ class fileModel extends file
 	/**
 	 * method for compatibility
 	 */
-	function getFileModuleConfig($module_srl)
+	public static function getFileModuleConfig($module_srl)
 	{
-		return $this->getFileConfig($module_srl);
+		return self::getFileConfig($module_srl);
 	}
 
 	/**
 	 * method for compatibility
 	 */
-	function getFileGrant($file_info, $member_info)
+	public static function getFileGrant($file_info, $member_info)
 	{
-		return (object)['is_deletable' => $this->isDeletable($file_info, $member_info)];
+		return (object)['is_deletable' => self::isDeletable($file_info, $member_info)];
 	}
 }
 /* End of file file.model.php */

--- a/modules/file/file.model.php
+++ b/modules/file/file.model.php
@@ -36,22 +36,19 @@ class fileModel extends file
 		// Get uploaded files
 		if($upload_target_srl)
 		{
-			$oModuleModel = getModel('module');
-			$oCommentModel = getModel('comment');
-			$oDocumentModel = getModel('document');
-			$oDocument = $oDocumentModel->getDocument($upload_target_srl);
+			$oDocument = DocumentModel::getDocument($upload_target_srl);
 			
 			// Check permissions of the comment
 			if(!$oDocument->isExists())
 			{
-				$oComment = $oCommentModel->getComment($upload_target_srl);
+				$oComment = CommentModel::getComment($upload_target_srl);
 				if($oComment->isExists())
 				{
 					if(!$oComment->isAccessible())
 					{
 						throw new Rhymix\Framework\Exceptions\NotPermitted;
 					}
-					$oDocument = $oDocumentModel->getDocument($oComment->get('document_srl'));
+					$oDocument = DocumentModel::getDocument($oComment->get('document_srl'));
 				}
 			}
 			
@@ -64,12 +61,12 @@ class fileModel extends file
 			// Check permissions of the module
 			if($module_srl = isset($oComment) ? $oComment->get('module_srl') : $oDocument->get('module_srl'))
 			{
-				$module_info = $oModuleModel->getModuleInfoByModuleSrl($module_srl);
+				$module_info = ModuleModel::getModuleInfoByModuleSrl($module_srl);
 				if(empty($module_info->module_srl))
 				{
 					throw new Rhymix\Framework\Exceptions\NotPermitted;
 				}
-				$grant = $oModuleModel->getGrant($module_info, Context::get('logged_info'));
+				$grant = ModuleModel::getGrant($module_info, Context::get('logged_info'));
 				if(!$grant->access)
 				{
 					throw new Rhymix\Framework\Exceptions\NotPermitted;
@@ -161,7 +158,7 @@ class fileModel extends file
 			}
 			if(!isset($member_info->group_list))
 			{
-				$member_info->group_list = getModel('member')->getMemberGroups($member_info->member_srl);
+				$member_info->group_list = MemberModel::getMemberGroups($member_info->member_srl);
 			}
 			$is_group = false;
 			foreach($config->download_groups as $group_srl)
@@ -204,27 +201,26 @@ class fileModel extends file
 		}
 		
 		// Check permissions of the module
-		$oModuleModel = getModel('module');
-		$module_info = $oModuleModel->getModuleInfoByModuleSrl($file_info->module_srl);
+		$module_info = ModuleModel::getModuleInfoByModuleSrl($file_info->module_srl);
 		if(empty($module_info->module_srl))
 		{
 			return false;
 		}
-		$grant = $oModuleModel->getGrant($module_info, $member_info);
+		$grant = ModuleModel::getGrant($module_info, $member_info);
 		if($grant->manager)
 		{
 			return true;
 		}
 		
 		// Check permissions of the document
-		$oDocument = getModel('document')->getDocument($file_info->upload_target_srl);
+		$oDocument = DocumentModel::getDocument($file_info->upload_target_srl);
 		if($oDocument->isExists() && $oDocument->isGranted())
 		{
 			return true;
 		}
 		
 		// Check permissions of the comment
-		$oComment = getModel('comment')->getComment($file_info->upload_target_srl);
+		$oComment = CommentModel::getComment($file_info->upload_target_srl);
 		if($oComment->isExists() && $oComment->isGranted())
 		{
 			return true;
@@ -406,7 +402,7 @@ class fileModel extends file
 		$config = self::getFileConfig(Context::get('module_srl') ?: Context::get('current_module_info')->module_srl);
 		if (Rhymix\Framework\Session::isAdmin())
 		{
-			$module_config = getModel('module')->getModuleConfig('file');
+			$module_config = ModuleModel::getModuleConfig('file');
 			$config->allowed_filesize = max($config->allowed_filesize, $module_config->allowed_filesize);
 			$config->allowed_attach_size = max($config->allowed_attach_size, $module_config->allowed_attach_size);
 			$config->allowed_extensions = [];

--- a/modules/file/file.view.php
+++ b/modules/file/file.view.php
@@ -35,14 +35,12 @@ class fileView extends file
 		}
 		
 		// Get file configurations of the module
-		$oFileModel = getModel('file');
-		$config = $oFileModel->getFileConfig($current_module_srl);
+		$config = FileModel::getFileConfig($current_module_srl);
 		Context::set('config', $config);
 		Context::set('is_ffmpeg', function_exists('exec') && Rhymix\Framework\Storage::isExecutable($config->ffmpeg_command) && Rhymix\Framework\Storage::isExecutable($config->ffprobe_command));
 		
 		// Get a permission for group setting
-		$oMemberModel = getModel('member');
-		$group_list = $oMemberModel->getGroups();
+		$group_list = MemberModel::getGroups();
 		Context::set('group_list', $group_list);
 		
 		// Set a template file

--- a/modules/member/member.model.php
+++ b/modules/member/member.model.php
@@ -18,8 +18,9 @@ class memberModel extends member
 	/**
 	 * @brief Initialization
 	 */
-	function init()
+	public function init()
 	{
+		
 	}
 
 	/**
@@ -130,7 +131,7 @@ class memberModel extends member
 	/**
 	 * @brief Display menus of the member
 	 */
-	function getMemberMenu()
+	public static function getMemberMenu()
 	{
 		// Get member_srl of he target member and logged info of the current user
 		$member_srl = Context::get('target_srl');

--- a/modules/member/member.model.php
+++ b/modules/member/member.model.php
@@ -268,6 +268,8 @@ class memberModel extends member
 
 	/**
 	 * @brief Return member information with user_id
+	 * 
+	 * @return object|null
 	 */
 	public static function getMemberInfoByUserID($user_id)
 	{
@@ -286,6 +288,8 @@ class memberModel extends member
 
 	/**
 	 * @brief Return member information with email_address
+	 * 
+	 * @return object|null
 	 */
 	public static function getMemberInfoByEmailAddress($email_address)
 	{
@@ -303,6 +307,8 @@ class memberModel extends member
 
 	/**
 	 * @brief Return member information with phone number
+	 * 
+	 * @return object|null
 	 */
 	public static function getMemberInfoByPhoneNumber($phone_number, $phone_country = null)
 	{
@@ -332,6 +338,8 @@ class memberModel extends member
 
 	/**
 	 * @brief Return member information with member_srl
+	 * 
+	 * @return object
 	 */
 	public static function getMemberInfoByMemberSrl($member_srl, $site_srl = 0)
 	{
@@ -360,6 +368,17 @@ class memberModel extends member
 		}
 
 		return $GLOBALS['__member_info__'][$member_srl];
+	}
+
+	/**
+	 * @brief Shortcut to getMemberInfoByMemberSrl()
+	 * 
+	 * @param int $member_srl
+	 * @return object
+	 */
+	public static function getMemberInfo($member_srl)
+	{
+		return self::getMemberInfoByMemberSrl(intval($member_srl));
 	}
 
 	/**

--- a/modules/member/member.model.php
+++ b/modules/member/member.model.php
@@ -10,7 +10,10 @@ class memberModel extends member
 	/**
 	 * @brief Keep data internally which may be frequently called ...
 	 */
-	var $join_form_list = NULL;
+	protected static $_denied_id_list;
+	protected static $_join_form_list;
+	protected static $_managed_email_hosts;
+	protected static $_member_config;
 
 	/**
 	 * @brief Initialization
@@ -22,13 +25,11 @@ class memberModel extends member
 	/**
 	 * @brief Return member's configuration
 	 */
-	function getMemberConfig()
+	public static function getMemberConfig()
 	{
-		static $member_config;
-
-		if($member_config)
+		if (self::$_member_config)
 		{
-			return $member_config;
+			return self::$_member_config;
 		}
 
 		// Get member configuration stored in the DB
@@ -52,7 +53,7 @@ class memberModel extends member
 		// Get terms of user
 		if(!$config->agreements)
 		{
-			$config->agreement = memberModel::_getAgreement();
+			$config->agreement = self::_getAgreement();
 			$config->agreements[1] = new stdClass;
 			$config->agreements[1]->title = lang('agreement');
 			$config->agreements[1]->content = $config->agreement;
@@ -93,15 +94,13 @@ class memberModel extends member
 			$config->redirect_url = getNotEncodedFullUrl('','mid',$config->redirect_mid);
 		}
 
-		$member_config = $config;
-
-		return $config;
+		return self::$_member_config = $config;
 	}
 
 	/**
 	 * @deprecated
 	 */
-	function _getAgreement()
+	protected static function _getAgreement()
 	{
 		$agreement_file = _XE_PATH_.'files/member_extra_info/agreement_' . Context::get('lang_type') . '.txt';
 		if(is_readable($agreement_file))
@@ -137,17 +136,20 @@ class memberModel extends member
 		$member_srl = Context::get('target_srl');
 		$mid = Context::get('cur_mid');
 		$logged_info = Context::get('logged_info');
+		$module_config = self::getMemberConfig();
 		$act = Context::get('cur_act');
 		// When click user's own nickname
 		if($member_srl == $logged_info->member_srl) $member_info = $logged_info;
 		// When click other's nickname
-		else $member_info = $this->getMemberInfoByMemberSrl($member_srl);
+		else $member_info = self::getMemberInfoByMemberSrl($member_srl);
 
 		$member_srl = $member_info->member_srl;
 		if(!$member_srl) return;
+
 		// List variables
 		$user_id = $member_info->user_id;
 		$user_name = $member_info->user_name;
+		$icon_path = '';
 
 		ModuleHandler::triggerCall('member.getMemberMenu', 'before', $member_info);
 
@@ -163,7 +165,7 @@ class memberModel extends member
 		if($member_srl != $logged_info->member_srl && $logged_info->member_srl)
 		{
 			// Get email config
-			foreach($this->module_config->signupForm as $field)
+			foreach($module_config->signupForm as $field)
 			{
 				if($field->name == 'email_address')
 				{
@@ -194,7 +196,7 @@ class memberModel extends member
 		}
 		else
 		{
-			foreach ($this->module_config->signupForm as $field)
+			foreach ($module_config->signupForm as $field)
 			{
 				if ($field->name === 'homepage' && $field->isPublic === 'Y')
 				{
@@ -250,7 +252,7 @@ class memberModel extends member
 	/**
 	 * @brief Check if logged-in
 	 */
-	function isLogged()
+	public static function isLogged()
 	{
 		return Rhymix\Framework\Session::getMemberSrl() ? true : false;
 	}
@@ -258,7 +260,7 @@ class memberModel extends member
 	/**
 	 * @brief Return session information of the logged-in user
 	 */
-	function getLoggedInfo()
+	public static function getLoggedInfo()
 	{
 		return Context::get('logged_info');
 	}
@@ -266,7 +268,7 @@ class memberModel extends member
 	/**
 	 * @brief Return member information with user_id
 	 */
-	function getMemberInfoByUserID($user_id)
+	public static function getMemberInfoByUserID($user_id)
 	{
 		if(!$user_id) return;
 
@@ -276,7 +278,7 @@ class memberModel extends member
 		if(!$output->toBool()) return $output;
 		if(!$output->data) return;
 
-		$member_info = $this->arrangeMemberInfo($output->data);
+		$member_info = self::arrangeMemberInfo($output->data);
 
 		return $member_info;
 	}
@@ -284,7 +286,7 @@ class memberModel extends member
 	/**
 	 * @brief Return member information with email_address
 	 */
-	function getMemberInfoByEmailAddress($email_address)
+	public static function getMemberInfoByEmailAddress($email_address)
 	{
 		if(!$email_address) return;
 
@@ -294,14 +296,14 @@ class memberModel extends member
 		if(!$output->toBool()) return $output;
 		if(!$output->data) return;
 
-		$member_info = $this->arrangeMemberInfo($output->data);
+		$member_info = self::arrangeMemberInfo($output->data);
 		return $member_info;
 	}
 
 	/**
 	 * @brief Return member information with phone number
 	 */
-	function getMemberInfoByPhoneNumber($phone_number, $phone_country = null)
+	public static function getMemberInfoByPhoneNumber($phone_number, $phone_country = null)
 	{
 		if(!$phone_number) return;
 		if($phone_country)
@@ -323,14 +325,14 @@ class memberModel extends member
 		if(!$output->toBool()) return $output;
 		if(!$output->data) return;
 
-		$member_info = $this->arrangeMemberInfo($output->data);
+		$member_info = self::arrangeMemberInfo($output->data);
 		return $member_info;
 	}
 
 	/**
 	 * @brief Return member information with member_srl
 	 */
-	function getMemberInfoByMemberSrl($member_srl, $site_srl = 0)
+	public static function getMemberInfoByMemberSrl($member_srl, $site_srl = 0)
 	{
 		if(!$member_srl) return new stdClass;
 
@@ -348,7 +350,7 @@ class memberModel extends member
 					return new stdClass;
 				}
 				
-				$member_info = $this->arrangeMemberInfo($output->data, $site_srl);
+				$member_info = self::arrangeMemberInfo($output->data, $site_srl);
 				if($output->toBool())
 				{
 					Rhymix\Framework\Cache::set($cache_key, $member_info);
@@ -362,23 +364,22 @@ class memberModel extends member
 	/**
 	 * @brief Add member info from extra_vars and other information
 	 */
-	function arrangeMemberInfo($info, $site_srl = 0)
+	public static function arrangeMemberInfo($info, $site_srl = 0)
 	{
 		if(!$GLOBALS['__member_info__'][$info->member_srl])
 		{
-			$oModuleModel = getModel('module');
-			$config = $oModuleModel->getModuleConfig('member');
+			$config = self::getMemberConfig();
 
-			$info->profile_image = $this->getProfileImage($info->member_srl);
-			$info->image_name = $this->getImageName($info->member_srl);
-			$info->image_mark = $this->getImageMark($info->member_srl);
+			$info->profile_image = self::getProfileImage($info->member_srl);
+			$info->image_name = self::getImageName($info->member_srl);
+			$info->image_mark = self::getImageMark($info->member_srl);
 			if($config->group_image_mark=='Y')
 			{
-				$info->group_mark = $this->getGroupImageMark($info->member_srl,$site_srl);
+				$info->group_mark = self::getGroupImageMark($info->member_srl,$site_srl);
 			}
-			$info->signature = $this->getSignature($info->member_srl);
-			$info->group_list = $this->getMemberGroups($info->member_srl, $site_srl);
-			$info->is_site_admin = $oModuleModel->isSiteAdmin($info) ? true : false;
+			$info->signature = self::getSignature($info->member_srl);
+			$info->group_list = self::getMemberGroups($info->member_srl, $site_srl);
+			$info->is_site_admin = ModuleModel::isSiteAdmin($info) ? true : false;
 
 			$extra_vars = unserialize($info->extra_vars);
 			unset($info->extra_vars);
@@ -445,7 +446,7 @@ class memberModel extends member
 	/**
 	 * @brief Get member_srl corresponding to userid
 	 */
-	function getMemberSrlByUserID($user_id)
+	public static function getMemberSrlByUserID($user_id)
 	{
 		$args = new stdClass();
 		$args->user_id = $user_id;
@@ -456,7 +457,7 @@ class memberModel extends member
 	/**
 	 * @brief Get member_srl corresponding to EmailAddress
 	 */
-	function getMemberSrlByEmailAddress($email_address)
+	public static function getMemberSrlByEmailAddress($email_address)
 	{
 		$args = new stdClass();
 		$args->email_address = $email_address;
@@ -467,7 +468,7 @@ class memberModel extends member
 	/**
 	 * @brief Get member_srl corresponding to phone number
 	 */
-	function getMemberSrlByPhoneNumber($phone_number, $phone_country = null)
+	public static function getMemberSrlByPhoneNumber($phone_number, $phone_country = null)
 	{
 		$args = new stdClass();
 		$args->phone_number = $phone_number;
@@ -479,7 +480,7 @@ class memberModel extends member
 	/**
 	 * @brief Get member_srl corresponding to nickname
 	 */
-	function getMemberSrlByNickName($nick_name)
+	public static function getMemberSrlByNickName($nick_name)
 	{
 		$args = new stdClass();
 		$args->nick_name = $nick_name;
@@ -490,7 +491,7 @@ class memberModel extends member
 	/**
 	 * @brief Return member_srl of the current logged-in user
 	 */
-	function getLoggedMemberSrl()
+	public static function getLoggedMemberSrl()
 	{
 		return Rhymix\Framework\Session::getMemberSrl();
 	}
@@ -498,17 +499,17 @@ class memberModel extends member
 	/**
 	 * @brief Return user_id of the current logged-in user
 	 */
-	function getLoggedUserID()
+	public static function getLoggedUserID()
 	{
-		if(!$this->isLogged()) return;
 		$logged_info = Context::get('logged_info');
+		if (!$logged_info || !$logged_info->member_srl) return;
 		return $logged_info->user_id;
 	}
 
 	/**
 	 * @brief Get a list of groups which the member_srl belongs to
 	 */
-	function getMemberGroups($member_srl, $site_srl = 0, $force_reload = false)
+	public static function getMemberGroups($member_srl, $site_srl = 0, $force_reload = false)
 	{
 		static $member_groups = array();
 
@@ -527,7 +528,7 @@ class memberModel extends member
 				$group_list = $output->data;
 				if (!count($group_list))
 				{
-					$default_group = $this->getDefaultGroup($site_srl);
+					$default_group = self::getDefaultGroup($site_srl);
 					getController('member')->addMemberToGroup($member_srl, $default_group->group_srl, $site_srl);
 					$group_list[$default_group->group_srl] = $default_group->title;
 				}
@@ -551,7 +552,7 @@ class memberModel extends member
 	/**
 	 * @brief Get a list of groups which member_srls belong to
 	 */
-	function getMembersGroups($member_srls, $site_srl = 0)
+	public static function getMembersGroups($member_srls, $site_srl = 0)
 	{
 		$args = new stdClass;
 		$args->member_srls = implode(',',$member_srls);
@@ -571,7 +572,7 @@ class memberModel extends member
 	/**
 	 * @brief Get a default group
 	 */
-	function getDefaultGroup($site_srl = 0)
+	public static function getDefaultGroup($site_srl = 0)
 	{
 		$cache_key = sprintf('member:default_group:site:%d', $site_srl);
 		$default_group = Rhymix\Framework\Cache::get($cache_key);
@@ -594,7 +595,7 @@ class memberModel extends member
 	/**
 	 * @brief Get an admin group
 	 */
-	function getAdminGroup($columnList = array())
+	public static function getAdminGroup($columnList = array())
 	{
 		$args = new stdClass;
 		$output = executeQuery('member.getAdminGroup', $args, $columnList);
@@ -604,7 +605,7 @@ class memberModel extends member
 	/**
 	 * @brief Get group info corresponding to group_srl
 	 */
-	function getGroup($group_srl, $columnList = array())
+	public static function getGroup($group_srl, $columnList = array())
 	{
 		$args = new stdClass;
 		$args->group_srl = $group_srl;
@@ -615,7 +616,7 @@ class memberModel extends member
 	/**
 	 * @brief Get a list of groups
 	 */
-	function getGroups($site_srl = 0)
+	public static function getGroups($site_srl = 0)
 	{
 		if(!$GLOBALS['__group_info__'][$site_srl])
 		{
@@ -657,12 +658,14 @@ class memberModel extends member
 		return $GLOBALS['__group_info__'][$site_srl];
 	}
 
-	public function getApiGroups()
+	/**
+	 * @deprecated
+	 */
+	public static function getApiGroups()
 	{
 		$siteSrl = Context::get('siteSrl');
-		$groupInfo = $this->getGroups($siteSrl);
-
-		$this->add($groupInfo);
+		$groupInfo = self::getGroups($siteSrl);
+		//$this->add($groupInfo);
 	}
 
 	/**
@@ -672,18 +675,18 @@ class memberModel extends member
 	 * To use as extend_filter, the argument should be boolean.
 	 * When the argument is true, it returns object result in type of filter.
 	 */
-	function getJoinFormList($filter_response = false)
+	public static function getJoinFormList($filter_response = false)
 	{
 		global $lang;
 		// Set to ignore if a super administrator.
 		$logged_info = Context::get('logged_info');
 
-		if(!$this->join_form_list)
+		if(!self::$_join_form_list)
 		{
 			// Argument setting to sort list_order column
 			$args = new stdClass();
 			$args->sort_index = "list_order";
-			$output = executeQuery('member.getJoinFormList', $args);
+			$output = executeQueryArray('member.getJoinFormList', $args);
 			// NULL if output data deosn't exist
 			$join_form_list = $output->data;
 			if(!$join_form_list) return NULL;
@@ -715,15 +718,15 @@ class memberModel extends member
 
 				$list[$member_join_form_srl] = $join_form_list[$i];
 			}
-			$this->join_form_list = $list;
+			self::$_join_form_list = $list;
 		}
 		// Get object style if the filter_response is true
-		if($filter_response && count($this->join_form_list))
+		if($filter_response && count(self::$_join_form_list))
 		{
-			foreach($this->join_form_list as $key => $val)
+			foreach(self::$_join_form_list as $key => $val)
 			{
 				if($val->is_active != 'Y') continue;
-				unset($obj);
+				$obj = new stdClass;
 				$obj->type = $val->column_type;
 				$obj->name = $val->column_name;
 				$obj->lang = $val->column_title;
@@ -731,7 +734,7 @@ class memberModel extends member
 				else $obj->required = false;
 				$filter_output[] = $obj;
 
-				unset($open_obj);
+				$open_obj = new stdClass;
 				$open_obj->name = 'open_'.$val->column_name;
 				$open_obj->required = false;
 				$filter_output[] = $open_obj;
@@ -740,7 +743,7 @@ class memberModel extends member
 			return $filter_output;
 		}
 		// Return the result
-		return $this->join_form_list;
+		return self::$_join_form_list;
 	}
 
 	/**
@@ -748,7 +751,7 @@ class memberModel extends member
 	 *
 	 * @return array $joinFormList
 	 */
-	function getUsedJoinFormList()
+	public static function getUsedJoinFormList()
 	{
 		$args = new stdClass();
 		$args->sort_index = "list_order";
@@ -776,9 +779,9 @@ class memberModel extends member
 	/**
 	 * @brief Combine extend join form and member information (used to modify member information)
 	 */
-	function getCombineJoinForm($member_info)
+	public static function getCombineJoinForm($member_info)
 	{
-		$extend_form_list = $this->getJoinFormlist();
+		$extend_form_list = self::getJoinFormlist();
 		if(!$extend_form_list) return;
 		// Member info is open only to an administrator and him/herself when is_private is true.
 		$logged_info = Context::get('logged_info');
@@ -815,7 +818,7 @@ class memberModel extends member
 	/**
 	 * @brief Get a join form
 	 */
-	function getJoinForm($member_join_form_srl)
+	public static function getJoinForm($member_join_form_srl)
 	{
 		$args = new stdClass();
 		$args->member_join_form_srl = $member_join_form_srl;
@@ -841,9 +844,9 @@ class memberModel extends member
 	/**
 	 * @brief Get a list of denied IDs
 	 */
-	function getDeniedIDList()
+	public static function getDeniedIDList()
 	{
-		if(!$this->denied_id_list)
+		if(!isset(self::$_denied_id_list))
 		{
 			$args = new stdClass();
 			$args->sort_index = "list_order";
@@ -851,20 +854,20 @@ class memberModel extends member
 			$args->list_count = 40;
 			$args->page_count = 10;
 
-			$output = executeQuery('member.getDeniedIDList', $args);
-			$this->denied_id_list = $output;
+			$output = executeQueryArray('member.getDeniedIDList', $args);
+			self::$_denied_id_list = $output;
 		}
-		return $this->denied_id_list;
+		return self::$_denied_id_list;
 	}
 
-	function getDeniedIDs()
+	public static function getDeniedIDs()
 	{
 		$output = executeQueryArray('member.getDeniedIDs');
 		if(!$output->toBool()) return array();
 		return $output->data;
 	}
 
-	function getDeniedNickNames()
+	public static function getDeniedNickNames()
 	{
 		$output = executeQueryArray('member.getDeniedNickNames');
 		if(!$output->toBool())
@@ -875,24 +878,24 @@ class memberModel extends member
 		return $output->data;
 	}
 
-	function getManagedEmailHosts()
+	public static function getManagedEmailHosts()
 	{
-		static $output;
-		if(isset($output->data)) return $output->data;
+		if(isset(self::$_managed_email_hosts)) {
+			return self::$_managed_email_hosts;
+		}
 		$output = executeQueryArray('member.getManagedEmailHosts');
 		if(!$output->toBool())
 		{
-			$output->data = array();
-			return array();
+			return self::$_managed_email_hosts = array();
 		}
 
-		return $output->data;
+		return self::$_managed_email_hosts = $output->data;
 	}
 
 	/**
 	 * @brief Verify if ID is denied
 	 */
-	function isDeniedID($user_id)
+	public static function isDeniedID($user_id)
 	{
 		$args = new stdClass();
 		$args->user_id = $user_id;
@@ -904,7 +907,7 @@ class memberModel extends member
 	/**
 	 * @brief Verify if nick name is denied
 	 */
-	function isDeniedNickName($nickName)
+	public static function isDeniedNickName($nickName)
 	{
 		$args = new stdClass();
 		$args->nick_name = $nickName;
@@ -920,13 +923,12 @@ class memberModel extends member
 	/**
 	 * @brief Verify if email_host from email_address is denied
 	 */
-	function isDeniedEmailHost($email_address)
+	public static function isDeniedEmailHost($email_address)
 	{
 		$email_address = trim($email_address);
-		$oMemberModel = &getModel('member');
-		$config = $oMemberModel->getMemberConfig();
+		$config = self::getMemberConfig();
 		$emailhost_check = $config->emailhost_check;
-		$managedHosts = $oMemberModel->getManagedEmailHosts();
+		$managedHosts = self::getManagedEmailHosts();
 		if(count($managedHosts) < 1) return FALSE;
 
 		static $return;
@@ -962,7 +964,7 @@ class memberModel extends member
 	/**
 	 * @brief Get information of the profile image
 	 */
-	function getProfileImage($member_srl)
+	public static function getProfileImage($member_srl)
 	{
 		if(!isset($GLOBALS['__member_info__']['profile_image'][$member_srl]))
 		{
@@ -991,7 +993,7 @@ class memberModel extends member
 	/**
 	 * @brief Get the image name
 	 */
-	function getImageName($member_srl)
+	public static function getImageName($member_srl)
 	{
 		if(!isset($GLOBALS['__member_info__']['image_name'][$member_srl]))
 		{
@@ -1014,7 +1016,7 @@ class memberModel extends member
 	/**
 	 * @brief Get the image mark
 	 */
-	function getImageMark($member_srl)
+	public static function getImageMark($member_srl)
 	{
 		if(!isset($GLOBALS['__member_info__']['image_mark'][$member_srl]))
 		{
@@ -1039,7 +1041,7 @@ class memberModel extends member
 	/**
 	 * @brief Get the image mark of the group
 	 */
-	function getGroupImageMark($member_srl,$site_srl=0)
+	public static function getGroupImageMark($member_srl,$site_srl=0)
 	{
 		if(!isset($GLOBALS['__member_info__']['group_image_mark'][$member_srl]))
 		{
@@ -1049,8 +1051,8 @@ class memberModel extends member
 			{
 				return null;
 			}
-			$member_group = $this->getMemberGroups($member_srl,$site_srl);
-			$groups_info = $this->getGroups($site_srl);
+			$member_group = self::getMemberGroups($member_srl, $site_srl);
+			$groups_info = self::getGroups($site_srl);
 			if(count($member_group) > 0 && is_array($member_group))
 			{
 				$memberGroups = array_keys($member_group);
@@ -1089,7 +1091,7 @@ class memberModel extends member
 	/**
 	 * @brief Get user's signature
 	 */
-	function getSignature($member_srl)
+	public static function getSignature($member_srl)
 	{
 		if(!isset($GLOBALS['__member_info__']['signature'][$member_srl]))
 		{
@@ -1099,7 +1101,7 @@ class memberModel extends member
 				$signature = preg_replace('/<\?.*\?>/', '', FileHandler::readFile($filename));
 				
 				// retroact
-				$config = getModel('member')->getMemberConfig();
+				$config = self::getMemberConfig();
 				if($config->signature_html_retroact == 'Y' && $config->signature_html == 'N' && preg_match('/<[^br]+>/i', $signature))
 				{
 					$signature = preg_replace('/(\r?\n)+/', "\n", $signature);
@@ -1124,7 +1126,7 @@ class memberModel extends member
 	 * @param int $member_srl Set this to member_srl when comparing a member's password (optional)
 	 * @return bool
 	 */
-	function isValidPassword($hashed_password, $password_text, $member_srl=null)
+	public static function isValidPassword($hashed_password, $password_text, $member_srl=null)
 	{
 		// False if no password in entered
 		if(!$password_text)
@@ -1151,7 +1153,7 @@ class memberModel extends member
 		}
 		
 		// Update the encryption method if necessary
-		$config = $this->getMemberConfig();
+		$config = self::getMemberConfig();
 		if($member_srl > 0 && $config->password_hashing_auto_upgrade != 'N')
 		{
 			$required_algorithm = Rhymix\Framework\Password::getDefaultAlgorithm();
@@ -1177,7 +1179,7 @@ class memberModel extends member
 			{
 				$args = new stdClass();
 				$args->member_srl = $member_srl;
-				$args->hashed_password = $this->hashPassword($password_text, $required_algorithm);
+				$args->hashed_password = self::hashPassword($password_text, $required_algorithm);
 				$oMemberController = getController('member');
 				$oMemberController->updateMemberPassword($args);
 			}
@@ -1192,19 +1194,19 @@ class memberModel extends member
 	 * @param string $algorithm The algorithm to use (optional, only set this when you want to use a non-default algorithm)
 	 * @return string
 	 */
-	function hashPassword($password_text, $algorithm = null)
+	public static function hashPassword($password_text, $algorithm = null)
 	{
 		return Rhymix\Framework\Password::hashPassword($password_text, $algorithm);
 	}
 	
-	function checkPasswordStrength($password, $strength)
+	public static function checkPasswordStrength($password, $strength)
 	{
 		$logged_info = Context::get('logged_info');
 		if($logged_info->is_admin == 'Y') return true;
 		
 		if($strength == NULL)
 		{
-			$config = $this->getMemberConfig();
+			$config = self::getMemberConfig();
 			$strength = $config->password_strength?$config->password_strength:'normal';
 		}
 		
@@ -1227,10 +1229,10 @@ class memberModel extends member
 		return true;
 	}
 	
-	function getAdminGroupSrl($site_srl = 0)
+	public static function getAdminGroupSrl($site_srl = 0)
 	{
 		$groupSrl = 0;
-		$output = $this->getGroups($site_srl);
+		$output = self::getGroups($site_srl);
 		if(is_array($output))
 		{
 			foreach($output AS $key=>$value)
@@ -1245,7 +1247,7 @@ class memberModel extends member
 		return $groupSrl;
 	}
 	
-	function getMemberModifyNicknameLog($page = 1, $member_srl = null)
+	public static function getMemberModifyNicknameLog($page = 1, $member_srl = null)
 	{
 		$args = new stdClass();
 		$args->member_srl = $member_srl;

--- a/modules/member/member.model.php
+++ b/modules/member/member.model.php
@@ -34,8 +34,7 @@ class memberModel extends member
 		}
 
 		// Get member configuration stored in the DB
-		$oModuleModel = getModel('module');
-		$config = $oModuleModel->getModuleConfig('member');
+		$config = ModuleModel::getModuleConfig('member');
 
 		if(!$config->signupForm || !is_array($config->signupForm))
 		{
@@ -131,7 +130,7 @@ class memberModel extends member
 	/**
 	 * @brief Display menus of the member
 	 */
-	public static function getMemberMenu()
+	public function getMemberMenu()
 	{
 		// Get member_srl of he target member and logged info of the current user
 		$member_srl = Context::get('target_srl');
@@ -154,7 +153,7 @@ class memberModel extends member
 
 		ModuleHandler::triggerCall('member.getMemberMenu', 'before', $member_info);
 
-		$oMemberController = getController('member');
+		$oMemberController = MemberController::getInstance();
 		// Display member information (Don't display to non-logged user)
 		if($logged_info->member_srl)
 		{
@@ -178,7 +177,7 @@ class memberModel extends member
 			// Send an email only if email address is public
 			if($email_config->isPublic == 'Y' && $member_info->email_address)
 			{
-				$oCommunicationModel = getModel('communication');
+				$oCommunicationModel = CommunicationModel::getInstance();
 				if($logged_info->is_admin == 'Y' || $oCommunicationModel->isFriend($member_info->member_srl))
 				{
 					$url = 'mailto:'.escape($member_info->email_address);
@@ -549,7 +548,7 @@ class memberModel extends member
 				if (!count($group_list))
 				{
 					$default_group = self::getDefaultGroup($site_srl);
-					getController('member')->addMemberToGroup($member_srl, $default_group->group_srl, $site_srl);
+					MemberController::getInstance()->addMemberToGroup($member_srl, $default_group->group_srl, $site_srl);
 					$group_list[$default_group->group_srl] = $default_group->title;
 				}
 				//insert in cache
@@ -1065,8 +1064,7 @@ class memberModel extends member
 	{
 		if(!isset($GLOBALS['__member_info__']['group_image_mark'][$member_srl]))
 		{
-			$oModuleModel = getModel('module');
-			$config = $oModuleModel->getModuleConfig('member');
+			$config = ModuleModel::getModuleConfig('member');
 			if($config->group_image_mark!='Y')
 			{
 				return null;
@@ -1125,7 +1123,7 @@ class memberModel extends member
 				if($config->signature_html_retroact == 'Y' && $config->signature_html == 'N' && preg_match('/<[^br]+>/i', $signature))
 				{
 					$signature = preg_replace('/(\r?\n)+/', "\n", $signature);
-					return getController('member')->putSignature($member_srl, $signature);
+					return MemberController::getInstance()->putSignature($member_srl, $signature);
 				}
 				
 				$GLOBALS['__member_info__']['signature'][$member_srl] = $signature;
@@ -1200,8 +1198,7 @@ class memberModel extends member
 				$args = new stdClass();
 				$args->member_srl = $member_srl;
 				$args->hashed_password = self::hashPassword($password_text, $required_algorithm);
-				$oMemberController = getController('member');
-				$oMemberController->updateMemberPassword($args);
+				MemberController::getInstance()->updateMemberPassword($args);
 			}
 		}
 		

--- a/modules/module/module.controller.php
+++ b/modules/module/module.controller.php
@@ -185,7 +185,7 @@ class moduleController extends module
 
 	function updateModuleConfig($module, $config, $site_srl = 0)
 	{
-		$origin_config = getModel('module')->getModuleConfig($module, $site_srl);
+		$origin_config = ModuleModel::getModuleConfig($module, $site_srl);
 		
 		foreach($config as $key => $val)
 		{
@@ -197,7 +197,7 @@ class moduleController extends module
 
 	function updateModulePartConfig($module, $module_srl, $config)
 	{
-		$origin_config = getModel('module')->getModulePartConfig($module, $module_srl);
+		$origin_config = ModuleModel::getModulePartConfig($module, $module_srl);
 		
 		foreach($config as $key => $val)
 		{
@@ -256,8 +256,7 @@ class moduleController extends module
 	{
 		if(isSiteID($domain))
 		{
-			$oModuleModel = getModel('module');
-			if($oModuleModel->isIDExists($domain, 0)) return new BaseObject(-1, 'msg_already_registed_vid');
+			if(ModuleModel::isIDExists($domain, 0)) return new BaseObject(-1, 'msg_already_registed_vid');
 		}
 		else
 		{
@@ -271,8 +270,7 @@ class moduleController extends module
 		$args->default_language = Context::getLangType();
 
 		$columnList = array('modules.site_srl');
-		$oModuleModel = getModel('module');
-		$output = $oModuleModel->getSiteInfoByDomain($args->domain, $columnList);
+		$output = ModuleModel::getSiteInfoByDomain($args->domain, $columnList);
 		if($output) return new BaseObject(-1,'msg_already_registed_vid');
 
 		$output = executeQuery('module.insertSite', $args);
@@ -287,9 +285,8 @@ class moduleController extends module
 	 */
 	function updateSite($args)
 	{
-		$oModuleModel = getModel('module');
 		$columnList = array('sites.site_srl', 'sites.domain');
-		$site_info = $oModuleModel->getSiteInfo($args->site_srl, $columnList);
+		$site_info = ModuleModel::getSiteInfo($args->site_srl, $columnList);
 
 		if(!$args->domain && $site_info->site_srl == $args->site_srl)
 		{
@@ -298,9 +295,9 @@ class moduleController extends module
 
 		if($site_info->domain != $args->domain)
 		{
-			$info = $oModuleModel->getSiteInfoByDomain($args->domain, $columnList);
+			$info = ModuleModel::getSiteInfoByDomain($args->domain, $columnList);
 			if($info->site_srl && $info->site_srl != $args->site_srl) return new BaseObject(-1, 'msg_already_registed_domain');
-			if(isSiteID($args->domain) && $oModuleModel->isIDExists($args->domain)) return new BaseObject(-1, 'msg_already_registed_vid');
+			if(isSiteID($args->domain) && ModuleModel::isIDExists($args->domain)) return new BaseObject(-1, 'msg_already_registed_vid');
 
 			if($args->domain && !isSiteID($args->domain))
 			{
@@ -312,7 +309,7 @@ class moduleController extends module
 		if($args->site_srl == 0) $vid='';
 		else $vid=$args->domain;
 
-		$module_info = $oModuleModel->getModuleInfoByModuleSrl($args->index_module_srl);
+		$module_info = ModuleModel::getModuleInfoByModuleSrl($args->index_module_srl);
 		$mid = $module_info->mid;
 
 		Rhymix\Framework\Cache::clearGroup('site_and_module');
@@ -376,15 +373,14 @@ class moduleController extends module
 		if(!$output->toBool()) return $output;
 		// Check whether the module name already exists
 		if(!$args->site_srl) $args->site_srl = 0;
-		$oModuleModel = getModel('module');
-		if($oModuleModel->isIDExists($args->mid, $args->site_srl)) return new BaseObject(-1, 'msg_module_name_exists');
+		if(ModuleModel::isIDExists($args->mid, $args->site_srl)) return new BaseObject(-1, 'msg_module_name_exists');
 
 		// begin transaction
 		$oDB = &DB::getInstance();
 		$oDB->begin();
 		// Get colorset from the skin information
 		$module_path = ModuleHandler::getModulePath($args->module);
-		$skin_info = $oModuleModel->loadSkinInfo($module_path, $args->skin);
+		$skin_info = ModuleModel::loadSkinInfo($module_path, $args->skin);
 		$skin_vars = new stdClass();
 		$skin_vars->colorset = $skin_info->colorset[0]->name;
 		// Arrange variables and then execute a query
@@ -436,8 +432,6 @@ class moduleController extends module
 			// if menu is not created, create menu also. and does not supported that in virtual site.
 			if(!$menuOutput->data && !$args->site_srl)
 			{
-				$oMenuAdminModel = getAdminModel('menu');
-
 				$oMenuAdminController = getAdminController('menu');
 				$menuSrl = $oMenuAdminController->getUnlinkedMenu();
 
@@ -502,9 +496,7 @@ class moduleController extends module
 		$oDB = &DB::getInstance();
 		$oDB->begin();
 
-		$oModuleModel = getModel('module');
-		$columnList = array('module_srl', 'site_srl', 'browser_title', 'mid');
-		$module_info = $oModuleModel->getModuleInfoByModuleSrl($args->module_srl);
+		$module_info = ModuleModel::getModuleInfoByModuleSrl($args->module_srl);
 
 		if(!$args->site_srl || !$args->browser_title)
 		{
@@ -645,8 +637,7 @@ class moduleController extends module
 
 		$site_module_info = Context::get('site_module_info');
 
-		$oModuleModel = getModel('module');
-		$output = $oModuleModel->getModuleInfoByModuleSrl($module_srl);
+		$output = ModuleModel::getModuleInfoByModuleSrl($module_srl);
 
 		$args = new stdClass();
 		$args->url = $output->mid;
@@ -707,9 +698,8 @@ class moduleController extends module
 		if(!$module_srl) return new BaseObject(-1, 'msg_invalid_request');
 
 		// check start module
-		$oModuleModel = getModel('module');
 		$columnList = array('sites.index_module_srl');
-		$start_module = $oModuleModel->getSiteInfo(0, $columnList);
+		$start_module = ModuleModel::getSiteInfo(0, $columnList);
 		if($module_srl == $start_module->index_module_srl) return new BaseObject(-1, 'msg_cannot_delete_startmodule');
 
 		// Call a trigger (before)
@@ -803,13 +793,12 @@ class moduleController extends module
 	 */
 	function insertAdminId($module_srl, $admin_id)
 	{
-		$oMemberModel = getModel('member');
-		$member_config = $oMemberModel->getMemberConfig();
+		$member_config = MemberModel::getMemberConfig();
 
 		if($member_config->identifier == 'email_address')
-			$member_info = $oMemberModel->getMemberInfoByEmailAddress($admin_id);
+			$member_info = MemberModel::getMemberInfoByEmailAddress($admin_id);
 		else
-			$member_info = $oMemberModel->getMemberInfoByUserID($admin_id);
+			$member_info = MemberModel::getMemberInfoByUserID($admin_id);
 		
 		if(!$member_info->member_srl) return;
 		
@@ -831,8 +820,7 @@ class moduleController extends module
 
 		if($admin_id)
 		{
-			$oMemberModel = getModel('member');
-			$member_info = $oMemberModel->getMemberInfoByUserID($admin_id);
+			$member_info = MemberModel::getMemberInfoByUserID($admin_id);
 			if($member_info->member_srl) $args->member_srl = $member_info->member_srl;
 		}
 		
@@ -1156,11 +1144,10 @@ class moduleController extends module
 		// have file
 		if($vars->addfile['tmp_name'] && is_uploaded_file($vars->addfile['tmp_name']))
 		{
-			$oModuleModel = getModel('module');
-			$output = $oModuleModel->getModuleFileBox($vars->module_filebox_srl);
+			$output = ModuleModel::getModuleFileBox($vars->module_filebox_srl);
 			FileHandler::removeFile($output->data->filename);
 
-			$path = $oModuleModel->getModuleFileBoxPath($vars->module_filebox_srl);
+			$path = ModuleModel::getModuleFileBoxPath($vars->module_filebox_srl);
 			FileHandler::makeDir($path);
 
 			$random = Rhymix\Framework\Security::getRandom(32, 'hex');
@@ -1196,8 +1183,7 @@ class moduleController extends module
 		$vars->module_filebox_srl = getNextSequence();
 
 		// get file path
-		$oModuleModel = getModel('module');
-		$path = $oModuleModel->getModuleFileBoxPath($vars->module_filebox_srl);
+		$path = ModuleModel::getModuleFileBoxPath($vars->module_filebox_srl);
 		FileHandler::makeDir($path);
 		
 		$random = Rhymix\Framework\Security::getRandom(32, 'hex');
@@ -1252,8 +1238,7 @@ class moduleController extends module
 	function deleteModuleFileBox($vars)
 	{
 		// delete real file
-		$oModuleModel = getModel('module');
-		$output = $oModuleModel->getModuleFileBox($vars->module_filebox_srl);
+		$output = ModuleModel::getModuleFileBox($vars->module_filebox_srl);
 		FileHandler::removeFile($output->data->filename);
 
 		$args = new stdClass();

--- a/modules/module/module.model.php
+++ b/modules/module/module.model.php
@@ -15,9 +15,9 @@ class moduleModel extends module
 	}
 
 	/**
-	 * @brief Check if mid, vid are available
+	 * @brief Check if mid is available
 	 */
-	function isIDExists($id)
+	public static function isIDExists($id)
 	{
 		if (!preg_match('/^[a-z]{1}([a-z0-9_]+)$/i', $id))
 		{
@@ -49,7 +49,7 @@ class moduleModel extends module
 	/**
 	 * @brief Get all domains
 	 */
-	function getAllDomains($count = 20, $page = 1)
+	public static function getAllDomains($count = 20, $page = 1)
 	{
 		$args = new stdClass;
 		$args->list_count = $count;
@@ -65,7 +65,7 @@ class moduleModel extends module
 	/**
 	 * @brief Get default domain information
 	 */
-	function getDefaultDomainInfo()
+	public static function getDefaultDomainInfo()
 	{
 		$domain_info = Rhymix\Framework\Cache::get('site_and_module:domain_info:default');
 		if ($domain_info === null)
@@ -93,7 +93,7 @@ class moduleModel extends module
 	/**
 	 * @brief Get site information by domain_srl
 	 */
-	function getSiteInfo($domain_srl)
+	public static function getSiteInfo($domain_srl)
 	{
 		$domain_srl = intval($domain_srl);
 		$domain_info = Rhymix\Framework\Cache::get('site_and_module:domain_info:srl:' . $domain_srl);
@@ -122,7 +122,7 @@ class moduleModel extends module
 	/**
 	 * @brief Get site information by domain name
 	 */
-	function getSiteInfoByDomain($domain)
+	public static function getSiteInfoByDomain($domain)
 	{
 		if (strpos($domain, '/') !== false)
 		{
@@ -165,32 +165,32 @@ class moduleModel extends module
 	 * @brief Get module information with document_srl
 	 * In this case, it is unable to use the cache file
 	 */
-	function getModuleInfoByDocumentSrl($document_srl)
+	public static function getModuleInfoByDocumentSrl($document_srl)
 	{
 		$args = new stdClass();
 		$args->document_srl = $document_srl;
 		$output = executeQuery('module.getModuleInfoByDocument', $args);
-		$this->applyDefaultSkin($output->data);
-		return $this->addModuleExtraVars($output->data);
+		self::_applyDefaultSkin($output->data);
+		return self::addModuleExtraVars($output->data);
 	}
 
 	/**
 	 * @brief Get the default mid according to the domain
 	 */
-	function getDefaultMid($domain = null)
+	public static function getDefaultMid($domain = null)
 	{
 		// Get current domain.
 		$domain = $domain ?: strtolower(preg_replace('/:\d+$/', '', $_SERVER['HTTP_HOST']));
 		$domain = Rhymix\Framework\URL::decodeIdna($domain);
 		
 		// Find the domain information.
-		$domain_info = $this->getSiteInfoByDomain($domain);
+		$domain_info = self::getSiteInfoByDomain($domain);
 		if (!$domain_info)
 		{
-			$domain_info = $this->getDefaultDomainInfo();
+			$domain_info = self::getDefaultDomainInfo();
 			if (!$domain_info)
 			{
-				$domain_info = $this->migrateDomains();
+				$domain_info = getClass('module')->migrateDomains();
 			}
 			$domain_info->is_default_replaced = true;
 		}
@@ -198,7 +198,7 @@ class moduleModel extends module
 		// Fill in module extra vars and return.
 		if ($domain_info->module_srl)
 		{
-			return $this->addModuleExtraVars($domain_info);
+			return self::addModuleExtraVars($domain_info);
 		}
 		else
 		{
@@ -209,7 +209,7 @@ class moduleModel extends module
 	/**
 	 * @brief Get module information by mid
 	 */
-	function getModuleInfoByMid($mid, $site_srl = 0, $columnList = array())
+	public static function getModuleInfoByMid($mid, $site_srl = 0, $columnList = array())
 	{
 		if(!$mid || ($mid && !preg_match("/^[a-z][a-z0-9_]+$/i", $mid)))
 		{
@@ -240,9 +240,9 @@ class moduleModel extends module
 			}
 		}
 
-		$this->applyDefaultSkin($module_info);
+		self::_applyDefaultSkin($module_info);
 		if(!$module_info->module_srl && $module_info->data[0]) $module_info = $module_info->data[0];
-		return $this->addModuleExtraVars($module_info);
+		return self::addModuleExtraVars($module_info);
 	}
 
 	/**
@@ -280,14 +280,14 @@ class moduleModel extends module
 		$oLayoutAdminModel = getAdminModel('layout');
 		$layoutSrlPc = ($moduleInfo->layout_srl == -1) ? $oLayoutAdminModel->getSiteDefaultLayout('P') : $moduleInfo->layout_srl;
 		$layoutSrlMobile = ($moduleInfo->mlayout_srl == -1) ? $oLayoutAdminModel->getSiteDefaultLayout('M') : $moduleInfo->mlayout_srl;
-		$skinNamePc = ($moduleInfo->is_skin_fix == 'N') ? $this->getModuleDefaultSkin($moduleInfo->module, 'P') : $moduleInfo->skin;
-		$skinNameMobile = ($moduleInfo->is_mskin_fix == 'N') ? $this->getModuleDefaultSkin($moduleInfo->module, $moduleInfo->mskin === '/USE_RESPONSIVE/' ? 'P' : 'M') : $moduleInfo->mskin;
+		$skinNamePc = ($moduleInfo->is_skin_fix == 'N') ? self::getModuleDefaultSkin($moduleInfo->module, 'P') : $moduleInfo->skin;
+		$skinNameMobile = ($moduleInfo->is_mskin_fix == 'N') ? self::getModuleDefaultSkin($moduleInfo->module, $moduleInfo->mskin === '/USE_RESPONSIVE/' ? 'P' : 'M') : $moduleInfo->mskin;
 
 		$oLayoutModel = getModel('layout');
 		$layoutInfoPc = $layoutSrlPc ? $oLayoutModel->getLayoutRawData($layoutSrlPc, array('title')) : NULL;
 		$layoutInfoMobile = $layoutSrlMobile ? $oLayoutModel->getLayoutRawData($layoutSrlMobile, array('title')) : NULL;
-		$skinInfoPc = $this->loadSkinInfo(Modulehandler::getModulePath($moduleInfo->module), $skinNamePc);
-		$skinInfoMobile = $this->loadSkinInfo(Modulehandler::getModulePath($moduleInfo->module), $skinNameMobile, 'm.skins');
+		$skinInfoPc = self::loadSkinInfo(Modulehandler::getModulePath($moduleInfo->module), $skinNamePc);
+		$skinInfoMobile = self::loadSkinInfo(Modulehandler::getModulePath($moduleInfo->module), $skinNameMobile, 'm.skins');
 		if(!$skinInfoPc)
 		{
 			$skinInfoPc = new stdClass();
@@ -329,7 +329,7 @@ class moduleModel extends module
 			$moduleInfo = $mid_info;
 		}
 
-		$moduleInfo = $this->addModuleExtraVars($moduleInfo);
+		$moduleInfo = self::addModuleExtraVars($moduleInfo);
 
 		if($moduleInfo->module == 'page' && $moduleInfo->page_type != 'ARTICLE')
 		{
@@ -345,7 +345,7 @@ class moduleModel extends module
 	/**
 	 * @brief Get module information corresponding to module_srl
 	 */
-	function getModuleInfoByModuleSrl($module_srl, $columnList = array())
+	public static function getModuleInfoByModuleSrl($module_srl, $columnList = array())
 	{
 		if(intval($module_srl) == 0)
 		{
@@ -362,7 +362,7 @@ class moduleModel extends module
 			$mid_info = $output->data;
 			if($mid_info)
 			{
-				$this->applyDefaultSkin($mid_info);
+				self::_applyDefaultSkin($mid_info);
 				Rhymix\Framework\Cache::set("site_and_module:mid_info:$module_srl", $mid_info, 0, true);
 			}
 		}
@@ -388,8 +388,8 @@ class moduleModel extends module
 		if(isset($module_info->browser_title)) $oModuleController->replaceDefinedLangCode($module_info->browser_title);
 		*/
 
-		$this->applyDefaultSkin($module_info);
-		return $this->addModuleExtraVars($module_info);
+		self::_applyDefaultSkin($module_info);
+		return self::addModuleExtraVars($module_info);
 	}
 
 	/**
@@ -397,23 +397,23 @@ class moduleModel extends module
 	 *
 	 * @param stdClass $moduleInfo Module information
 	 */
-	private function applyDefaultSkin(&$moduleInfo)
+	private static function _applyDefaultSkin(&$module_info)
 	{
-		if($moduleInfo->is_skin_fix == 'N')
+		if($module_info->is_skin_fix == 'N')
 		{
-			$moduleInfo->skin = '/USE_DEFAULT/';
+			$module_info->skin = '/USE_DEFAULT/';
 		}
 
-		if($moduleInfo->is_mskin_fix == 'N' && $moduleInfo->mskin !== '/USE_RESPONSIVE/')
+		if($module_info->is_mskin_fix == 'N' && $module_info->mskin !== '/USE_RESPONSIVE/')
 		{
-			$moduleInfo->mskin = '/USE_DEFAULT/';
+			$module_info->mskin = '/USE_DEFAULT/';
 		}
 	}
 
 	/**
 	 * @brief Get module information corresponding to layout_srl
 	 */
-	function getModulesInfoByLayout($layout_srl, $columnList = array())
+	public static function getModulesInfoByLayout($layout_srl, $columnList = array())
 	{
 		// Imported data
 		$args = new stdClass;
@@ -427,26 +427,26 @@ class moduleModel extends module
 		{
 			$modules[] = $output->data[$i];
 		}
-		return $this->addModuleExtraVars($modules);
+		return self::addModuleExtraVars($modules);
 	}
 
 	/**
 	 * @brief Get module information corresponding to multiple module_srls
 	 */
-	function getModulesInfo($module_srls, $columnList = array())
+	public static function getModulesInfo($module_srls, $columnList = array())
 	{
 		if(is_array($module_srls)) $module_srls = implode(',',$module_srls);
 		$args = new stdClass();
 		$args->module_srls = $module_srls;
 		$output = executeQueryArray('module.getModulesInfo', $args, $columnList);
 		if(!$output->toBool()) return;
-		return $this->addModuleExtraVars($output->data);
+		return self::addModuleExtraVars($output->data);
 	}
 
 	/**
 	 * @brief Add extra vars to the module basic information
 	 */
-	function addModuleExtraVars($module_info)
+	public static function addModuleExtraVars($module_info)
 	{
 		// Process although one or more module informaion is requested
 		if(!is_array($module_info)) $target_module_info = array($module_info);
@@ -460,7 +460,7 @@ class moduleModel extends module
 			$module_srls[] = $val->module_srl;
 		}
 		// Extract extra information of the module and skin
-		$extra_vars = $this->getModuleExtraVars($module_srls);
+		$extra_vars = self::getModuleExtraVars($module_srls);
 		if(!count($module_srls) || !count($extra_vars)) return $module_info;
 
 		foreach($target_module_info as $key => $val)
@@ -480,7 +480,7 @@ class moduleModel extends module
 	/**
 	 * @brief Get a complete list of mid, which is created in the DB
 	 */
-	function getMidList($args = null, $columnList = array())
+	public static function getMidList($args = null, $columnList = array())
 	{
 		$list = Rhymix\Framework\Cache::get('site_and_module:module:mid_list');
 		if($list === null)
@@ -517,7 +517,7 @@ class moduleModel extends module
 	/**
 	 * @brief Get a complete list of module_srl, which is created in the DB
 	 */
-	function getModuleSrlList($args = null, $columnList = array())
+	public static function getModuleSrlList($args = null, $columnList = array())
 	{
 		$output = executeQueryArray('module.getMidList', $args, $columnList);
 		if(!$output->toBool()) return $output;
@@ -531,7 +531,7 @@ class moduleModel extends module
 	/**
 	 * @brief Return an array of module_srl corresponding to a mid list
 	 */
-	function getModuleSrlByMid($mid)
+	public static function getModuleSrlByMid($mid)
 	{
 		if($mid && !is_array($mid)) $mid = explode(',',$mid);
 		if(is_array($mid)) $mid = "'".implode("','",$mid)."'";
@@ -556,7 +556,7 @@ class moduleModel extends module
 	/**
 	 * @brief Get forward value by the value of act
 	 */
-	function getActionForward($act)
+	public static function getActionForward($act)
 	{
 		$action_forward = Rhymix\Framework\Cache::get('action_forward');
 		if($action_forward === null)
@@ -588,7 +588,7 @@ class moduleModel extends module
 	/**
 	 * @brief Get trigger functions
 	 */
-	function getTriggerFunctions($trigger_name, $called_position)
+	public static function getTriggerFunctions($trigger_name, $called_position)
 	{
 		if(isset($GLOBALS['__trigger_functions__'][$trigger_name][$called_position]))
 		{
@@ -603,7 +603,7 @@ class moduleModel extends module
 	/**
 	 * @brief Get a list of all triggers on the trigger_name
 	 */
-	function getTriggers($trigger_name, $called_position)
+	public static function getTriggers($trigger_name, $called_position)
 	{
 		if(is_null($GLOBALS['__triggers__']))
 		{
@@ -631,9 +631,9 @@ class moduleModel extends module
 	/**
 	 * @brief Get specific triggers from the trigger_name
 	 */
-	function getTrigger($trigger_name, $module, $type, $called_method, $called_position)
+	public static function getTrigger($trigger_name, $module, $type, $called_method, $called_position)
 	{
-		$triggers = $this->getTriggers($trigger_name, $called_position);
+		$triggers = self::getTriggers($trigger_name, $called_position);
 
 		if($triggers && is_array($triggers))
 		{
@@ -651,67 +651,29 @@ class moduleModel extends module
 
 	/**
 	 * @brief Get module extend
+	 * 
+	 * @deprecated
 	 */
-	function getModuleExtend($parent_module, $type, $kind='')
+	public static function getModuleExtend($parent_module, $type, $kind = '')
 	{
-		$key = $parent_module.'.'.$kind.'.'.$type;
-
-		$module_extend_info = $this->loadModuleExtends();
-		if(array_key_exists($key, $module_extend_info))
-		{
-			return $module_extend_info[$key];
-		}
-
 		return false;
 	}
 
 	/**
 	 * @brief Get all the module extend
+	 * 
+	 * @deprecated
+	 * 
 	 */
-	function loadModuleExtends()
+	public static function loadModuleExtends()
 	{
-		$cache_file = './files/cache/common/module_extend.php';
-		$cache_file = FileHandler::getRealPath($cache_file);
-
-		if(!isset($GLOBALS['__MODULE_EXTEND__']))
-		{
-			// check pre install
-			if(file_exists(FileHandler::getRealPath('./files')) && !file_exists($cache_file))
-			{
-				$arr = array();
-				$output = executeQueryArray('module.getModuleExtend');
-				if($output->data)
-				{
-					foreach($output->data as $v)
-					{
-						$arr[] = sprintf("'%s.%s.%s' => '%s'", $v->parent_module, $v->kind, $v->type, $v->extend_module);
-					}
-				}
-
-				$str = '<?PHP return array(%s); ?>';
-				$str = sprintf($str, join(',',$arr));
-
-				FileHandler::writeFile($cache_file, $str);
-			}
-
-
-			if(file_exists($cache_file))
-			{
-				$GLOBALS['__MODULE_EXTEND__'] = include($cache_file);
-			}
-			else
-			{
-				$GLOBALS['__MODULE_EXTEND__'] = array();
-			}
-		}
-
-		return $GLOBALS['__MODULE_EXTEND__'];
+		return array();
 	}
 
 	/**
 	 * @brief Get information from conf/info.xml
 	 */
-	function getModuleInfoXml($module)
+	public static function getModuleInfoXml($module)
 	{
 		// Get a path of the requested module. Return if not exists.
 		$module_path = ModuleHandler::getModulePath($module);
@@ -773,7 +735,7 @@ class moduleModel extends module
 			$module_info->author[] = $author_obj;
 		}
 		// Add admin_index by using action information
-		$action_info = $this->getModuleActionXml($module);
+		$action_info = self::getModuleActionXml($module);
 		$module_info->admin_index_act = $action_info->admin_index_act;
 		$module_info->default_index_act = $action_info->default_index_act;
 		$module_info->setup_index_act = $action_info->setup_index_act;
@@ -788,7 +750,7 @@ class moduleModel extends module
 	 * When caching, add codes so to include it directly
 	 * This is apparently good for performance, but not sure about its side-effects
 	 */
-	function getModuleActionXml($module)
+	public static function getModuleActionXml($module)
 	{
 		// Get a path of the requested module. Return if not exists.
 		$class_path = ModuleHandler::getModulePath($module);
@@ -1045,7 +1007,7 @@ class moduleModel extends module
 
 		$path = ModuleHandler::getModulePath($module);
 		$dir = ($skinType == 'M') ? 'm.skins' : 'skins';
-		$skin_list = $this->getSkins($path, $dir);
+		$skin_list = self::getSkins($path, $dir);
 
 		$this->add('skin_info_list', $skin_list);
 	}
@@ -1054,7 +1016,7 @@ class moduleModel extends module
 	 * @brief Get a list of skins for the module
 	 * Return file analysis of skin and skin.xml
 	 */
-	function getSkins($path, $dir = 'skins')
+	public static function getSkins($path, $dir = 'skins')
 	{
 		if(substr($path, -1) == '/')
 		{
@@ -1075,7 +1037,7 @@ class moduleModel extends module
 				continue;
 			}
 			unset($skin_info);
-			$skin_info = $this->loadSkinInfo($path, $skin_name, $dir);
+			$skin_info = self::loadSkinInfo($path, $skin_name, $dir);
 			if(!$skin_info)
 			{
 				$skin_info = new stdClass();
@@ -1117,10 +1079,10 @@ class moduleModel extends module
 		$useDefaultList = array();
 		if(array_key_exists($moduleName, $installedMenuTypes))
 		{
-			$defaultSkinName = $this->getModuleDefaultSkin($module, $dir == 'skins' ? 'P' : 'M');
+			$defaultSkinName = self::getModuleDefaultSkin($module, $dir == 'skins' ? 'P' : 'M');
 			if(isset($defaultSkinName))
 			{
-				$defaultSkinInfo = $this->loadSkinInfo($path, $defaultSkinName, $dir);
+				$defaultSkinInfo = self::loadSkinInfo($path, $defaultSkinName, $dir);
 
 				$useDefault = new stdClass();
 				$useDefault->title = lang('use_site_default_skin') . ' (' . $defaultSkinInfo->title . ')';
@@ -1141,7 +1103,7 @@ class moduleModel extends module
 	/**
 	 * @brief Get skin information on a specific location
 	 */
-	function loadSkinInfo($path, $skin, $dir = 'skins')
+	public static function loadSkinInfo($path, $skin, $dir = 'skins')
 	{
 		// Read xml file having skin information
 		if(substr($path,-1)!='/') $path .= '/';
@@ -1544,7 +1506,7 @@ class moduleModel extends module
 
 			$path = ModuleHandler::getModulePath($module_name);
 			// Get information of the module
-			$info = $this->getModuleInfoXml($module_name);
+			$info = self::getModuleInfoXml($module_name);
 			unset($obj);
 
 			if(!isset($info)) continue;
@@ -1647,7 +1609,7 @@ class moduleModel extends module
 			}
 			// Get information of the module
 			$info = NULL;
-			$info = $this->getModuleInfoXml($module_name);
+			$info = self::getModuleInfoXml($module_name);
 			if(!$info) continue;
 
 			$info->module = $module_name;
@@ -1690,7 +1652,7 @@ class moduleModel extends module
 	 * Because XE DBHandler doesn't support left outer join,
 	 * it should be as same as $Output->data[]->module_srl.
 	 */
-	function syncModuleToSite(&$data)
+	public static function syncModuleToSite(&$data)
 	{
 		if(!$data) return;
 
@@ -1747,7 +1709,7 @@ class moduleModel extends module
 	/**
 	 * @brief Get admin information of the site
 	 */
-	function getSiteAdmin($site_srl)
+	public static function getSiteAdmin($site_srl)
 	{
 		return array();
 	}
@@ -1755,7 +1717,7 @@ class moduleModel extends module
 	/**
 	 * @brief Check if a member is a module administrator
 	 */
-	function isModuleAdmin($member_info, $module_srl = null)
+	public static function isModuleAdmin($member_info, $module_srl = null)
 	{
 		if (!$member_info || !$member_info->member_srl)
 		{
@@ -1795,7 +1757,7 @@ class moduleModel extends module
 	/**
 	 * @brief Get admin ID of the module
 	 */
-	function getAdminId($module_srl)
+	public static function getAdminId($module_srl)
 	{
 		$obj = new stdClass();
 		$obj->module_srl = $module_srl;
@@ -1809,7 +1771,7 @@ class moduleModel extends module
 	 * @brief Get extra vars of the module
 	 * Extra information, not in the modules table
 	 */
-	function getModuleExtraVars($list_module_srl)
+	public static function getModuleExtraVars($list_module_srl)
 	{
 		$extra_vars = array();
 		$get_module_srls = array();
@@ -1866,7 +1828,7 @@ class moduleModel extends module
 	/**
 	 * @brief Get skin information of the module
 	 */
-	function getModuleSkinVars($module_srl)
+	public static function getModuleSkinVars($module_srl)
 	{
 		$skin_vars = Rhymix\Framework\Cache::get("site_and_module:module_skin_vars:$module_srl");
 		if($skin_vars === null)
@@ -1891,7 +1853,7 @@ class moduleModel extends module
 	/**
 	 * Get default skin name
 	 */
-	function getModuleDefaultSkin($module_name, $skin_type = 'P', $site_srl = 0, $updateCache = true)
+	public static function getModuleDefaultSkin($module_name, $skin_type = 'P', $site_srl = 0, $updateCache = true)
 	{
 		$target = ($skin_type == 'M') ? 'mskin' : 'skin';
 		$site_srl = 0;
@@ -1951,11 +1913,11 @@ class moduleModel extends module
 
 		if(Mobile::isFromMobilePhone() && $module_info->mskin !== '/USE_RESPONSIVE/')
 		{
-			$skin_vars = $this->getModuleMobileSkinVars($module_info->module_srl);
+			$skin_vars = self::getModuleMobileSkinVars($module_info->module_srl);
 		}
 		else
 		{
-			$skin_vars = $this->getModuleSkinVars($module_info->module_srl);
+			$skin_vars = self::getModuleSkinVars($module_info->module_srl);
 		}
 
 		if(!$skin_vars) return;
@@ -1972,7 +1934,7 @@ class moduleModel extends module
 	 * @param $module_srl Sequence of module
 	 * @return array
 	 */
-	function getModuleMobileSkinVars($module_srl)
+	public static function getModuleMobileSkinVars($module_srl)
 	{
 		$skin_vars = Rhymix\Framework\Cache::get("site_and_module:module_mobile_skin_vars:$module_srl");
 		if($skin_vars === null)
@@ -2025,7 +1987,7 @@ class moduleModel extends module
 	/**
 	 * @brief Return privileges(granted) information by using module info, xml info and member info
 	 */
-	function getGrant($module_info, $member_info, $xml_info = null)
+	public static function getGrant($module_info, $member_info, $xml_info = null)
 	{
 		if(empty($module_info->module))
 		{
@@ -2044,13 +2006,13 @@ class moduleModel extends module
 		// Get information of module.xml 
 		if(!$xml_info)
 		{
-			$xml_info = $this->getModuleActionXml($module_info->module);
+			$xml_info = self::getModuleActionXml($module_info->module);
 		}
 		$xml_grant_list = isset($xml_info->grant) ? (array)$xml_info->grant : array();
 		
 		// Get group information of member
 		$member_group = !empty($member_info->group_list) ? array_keys($member_info->group_list) : array();
-		$is_module_admin = !empty($module_info->module_srl) ? $this->isModuleAdmin($member_info, $module_info->module_srl) : false;
+		$is_module_admin = !empty($module_info->module_srl) ? self::isModuleAdmin($member_info, $module_info->module_srl) : false;
 		
 		// Get 'privilege name' list from module.xml
 		$privilege_list = array_keys($xml_grant_list);
@@ -2093,7 +2055,7 @@ class moduleModel extends module
 			$checked = array();
 			
 			// Grant privileges by information that get from the DB
-			foreach($this->getModuleGrants($module_info->module_srl)->data as $val)
+			foreach(self::getModuleGrants($module_info->module_srl)->data as $val)
 			{
 				$checked[$val->name] = true;
 				if($grant->{$val->name})
@@ -2173,7 +2135,7 @@ class moduleModel extends module
 	 * @param object $member_info
 	 * @return array
 	 */
-	function getAccessibleModuleList($member_info = null)
+	public static function getAccessibleModuleList($member_info = null)
 	{
 		if(!$member_info)
 		{
@@ -2183,12 +2145,12 @@ class moduleModel extends module
 		$result = Rhymix\Framework\Cache::get(sprintf('site_and_module:accessible_modules:%d', $member_info->member_srl));
 		if($result === null)
 		{
-			$mid_list = $this->getMidList();
+			$mid_list = self::getMidList();
 			$result = array();
 			
 			foreach($mid_list as $module_info)
 			{
-				$grant = $this->getGrant($module_info, $member_info);
+				$grant = self::getGrant($module_info, $member_info);
 				if(!$grant->access)
 				{
 					continue;
@@ -2217,7 +2179,7 @@ class moduleModel extends module
 	 * @param object $member_info member information
 	 * @return mixed success : object, fail : false
 	 * */
-	function getPrivilegesBySrl($target_srl, $type = null, $member_info = null)
+	public static function getPrivilegesBySrl($target_srl, $type = null, $member_info = null)
 	{
 		if(empty($target_srl = trim($target_srl)) || !preg_match('/^([0-9]+)$/', $target_srl) && $type != 'module')
 		{
@@ -2240,13 +2202,13 @@ class moduleModel extends module
 			}
 			else if($type == 'module')
 			{
-				$module_info = $this->getModuleInfoByMid($target_srl);
+				$module_info = self::getModuleInfoByMid($target_srl);
 			}
 		}
 		
 		if(!isset($module_info))
 		{
-			$module_info = $this->getModuleInfoByModuleSrl($target_srl);
+			$module_info = self::getModuleInfoByModuleSrl($target_srl);
 		}
 		
 		if(!$module_info->module_srl)
@@ -2259,7 +2221,7 @@ class moduleModel extends module
 			$member_info = Context::get('logged_info');
 		}
 		
-		return $this->getGrant($module_info, $member_info);
+		return self::getGrant($module_info, $member_info);
 	}
 	
 	/**
@@ -2268,9 +2230,9 @@ class moduleModel extends module
 	 * @param string $module module name. if used, search scope is same module
 	 * @return mixed success : object, fail : false
 	 */
-	function findManagerPrivilege($member_info, $module = null)
+	public static function findManagerPrivilege($member_info, $module = null)
 	{
-		if(!$member_info->member_srl || empty($mid_list = $this->getMidList()))
+		if(!$member_info->member_srl || empty($mid_list = self::getMidList()))
 		{
 			return false;
 		}
@@ -2282,7 +2244,7 @@ class moduleModel extends module
 				continue;
 			}
 			
-			if(($grant = $this->getGrant($module_info, $member_info)) && $grant->manager)
+			if(($grant = self::getGrant($module_info, $member_info)) && $grant->manager)
 			{
 				return $grant;
 			}
@@ -2294,7 +2256,7 @@ class moduleModel extends module
 	/**
 	 * @brief Get module grants
 	 */
-	function getModuleGrants($module_srl)
+	public static function getModuleGrants($module_srl)
 	{
 		$output = Rhymix\Framework\Cache::get("site_and_module:module_grants:$module_srl");
 		if ($output === null)
@@ -2361,10 +2323,14 @@ class moduleModel extends module
 		return $module_filebox_list;
 	}
 
-	function getFileBoxListHtml()
+	public function getFileBoxListHtml()
 	{
 		$logged_info = Context::get('logged_info');
-		if($logged_info->is_admin !='Y' && !$logged_info->is_site_admin) return $this->setError('msg_not_permitted');
+		if($logged_info->is_admin !='Y' && !$logged_info->is_site_admin)
+		{
+			return new BaseObject(-1, 'msg_not_permitted');
+		}
+
 		$link = parse_url($_SERVER["HTTP_REFERER"]);
 		$link_params = explode('&',$link['query']);
 		foreach ($link_params as $param)
@@ -2394,7 +2360,7 @@ class moduleModel extends module
 		$this->add('html', $html);
 	}
 
-	function getModuleFileBoxPath($module_filebox_srl)
+	public static function getModuleFileBoxPath($module_filebox_srl)
 	{
 		return getController('file')->getStoragePath('filebox', 0, $module_filebox_srl, 0, '', false);
 	}
@@ -2403,7 +2369,7 @@ class moduleModel extends module
 	 * @brief Return ruleset cache file path
 	 * @param module, act
 	 */
-	function getValidatorFilePath($module, $ruleset, $mid=null)
+	public static function getValidatorFilePath($module, $ruleset, $mid=null)
 	{
 		// load dynamic ruleset xml file
 		if(strpos($ruleset, '@') !== false)
@@ -2434,7 +2400,7 @@ class moduleModel extends module
 		return $xml_file;
 	}
 
-	function getLangListByLangcodeForAutoComplete()
+	public function getLangListByLangcodeForAutoComplete()
 	{
 		$keyword = Context::get('search_keyword');
 
@@ -2468,14 +2434,14 @@ class moduleModel extends module
 	/**
 	 * @brief already instance created module list
 	 */
-	function getModuleListByInstance($site_srl = 0, $columnList = array())
+	public static function getModuleListByInstance($site_srl = 0, $columnList = array())
 	{
 		$args = new stdClass();
 		$output = executeQueryArray('module.getModuleListByInstance', $args, $columnList);
 		return $output;
 	}
 
-	function getLangByLangcode()
+	public function getLangByLangcode()
 	{
 		$langCode = Context::get('langCode');
 		if (!$langCode) return;

--- a/modules/module/module.model.php
+++ b/modules/module/module.model.php
@@ -10,7 +10,7 @@ class moduleModel extends module
 	/**
 	 * @brief Initialization
 	 */
-	function init()
+	public function init()
 	{
 	}
 
@@ -1341,7 +1341,7 @@ class moduleModel extends module
 	/**
 	 * @brief Return the number of modules which are registered on a virtual site
 	 */
-	function getModuleCount($site_srl = 0, $module = null)
+	public static function getModuleCount($site_srl = 0, $module = null)
 	{
 		$args = new stdClass;
 		if(!is_null($module)) $args->module = $module;
@@ -1353,7 +1353,7 @@ class moduleModel extends module
 	 * @brief Return module configurations
 	 * Global configuration is used to manage board, member and others
 	 */
-	function getModuleConfig($module, $site_srl = 0)
+	public static function getModuleConfig($module, $site_srl = 0)
 	{
 		$site_srl = 0;
 		if(!isset($GLOBALS['__ModuleConfig__'][$site_srl][$module]))
@@ -1391,7 +1391,7 @@ class moduleModel extends module
 	 * @brief Return the module configuration of mid
 	 * Manage mid configurations which depend on module
 	 */
-	function getModulePartConfig($module, $module_srl)
+	public static function getModulePartConfig($module, $module_srl)
 	{
 		if(!isset($GLOBALS['__ModulePartConfig__'][$module][$module_srl]))
 		{
@@ -1434,7 +1434,7 @@ class moduleModel extends module
 	/**
 	 * @brief Get all of module configurations for each mid
 	 */
-	function getModulePartConfigs($module, $site_srl = 0)
+	public static function getModulePartConfigs($module, $site_srl = 0)
 	{
 		$args = new stdClass();
 		$args->module = $module;
@@ -1457,7 +1457,7 @@ class moduleModel extends module
 	/**
 	 * @brief Get a list of module category
 	 */
-	function getModuleCategories($moduleCategorySrl = array())
+	public static function getModuleCategories($moduleCategorySrl = array())
 	{
 		$args = new stdClass();
 		$args->moduleCategorySrl = $moduleCategorySrl;
@@ -1478,7 +1478,7 @@ class moduleModel extends module
 	/**
 	 * @brief Get content from the module category
 	 */
-	function getModuleCategory($module_category_srl)
+	public static function getModuleCategory($module_category_srl)
 	{
 		// Get data from the DB
 		$args = new stdClass;
@@ -1491,7 +1491,7 @@ class moduleModel extends module
 	/**
 	 * @brief Get xml information of the module
 	 */
-	function getModulesXmlInfo()
+	public static function getModulesXmlInfo()
 	{
 		// Get a list of downloaded and installed modules
 		$searched_list = FileHandler::readDir('./modules');
@@ -1520,7 +1520,7 @@ class moduleModel extends module
 		return $list;
 	}
 
-	function checkNeedInstall($module_name)
+	public static function checkNeedInstall($module_name)
 	{
 		$oDB = &DB::getInstance();
 		$info = null;
@@ -1544,7 +1544,7 @@ class moduleModel extends module
 		return false;
 	}
 
-	function checkNeedUpdate($module_name)
+	public static function checkNeedUpdate($module_name)
 	{
 		// Check if it is upgraded to module.class.php on each module
 		$oDummy = getModule($module_name, 'class');
@@ -1560,7 +1560,7 @@ class moduleModel extends module
 	 * @param array|string $update_id
 	 * @return Boolean
 	 */
-	public function needUpdate($update_id)
+	public static function needUpdate($update_id)
 	{
 		if(!is_array($update_id)) $update_id = array($update_id);
 
@@ -1578,10 +1578,10 @@ class moduleModel extends module
 	/**
 	 * @brief Get a type and information of the module
 	 */
-	function getModuleList()
+	public static function getModuleList()
 	{
 		// Create DB Object
-		$oDB = &DB::getInstance();
+		$oDB = DB::getInstance();
 		// Get a list of downloaded and installed modules
 		$searched_list = FileHandler::readDir('./modules', '/^([a-zA-Z0-9_-]+)$/');
 		sort($searched_list);
@@ -1694,7 +1694,7 @@ class moduleModel extends module
 	/**
 	 * @brief Check if it is an administrator of site_module_info
 	 */
-	function isSiteAdmin($member_info, $site_srl = null)
+	public static function isSiteAdmin($member_info, $site_srl = null)
 	{
 		if ($member_info && $member_info->is_admin == 'Y')
 		{
@@ -1907,7 +1907,7 @@ class moduleModel extends module
 	/**
 	 * @brief Combine skin information with module information
 	 */
-	function syncSkinInfoToModuleInfo(&$module_info)
+	public static function syncSkinInfoToModuleInfo(&$module_info)
 	{
 		if(!$module_info->module_srl) return;
 
@@ -1960,7 +1960,7 @@ class moduleModel extends module
 	 * Combine skin information with module information
 	 * @param $module_info Module information
 	 */
-	function syncMobileSkinInfoToModuleInfo(&$module_info)
+	public static function syncMobileSkinInfoToModuleInfo(&$module_info)
 	{
 		if(!$module_info->module_srl) return;
 		
@@ -2272,27 +2272,25 @@ class moduleModel extends module
 		return $output;
 	}
 
-	function getModuleFileBox($module_filebox_srl)
+	public static function getModuleFileBox($module_filebox_srl)
 	{
 		$args = new stdClass();
 		$args->module_filebox_srl = $module_filebox_srl;
 		return executeQuery('module.getModuleFileBox', $args);
 	}
 
-	function getModuleFileBoxList()
+	public static function getModuleFileBoxList()
 	{
-		$oModuleModel = getModel('module');
-
 		$args = new stdClass();
 		$args->page = Context::get('page');
 		$args->list_count = 5;
 		$args->page_count = 5;
 		$output = executeQuery('module.getModuleFileBoxList', $args);
-		$output = $oModuleModel->unserializeAttributes($output);
+		$output = self::unserializeAttributes($output);
 		return $output;
 	}
 
-	function unserializeAttributes($module_filebox_list)
+	public static function unserializeAttributes($module_filebox_list)
 	{
 		if(is_array($module_filebox_list->data))
 		{

--- a/modules/module/module.model.php
+++ b/modules/module/module.model.php
@@ -2190,15 +2190,15 @@ class moduleModel extends module
 		{
 			if($type == 'document')
 			{
-				$target_srl = getModel('document')->getDocument($target_srl, false, false)->get('module_srl');
+				$target_srl = DocumentModel::getDocument($target_srl, false, false)->get('module_srl');
 			}
 			else if($type == 'comment')
 			{
-				$target_srl = getModel('comment')->getComment($target_srl)->get('module_srl');
+				$target_srl = CommentModel::getComment($target_srl)->get('module_srl');
 			}
 			else if($type == 'file')
 			{
-				$target_srl = getModel('file')->getFile($target_srl)->module_srl;
+				$target_srl = FileModel::getFile($target_srl)->module_srl;
 			}
 			else if($type == 'module')
 			{
@@ -2340,8 +2340,7 @@ class moduleModel extends module
 		if($selected_widget) $widget_info = $oWidgetModel->getWidgetInfo($selected_widget);
 		Context::set('allow_multiple', $widget_info->extra_var->images->allow_multiple);
 
-		$oModuleModel = getModel('module');
-		$output = $oModuleModel->getModuleFileBoxList();
+		$output = self::getModuleFileBoxList();
 		Context::set('filebox_list', $output->data);
 
 		$page = Context::get('page');
@@ -2360,7 +2359,7 @@ class moduleModel extends module
 
 	public static function getModuleFileBoxPath($module_filebox_srl)
 	{
-		return getController('file')->getStoragePath('filebox', 0, $module_filebox_srl, 0, '', false);
+		return FileController::getStoragePath('filebox', 0, $module_filebox_srl, 0, '', false);
 	}
 
 	/**
@@ -2444,9 +2443,7 @@ class moduleModel extends module
 		$langCode = Context::get('langCode');
 		if (!$langCode) return;
 
-		$oModuleController = getController('module');
-		$oModuleController->replaceDefinedLangCode($langCode);
-
+		ModuleController::getInstance()->replaceDefinedLangCode($langCode);
 		$this->add('lang', $langCode);
 	}
 }

--- a/modules/module/module.model.php
+++ b/modules/module/module.model.php
@@ -393,6 +393,17 @@ class moduleModel extends module
 	}
 
 	/**
+	 * @brief Shortcut to getModuleInfoByModuleSrl()
+	 * 
+	 * @param int $module_srl
+	 * @return object
+	 */
+	public static function getModuleInfo($module_srl)
+	{
+		return self::getModuleInfoByModuleSrl(intval($module_srl));
+	}
+
+	/**
 	 * Apply default skin info
 	 *
 	 * @param stdClass $moduleInfo Module information

--- a/modules/module/module.view.php
+++ b/modules/module/module.view.php
@@ -31,8 +31,7 @@ class moduleView extends module
 		$skin_info_xml = sprintf("%sskins/%s/skin.xml", $module_path, $skin);
 		if(!file_exists($skin_info_xml)) throw new Rhymix\Framework\Exceptions\InvalidRequest;
 
-		$oModuleModel = getModel('module');
-		$skin_info = $oModuleModel->loadSkinInfo($module_path, $skin);
+		$skin_info = ModuleModel::loadSkinInfo($module_path, $skin);
 		Context::set('skin_info',$skin_info);
 
 		$this->setLayoutFile("popup_layout");
@@ -49,11 +48,10 @@ class moduleView extends module
 		$output = executeQueryArray(isset($query_id) ? $query_id : 'module.getSiteModules', $args);
 		
 		$mid_list = array();
-		$oModuleModel = getModel('module');
 		
 		foreach($output->data as $key => $val)
 		{
-			if(!$oModuleModel->getGrant($val, Context::get('logged_info'))->manager)
+			if(!ModuleModel::getGrant($val, Context::get('logged_info'))->manager)
 			{
 				continue;
 			}
@@ -69,7 +67,7 @@ class moduleView extends module
 			$obj->browser_title = $val->browser_title;
 			
 			$mid_list[$val->module]->list[$val->category ?: 0][$val->mid] = $obj;
-			$mid_list[$val->module]->title = $oModuleModel->getModuleInfoXml($val->module)->title;
+			$mid_list[$val->module]->title = ModuleModel::getModuleInfoXml($val->module)->title;
 		}
 		
 		Context::set('mid_list', $mid_list);
@@ -118,8 +116,7 @@ class moduleView extends module
 				//]]></script>',$input_name);
 		Context::addHtmlHeader($addscript);
 
-		$oModuleModel = getModel('module');
-		$output = $oModuleModel->getModuleFileBoxList();
+		$output = ModuleModel::getModuleFileBoxList();
 		Context::set('filebox_list', $output->data);
 
 		$filter = Context::get('filter');

--- a/modules/point/point.controller.php
+++ b/modules/point/point.controller.php
@@ -32,7 +32,7 @@ class pointController extends point
 			return;
 		}
 		
-		$cur_point = getModel('point')->getPoint($member_srl);
+		$cur_point = PointModel::getPoint($member_srl);
 		$this->setPoint($member_srl, $cur_point + $point, 'signup');
 	}
 
@@ -60,7 +60,7 @@ class pointController extends point
 			return;
 		}
 		
-		$cur_point = getModel('point')->getPoint($member_srl);
+		$cur_point = PointModel::getPoint($member_srl);
 		$this->setPoint($member_srl, $cur_point + $point);
 	}
 
@@ -97,13 +97,13 @@ class pointController extends point
 		{
 			return;
 		}
-		if ($obj->status === getModel('document')->getConfigStatus('temp'))
+		if ($obj->status === DocumentModel::getConfigStatus('temp'))
 		{
 			return;
 		}
 		
 		// Get the points of the member
-		$cur_point = getModel('point')->getPoint($member_srl);
+		$cur_point = PointModel::getPoint($member_srl);
 
 		// Add points for the document.
 		$document_point = $this->_getModulePointConfig($module_srl, 'insert_document');
@@ -126,8 +126,7 @@ class pointController extends point
 	 */
 	public function triggerUpdateDocument($obj)
 	{
-		$oDocumentModel = getModel('document');
-		$oDocument = $oDocumentModel->getDocument($obj->document_srl);
+		$oDocument = DocumentModel::getDocument($obj->document_srl);
 		
 		$module_srl = $oDocument->get('module_srl');
 		$member_srl = abs($oDocument->get('member_srl'));
@@ -137,11 +136,11 @@ class pointController extends point
 		}
 		
 		// Only give points if the document is being updated from TEMP to another status such as PUBLIC.
-		if ($obj->status === $oDocumentModel->getConfigStatus('temp') || $oDocument->get('status') !== $oDocumentModel->getConfigStatus('temp'))
+		if ($obj->status === DocumentModel::getConfigStatus('temp') || $oDocument->get('status') !== DocumentModel::getConfigStatus('temp'))
 		{
 			if ($obj->uploaded_count > $oDocument->get('uploaded_count'))
 			{
-				$cur_point = getModel('point')->getPoint($member_srl);
+				$cur_point = PointModel::getPoint($member_srl);
 				$attached_files_point = $this->_getModulePointConfig($module_srl, 'upload_file');
 				$cur_point += $attached_files_point * ($obj->uploaded_count - $oDocument->get('uploaded_count'));
 				$this->setPoint($member_srl, $cur_point);
@@ -150,7 +149,7 @@ class pointController extends point
 		}
 
 		// Get the points of the member
-		$cur_point = getModel('point')->getPoint($member_srl);
+		$cur_point = PointModel::getPoint($member_srl);
 
 		// Add points for the document.
 		$document_point = $this->_getModulePointConfig($module_srl, 'insert_document');
@@ -203,13 +202,13 @@ class pointController extends point
 		{
 			return;
 		}
-		if ($obj->status === getModel('document')->getConfigStatus('temp'))
+		if ($obj->status === DocumentModel::getConfigStatus('temp'))
 		{
 			return;
 		}
 		
 		// Get the points of the member
-		$cur_point = getModel('point')->getPoint($member_srl);
+		$cur_point = PointModel::getPoint($member_srl);
 
 		// Subtract points for the document.
 		$document_point = $this->_getModulePointConfig($module_srl, 'insert_document');
@@ -243,7 +242,7 @@ class pointController extends point
 		}
 		
 		// Abort if the comment and the document have the same author.
-		$oDocument = getModel('document')->getDocument($obj->document_srl);
+		$oDocument = DocumentModel::getDocument($obj->document_srl);
 		if (!$oDocument->isExists() || abs($oDocument->get('member_srl')) == $member_srl)
 		{
 			return;
@@ -258,7 +257,7 @@ class pointController extends point
 		}
 		
 		// Get the points of the member
-		$cur_point = getModel('point')->getPoint($member_srl);
+		$cur_point = PointModel::getPoint($member_srl);
 
 		// Add points for the comment.
 		$comment_point = $this->_getModulePointConfig($module_srl, 'insert_comment');
@@ -307,7 +306,7 @@ class pointController extends point
 		}
 		
 		// Abort if the comment and the document have the same author.
-		$oDocument = getModel('document')->getDocument($obj->document_srl);
+		$oDocument = DocumentModel::getDocument($obj->document_srl);
 		if (!$oDocument->isExists() || abs($oDocument->get('member_srl')) == $member_srl)
 		{
 			return;
@@ -324,7 +323,7 @@ class pointController extends point
 		$module_srl = $oDocument->get('module_srl');
 		
 		// Get the points of the member
-		$cur_point = getModel('point')->getPoint($member_srl);
+		$cur_point = PointModel::getPoint($member_srl);
 
 		// Add points for the comment.
 		$comment_point = $this->_getModulePointConfig($module_srl, 'insert_comment');
@@ -372,7 +371,7 @@ class pointController extends point
 		}
 		
 		// Get the points of the member
-		$cur_point = getModel('point')->getPoint($member_srl);
+		$cur_point = PointModel::getPoint($member_srl);
 
 		// Subtract points for the file.
 		$file_point = $this->_getModulePointConfig($module_srl, 'upload_file');
@@ -403,7 +402,7 @@ class pointController extends point
 		}
 		
 		// Get current points.
-		$cur_point = $logged_member_srl ? getModel('point')->getPoint($logged_member_srl) : 0;
+		$cur_point = $logged_member_srl ? PointModel::getPoint($logged_member_srl) : 0;
 		
 		// If the user (member or guest) does not have enough points, deny access.
 		$config = $this->getConfig();
@@ -435,7 +434,7 @@ class pointController extends point
 			$point = $this->_getModulePointConfig($module_srl, 'download_file');
 			if ($point)
 			{
-				$cur_point = getModel('point')->getPoint($logged_member_srl);
+				$cur_point = PointModel::getPoint($logged_member_srl);
 				$this->setPoint($logged_member_srl, $cur_point + $point);
 			}
 		}
@@ -446,7 +445,7 @@ class pointController extends point
 			$point = $this->_getModulePointConfig($module_srl, 'download_file_author');
 			if ($point)
 			{
-				$cur_point = getModel('point')->getPoint($author_member_srl);
+				$cur_point = PointModel::getPoint($author_member_srl);
 				$this->setPoint($author_member_srl, $cur_point + $point);
 			}
 		}
@@ -517,7 +516,7 @@ class pointController extends point
 		if ($reader_point)
 		{
 			// Get current points.
-			$cur_point = $logged_member_srl ? getModel('point')->getPoint($logged_member_srl) : 0;
+			$cur_point = $logged_member_srl ? PointModel::getPoint($logged_member_srl) : 0;
 			
 			// If the reader does not have enough points, deny access.
 			if ($cur_point + $reader_point < 0 && $config->disable_read_document == 'Y')
@@ -554,7 +553,7 @@ class pointController extends point
 		// Adjust points of the person who wrote the document.
 		if ($author_point && $author_member_srl)
 		{
-			$cur_point = getModel('point')->getPoint($author_member_srl);
+			$cur_point = PointModel::getPoint($author_member_srl);
 			$this->setPoint($author_member_srl, $cur_point + $author_point);
 		}
 	}
@@ -579,13 +578,13 @@ class pointController extends point
 		$config = $this->getConfig();
 		if ($is_comment)
 		{
-			$regdate = ztime(getModel('comment')->getComment($obj->comment_srl)->get('regdate'));
+			$regdate = ztime(CommentModel::getComment($obj->comment_srl)->get('regdate'));
 			$logged_config_key = ($obj->point > 0) ? 'voter_comment_limit' : 'blamer_comment_limit';
 			$target_config_key = ($obj->point > 0) ? 'voted_comment_limit' : 'blamed_comment_limit';
 		}
 		else
 		{
-			$regdate = ztime(getModel('document')->getDocument($obj->document_srl)->get('regdate'));
+			$regdate = ztime(DocumentModel::getDocument($obj->document_srl)->get('regdate'));
 			$logged_config_key = ($obj->point > 0) ? 'voter_limit' : 'blamer_limit';
 			$target_config_key = ($obj->point > 0) ? 'voted_limit' : 'blamed_limit';
 		}
@@ -603,7 +602,7 @@ class pointController extends point
 				{
 					$point = -1 * $point;
 				}
-				$cur_point = getModel('point')->getPoint($logged_member_srl);
+				$cur_point = PointModel::getPoint($logged_member_srl);
 				$this->setPoint($logged_member_srl, $cur_point + $point);
 			}
 		}
@@ -619,7 +618,7 @@ class pointController extends point
 				{
 					$point = -1 * $point;
 				}
-				$cur_point = getModel('point')->getPoint($target_member_srl);
+				$cur_point = PointModel::getPoint($target_member_srl);
 				$this->setPoint($target_member_srl, $cur_point + $point);
 			}
 		}
@@ -630,8 +629,7 @@ class pointController extends point
 	 */
 	public function triggerCopyModule($obj)
 	{
-		$oModuleModel = getModel('module');
-		$pointConfig = $oModuleModel->getModulePartConfig('point', $obj->originModuleSrl);
+		$pointConfig = ModuleModel::getModulePartConfig('point', $obj->originModuleSrl);
 
 		$oModuleController = getController('module');
 		if(is_array($obj->moduleSrlList))
@@ -653,14 +651,11 @@ class pointController extends point
 		if(!$mode || !in_array($mode,$mode_arr)) $mode = 'update';
 
 		// Get configuration information
-		$oMemberModel = getModel('member');
-		$oModuleModel = getModel('module');
-		$oPointModel = getModel('point');
-		$config = $oModuleModel->getModuleConfig('point');
+		$config = ModuleModel::getModuleConfig('point');
 
 		// Get the default configuration information
-		$current_point = $oPointModel->getPoint($member_srl, false, $exists);
-		$current_level = $oPointModel->getLevel($current_point, $config->level_step);
+		$current_point = PointModel::getPoint($member_srl, false, $exists);
+		$current_level = PointModel::getLevel($current_point, $config->level_step);
 
 		// Change points
 		$args = new stdClass();
@@ -722,7 +717,7 @@ class pointController extends point
 		}
 
 		// Get a new level
-		$level = $oPointModel->getLevel($point, $config->level_step);
+		$level = PointModel::getLevel($point, $config->level_step);
 
 		// If existing level and a new one are different attempt to set a point group
 		$new_group_list = array();
@@ -744,7 +739,7 @@ class pointController extends point
 			if($point_group && is_array($point_group) && count($point_group) )
 			{
 				// Get the default group
-				$default_group = $oMemberModel->getDefaultGroup();
+				$default_group = MemberModel::getDefaultGroup();
 				asort($point_group);
 				
 				// Reset group after initialization
@@ -862,13 +857,11 @@ class pointController extends point
 			return 0;
 		}
 		
-		$oModuleModel = getModel('module');
-		
 		if ($module_srl)
 		{
 			if (!isset(self::$_module_config_cache[$module_srl]))
 			{
-				self::$_module_config_cache[$module_srl] = $oModuleModel->getModulePartConfig('point', $module_srl);
+				self::$_module_config_cache[$module_srl] = ModuleModel::getModulePartConfig('point', $module_srl);
 			}
 			$module_config = self::$_module_config_cache[$module_srl];
 		}

--- a/modules/point/point.model.php
+++ b/modules/point/point.model.php
@@ -123,7 +123,7 @@ class pointModel extends point
 		{
 			return;
 		}
-		if (!getModel('module')->isSiteAdmin($logged_info))
+		if (!ModuleModel::isSiteAdmin($logged_info))
 		{
 			$member_srls = array_filter($member_srls, function($member_srl) use($logged_info) { return $member_srl == $logged_info->member_srl; });
 			if (!count($member_srls))
@@ -132,8 +132,7 @@ class pointModel extends point
 			}
 		}
 
-		$oModuleModel = getModel('module');
-		$config = $oModuleModel->getModuleConfig('point');
+		$config = ModuleModel::getModuleConfig('point');
 
 		$info = array();
 		foreach($member_srls as $v)
@@ -212,8 +211,7 @@ class pointModel extends point
 
 		if($output->total_count)
 		{
-			$oModuleModel = getModel('module');
-			$config = $oModuleModel->getModuleConfig('point');
+			$config = ModuleModel::getModuleConfig('point');
 
 			foreach($output->data as $key => $val)
 			{

--- a/modules/point/point.model.php
+++ b/modules/point/point.model.php
@@ -10,14 +10,14 @@ class pointModel extends point
 	/**
 	 * @brief Initialization
 	 */
-	function init()
+	public function init()
 	{
 	}
 
 	/**
 	 * @brief Check if there is points information
 	 */
-	function isExistsPoint($member_srl)
+	public static function isExistsPoint($member_srl)
 	{
 		$args = new stdClass;
 		$args->member_srl = abs($member_srl);
@@ -29,7 +29,7 @@ class pointModel extends point
 	/**
 	 * @brief Get the points
 	 */
-	function getPoint($member_srl, $from_db = false, &$exists = null)
+	public static function getPoint($member_srl, $from_db = false, &$exists = null)
 	{
 		$member_srl = abs($member_srl);
 
@@ -93,7 +93,7 @@ class pointModel extends point
 	/**
 	 * @brief Get the level
 	 */
-	function getLevel($point, $level_step)
+	public static function getLevel($point, $level_step)
 	{
 		$level_count = count($level_step);
 		for ($level = 0; $level <= $level_count; $level++)
@@ -109,7 +109,7 @@ class pointModel extends point
 	/**
 	 * @deprecated
 	 */
-	function getMembersPointInfo()
+	public function getMembersPointInfo()
 	{
 		$member_srls = Context::get('member_srls');
 		$member_srls = array_unique(explode(',', $member_srls));
@@ -139,8 +139,8 @@ class pointModel extends point
 		foreach($member_srls as $v)
 		{
 			$obj = new stdClass;
-			$obj->point = $this->getPoint($v);
-			$obj->level = $this->getLevel($obj->point, $config->level_step);
+			$obj->point = self::getPoint($v);
+			$obj->level = self::getLevel($obj->point, $config->level_step);
 			$obj->member_srl = $v;
 			$info[] = $obj;
 		}
@@ -151,7 +151,7 @@ class pointModel extends point
 	/**
 	 * @brief Get a list of points members list
 	 */
-	function getMemberList($args = null, $columnList = array())
+	public static function getMemberList($args = null, $columnList = array())
 	{
 		// Arrange the search options
 		$args->is_admin = Context::get('is_admin')=='Y'?'Y':'';
@@ -217,7 +217,7 @@ class pointModel extends point
 
 			foreach($output->data as $key => $val)
 			{
-				$output->data[$key]->level = $this->getLevel($val->point, $config->level_step);
+				$output->data[$key]->level = self::getLevel($val->point, $config->level_step);
 			}
 		}
 

--- a/modules/point/point.view.php
+++ b/modules/point/point.view.php
@@ -33,12 +33,11 @@ class pointView extends point
 			if(!$current_module_srl) return;
 		}
 		// Get the configuration information
-		$oModuleModel = getModel('module');
-		$config = $oModuleModel->getModuleConfig('point');
+		$config = ModuleModel::getModuleConfig('point');
 
 		if($current_module_srl)
 		{
-			$module_config = $oModuleModel->getModulePartConfig('point', $current_module_srl);
+			$module_config = ModuleModel::getModulePartConfig('point', $current_module_srl);
 			if(!$module_config)
 			{
 				$module_config['insert_document'] = $config->insert_document;


### PR DESCRIPTION
#1292 후속으로, 단순히 정보를 불러오는 성격의 메소드들은 모듈 인스턴스를 생성할 필요 없이 static으로 직접 호출할 수 있도록 합니다. 물론 기존 방식으로도 호출할 수 있으나, static으로 호출하면 코드가 훨씬 짧고 간결해집니다.

기존:

    $oMemberModel = getModel('member');
    $member_info = $oMemberModel->getMemberInfoByMemberSrl($member_srl);

또는 #1292 적용 후:

    $member_info = MemberModel::getInstance()->getMemberInfoByMemberSrl($member_srl);

이제부터는:

    $member_info = MemberModel::getMemberInfo($member_srl);

(`ByMemberSrl`을 생략해도 됩니다.^^)

우선 변경 대상은 코어와 서드파티 자료에서 가장 많이 사용하는 6개의 model 클래스입니다.

- ModuleModel
- MemberModel
- DocumentModel
- CommentModel
- FileModel
- PointModel

적용 타겟은 next 브랜치(2.0)입니다.