### PR TITLE
_XE_LOCATION_SITE_ and _XE_DOWNLOAD_SERVER_ 

### DIFF
--- a/common/autoload.php
+++ b/common/autoload.php
@@ -36,6 +36,14 @@ if (function_exists('mb_regex_encoding'))
 }
 
 /**
+ * Load user configuration.
+ */
+if(file_exists(RX_BASEDIR . 'config/config.user.inc.php'))
+{
+	require_once RX_BASEDIR . 'config/config.user.inc.php';
+}
+
+/**
  * Load constants and common functions.
  */
 require_once __DIR__ . '/constants.php';
@@ -136,14 +144,6 @@ require_once RX_BASEDIR . 'vendor/autoload.php';
  * Load essential classes.
  */
 require_once RX_BASEDIR . 'classes/object/Object.class.php';
-
-/**
- * Load user configuration.
- */
-if(file_exists(RX_BASEDIR . 'config/config.user.inc.php'))
-{
-	require_once RX_BASEDIR . 'config/config.user.inc.php';
-}
 
 /**
  * Load system configuration.

--- a/common/constants.php
+++ b/common/constants.php
@@ -141,8 +141,14 @@ define('__ZBXE_VERSION__', RX_VERSION);
 define('_XE_PATH_', RX_BASEDIR);
 define('_XE_PACKAGE_', 'XE');
 define('_XE_LOCATION_', 'en');
-define('_XE_LOCATION_SITE_', 'https://xe1.xpressengine.com/');
-define('_XE_DOWNLOAD_SERVER_', 'https://download.xpressengine.com/');
+if (!define('_XE_LOCATION_SITE_'))
+{
+	define('_XE_LOCATION_SITE_', 'https://xe1.xpressengine.com/');
+}
+if (!define('_XE_DOWNLOAD_SERVER_'))
+{
+	define('_XE_DOWNLOAD_SERVER_', 'https://download.xpressengine.com/');
+}
 define('__DEBUG__', 0);
 
 /**


### PR DESCRIPTION
기존의 쉬운설치 자료실을 커스텀하게 지원할 수 있도록 옵션을 만들어 주고 싶었습니다.

autoload.php 에서 constants.php 파일보다 config.user.inc.php 파일을 먼저 로드하여

constants.php 에 존재하는 _XE_LOCATION_SITE_ 와 _XE_DOWNLOAD_SERVER_ 를 

코어 변경 없이 config.user.inc.php 이곳에 설정할 수 있도록 합니다.
