### PR TITLE
#1244 최신 iOS 13.5.1에서 한글 입력시 엔터키 호환성 개선

### DIFF
--- a/common/js/plugins/ckeditor/ckeditor/plugins/ios_enterkey/plugin.js
+++ b/common/js/plugins/ckeditor/ckeditor/plugins/ios_enterkey/plugin.js
@@ -3,22 +3,124 @@
  *
  * https://github.com/rhymix/rhymix/issues/932
  */
-CKEDITOR.plugins.add( 'ios_enterkey',
-{
-	icons: 'ios_enterkey',
-	init: function(editor)
-	{
-		editor.on('contentDom', function()
-		{
-			var editable = editor.editable();
-			editable.attachListener(editable, 'keyup', function(e)
-			{
-				if(e.data.getKey() === 13)
-				{
-					$(editor.document.$).find('.cke_wysiwyg_div').blur();
-					$(editor.document.$).find('.cke_wysiwyg_div').focus();
-				}
-			});
-		});
-	}
+CKEDITOR.plugins.add( 'ios_enterkey', {
+  icons: 'ios_enterkey',
+  init: function(editor) {
+    editor.setKeystroke( [
+      [ 13, '' ],
+      [ CKEDITOR.SHIFT + 13, '' ]
+    ] );
+
+    editor.on('contentDom', function() {
+      var selection;
+      var bookmarks;
+      var range;
+      var data;
+      var shift = false;
+
+      var editable = editor.editable();
+      editable.attachListener(editable, 'keyup', function(e) {
+
+        if(e.data.getKey() === 13) {
+          var eventData = {
+            dataValue: data
+          };
+          editor.fire( 'afterSetData', eventData );
+
+          range.moveToBookmark(bookmarks[0]);
+          range.collapse( true );
+          range.select();
+
+          if(shift) {
+            shiftEnter(editor);
+          } else {
+            enter(editor);
+          }
+
+          shift = false;
+        }
+      });
+
+      editable.attachListener(editable, 'keydown', function(e) {
+        if(e.data.getKey() === 13) {
+          selection = editor.getSelection();
+          bookmarks = selection.createBookmarks(true);
+          data = editor.getData();
+          range = selection.getRanges()[0];
+
+          if(e.data.$.shiftKey) shift = true;
+        }
+      });
+    });
+
+    plugin = CKEDITOR.plugins.enterkey;
+    enterBr = plugin.enterBr;
+    enterBlock = plugin.enterBlock;
+    headerTagRegex = /^h[1-6]$/;
+
+    function shiftEnter( editor ) {
+      // On SHIFT+ENTER:
+      // 1. We want to enforce the mode to be respected, instead
+      // of cloning the current block. (https://dev.ckeditor.com/ticket/77)
+      return enter( editor, editor.activeShiftEnterMode, 1 );
+    }
+
+    function enter( editor, mode, forceMode ) {
+      forceMode = editor.config.forceEnterMode || forceMode;
+
+      // Only effective within document.
+      if ( editor.mode != 'wysiwyg' )
+        return;
+
+      if ( !mode )
+        mode = editor.activeEnterMode;
+
+      // TODO this should be handled by setting editor.activeEnterMode on selection change.
+      // Check path block specialities:
+      // 1. Cannot be a un-splittable element, e.g. table caption;
+      var path = editor.elementPath();
+
+      if ( path && !path.isContextFor( 'p' ) ) {
+        mode = CKEDITOR.ENTER_BR;
+        forceMode = 1;
+      }
+
+      editor.fire( 'saveSnapshot' ); // Save undo step.
+
+      if ( mode == CKEDITOR.ENTER_BR )
+        enterBr( editor, mode, null, forceMode );
+      else
+        enterBlock( editor, mode, null, forceMode );
+
+      editor.fire( 'saveSnapshot' );
+    }
+
+    function getRange( editor ) {
+      // Get the selection ranges.
+      var ranges = editor.getSelection().getRanges( true );
+
+      // Delete the contents of all ranges except the first one.
+      for ( var i = ranges.length - 1; i > 0; i-- ) {
+        ranges[ i ].deleteContents();
+      }
+
+      // Return the first range.
+      return ranges[ 0 ];
+    }
+
+    function replaceRangeWithClosestEditableRoot( range ) {
+      var closestEditable = range.startContainer.getAscendant( function( node ) {
+        return node.type == CKEDITOR.NODE_ELEMENT && node.getAttribute( 'contenteditable' ) == 'true';
+      }, true );
+
+      if ( range.root.equals( closestEditable ) ) {
+        return range;
+      } else {
+        var newRange = new CKEDITOR.dom.range( closestEditable );
+
+        newRange.moveToRange( range );
+        return newRange;
+      }
+    }
+  }
 });


### PR DESCRIPTION
접수 된 #1244 이슈에 대해서 원인 확인 결과 최신 iOS에서 e.preventDefault()로 keydown이 중지 되었을 시 IME가 종료되지 않는 버그를 확인했습니다.

#### 원인
- ckeditor의 enterkey plugin에서 enter (13) 키와 shift + enter (13) 키를 단축키로 지정하고 있기 때문에 강제로 e.preventDefault() 되어버립니다. 강제 중지된 이벤트에 IME를 종료하지 않는 문제가 있습니다.
- 이전 iOS에서는 이것을 blur, focus로 IME를 강제 종료할 수 있었지만 최신 iOS에서는 종료되지 않고 있습니다.

#### 개선
- ios_enterkey 플러그인의 blur, focus 방식을 제거하고, e.preventDefault()를 수행하지 않으며 enterkey 플러그인과 동일한 플러그인으로 대체 합니다.

#### 문제점
- 이 개선 내용으로 iframe 방식으로도 IME문제를 해결할 수 있지만 개행이 많아질 경우 포커스를 찾지 못하는 증상은 여전하기에 divarea 플러그인은 계속 사용되어야 합니다.
- iOS에서 글 색상을 적용하지 못하는 문제가 있습니다. (단락 변경 등 한번 에디팅 한 경우는 문제없음)

#### 주의점
- 이 개선 내용을 적용하지 않고 enterkey 플러그인만 제거할 경우 H1~H6 등의 단락에서 개행시, br 모드에서 개행시 모두 div로 생성되니 주의가 필요합니다.