### PR TITLE
회원 닉네임 변경 기록에 검색 옵션을 추가.

### DIFF
--- a/modules/member/lang/ko.php
+++ b/modules/member/lang/ko.php
@@ -367,3 +367,4 @@ $lang->scrap_folder_create = '폴더 추가';
 $lang->scrap_folder_rename = '이름 변경';
 $lang->scrap_folder_delete = '삭제';
 $lang->member_unauthenticated = '미인증';
+$lang->member_number = '회원 번호';

--- a/modules/member/member.class.php
+++ b/modules/member/member.class.php
@@ -225,6 +225,10 @@ class member extends ModuleObject {
 		
 		// Check scrap folder table
 		if(!$oDB->isColumnExists("member_scrap", "folder_srl")) return true;
+
+		if(!$oDB->isIndexExists('member_nickname_log', 'idx_before_nick_name')) return true;
+		if(!$oDB->isIndexExists('member_nickname_log', 'idx_after_nick_name')) return true;
+		if(!$oDB->isIndexExists('member_nickname_log', 'idx_user_id')) return true;
 		
 		$oModuleModel = getModel('module');
 		$config = $oModuleModel->getModuleConfig('member');
@@ -437,6 +441,14 @@ class member extends ModuleObject {
 		{
 			$oDB->addColumn("member_scrap", "folder_srl", "number", 11);
 			$oDB->addIndex("member_scrap","idx_folder_srl", array("folder_srl"));
+		}
+		
+		// Add to index in member nickname log table. 2020. 07 .20 @BJRambo
+		if(!$oDB->isIndexExists('member_nickname_log', 'idx_before_nick_name'))
+		{
+			$oDB->addIndex('member_nickname_log', 'idx_before_nick_name', array('before_nick_name'));
+			$oDB->addIndex('member_nickname_log', 'idx_after_nick_name', array('after_nick_name'));
+			$oDB->addIndex('member_nickname_log', 'idx_user_id', array('user_id'));
 		}
 		
 		$oModuleModel = getModel('module');

--- a/modules/member/member.model.php
+++ b/modules/member/member.model.php
@@ -1247,10 +1247,44 @@ class memberModel extends member
 	
 	function getMemberModifyNicknameLog($page = 1, $member_srl = null)
 	{
+		$search_keyword = Context::get('search_keyword');
+		$search_target = Context::get('search_target');
+		
+		// $this->user 에 재대로 된 회원 정보가 들어 가지 않음.
+		$logged_info = Context::get('logged_info');
+
 		$args = new stdClass();
-		$args->member_srl = $member_srl;
 		$args->page = $page;
-		$output = executeQueryArray('member.getMemberModifyNickName', $args);
+		if($logged_info->is_admin == 'Y')
+		{
+			if($search_keyword && $search_keyword)
+			{
+				switch ($search_target)
+				{
+					case "before":
+						$args->before_nick_name = $search_keyword;
+						break;
+					case "after":
+						$args->after_nick_name = $search_keyword;
+						break;
+					case "user_id":
+						if($search_keyword) $search_keyword = str_replace(' ','%',$search_keyword);
+						$args->user_id = $search_keyword;
+						break;
+					case "member_srl":
+						$args->member_srl = intval($search_keyword);
+						break;
+					default:
+						break;
+				}
+				$output = executeQuery('member.getMemberModifyNickName', $args);
+				
+				return $output;
+			}
+		}
+		
+		$args->member_srl = $member_srl;
+		$output = executeQuery('member.getMemberModifyNickName', $args);
 		
 		return $output;
 	}

--- a/modules/member/queries/getMemberModifyNickName.xml
+++ b/modules/member/queries/getMemberModifyNickName.xml
@@ -7,6 +7,9 @@
 	</columns>
 	<conditions>
 		<condition operation="equal" column="member_srl" var="member_srl" />
+		<condition operation="equal" column="user_id" var="user_id" pipe="or" />
+		<condition operation="like" column="after_nick_name" var="after_nick_name" pipe="or" />
+		<condition operation="like" column="before_nick_name" var="before_nick_name" pipe="or" />
 	</conditions>
 	<navigation>
 		<index var="sort_index" default="regdate" order="desc" />

--- a/modules/member/schemas/member_nickname_log.xml
+++ b/modules/member/schemas/member_nickname_log.xml
@@ -1,7 +1,7 @@
 <table name="member_nickname_log">
-	<column name="member_srl" type="number" size="11" notnull="notnull" />
-	<column name="before_nick_name" type="varchar" size="80" notnull="notnull" />
-	<column name="after_nick_name" type="varchar" size="80" notnull="notnull" />
+	<column name="member_srl" type="number" size="11" notnull="notnull" index="idx_member_srl" />
+	<column name="before_nick_name" type="varchar" size="80" notnull="notnull" index="idx_before_nick_name" />
+	<column name="after_nick_name" type="varchar" size="80" notnull="notnull" index="idx_after_nick_name" />
 	<column name="regdate" type="date" index="idx_regdate" />
-	<column name="user_id" type="varchar" size="80" />
+	<column name="user_id" type="varchar" size="80" index="idx_user_id" />
 </table>

--- a/modules/member/tpl/nick_name_log.html
+++ b/modules/member/tpl/nick_name_log.html
@@ -27,6 +27,19 @@
 		</tr>
 	</tbody>
 </table>
+
+<form action="./" method="get" class="search center x_input-append" no-error-return-url="true">
+	<input type="hidden" name="module" value="{$module}" />
+	<select name="search_target" style="margin-right:4px" title="{$lang->search_target}">
+		<option value="before" selected="selected"|cond="$search_target=='before'">{$lang->nick_name_before_changing}</option>
+		<option value="after" selected="selected"|cond="$search_target=='after'">{$lang->nick_name_after_changing}</option>
+		<option value="user_id" selected="selected"|cond="$search_target=='user_id'">{$lang->user_id}</option>
+		<option value="member_srl" selected="selected"|cond="$search_target=='member_srl'">{$lang->member_number}</option>
+	</select>
+	<input type="search" name="search_keyword" value="{htmlspecialchars($search_keyword, ENT_COMPAT | ENT_HTML401, 'UTF-8', false)}" style="width:140px">
+	<button class="x_btn x_btn-inverse" type="submit">{$lang->cmd_search}</button>
+</form>
+
 <div class="x_clearfix">
 	<div class="x_pagination x_pull-left">
 		<ul>


### PR DESCRIPTION
회원 닉네임 변경 기록에 검색 옵션을 추가 합니다.

#599 

클래스에서 회원 변경 로그기록에 필요한 인덱스들을 추가 하였습니다.

그리고 검색은 관리자 페이지에서만 가능합니다.