### PR TITLE
에디터에 스크롤이 생기는 문제 해결

### DIFF
--- a/modules/editor/skins/ckeditor/css/default.less
+++ b/modules/editor/skins/ckeditor/css/default.less
@@ -53,6 +53,7 @@ html {
 	}
 	body.cke_editable {
 		min-height: 100vh;
+		box-sizing: border-box;
 		padding: 10px;
 		.light_dark(@colorset);
 	}


### PR DESCRIPTION
https://github.com/rhymix/rhymix/issues/1375 관련.

에디터 영역에만 box-sizing을 지정해주는 것으로 수정을 최소화 함.