### PR TITLE
쉬운설치 모듈 개선

### DIFF
--- a/common/constants.php
+++ b/common/constants.php
@@ -141,8 +141,8 @@ define('__ZBXE_VERSION__', RX_VERSION);
 define('_XE_PATH_', RX_BASEDIR);
 define('_XE_PACKAGE_', 'XE');
 define('_XE_LOCATION_', 'en');
-define('_XE_LOCATION_SITE_', 'https://xe1.xpressengine.com/');
-define('_XE_DOWNLOAD_SERVER_', 'https://download.xpressengine.com/');
+//define('_XE_LOCATION_SITE_', 'https://xe1.xpressengine.com/');
+//define('_XE_DOWNLOAD_SERVER_', 'https://download.xpressengine.com/');
 define('__DEBUG__', 0);
 
 /**

--- a/modules/admin/admin.admin.view.php
+++ b/modules/admin/admin.admin.view.php
@@ -104,16 +104,14 @@ class adminAdminView extends admin
 			return;
 		}
 
-		$oModuleModel = getModel('module');
-		$module_info = $oModuleModel->getModuleConfig('autoinstall');
-		$location_site = $module_info->location_site ? $module_info->location_site : 'https://xe1.xpressengine.com/';
-		$download_server = $module_info->download_server ? $module_info->download_server : 'https://download.xpressengine.com/';
+		$oModel = getAdminModel('autoinstall');
+		$config = $oModel->getAutoInstallAdminModuleConfig();
 
 		$oAutoinstallModel = getModel('autoinstall');
 		$params = array();
 		$params["act"] = "getResourceapiLastupdate";
 		$body = XmlGenerater::generate($params);
-		$buff = FileHandler::getRemoteResource($download_server, $body, 3, "POST", "application/xml");
+		$buff = FileHandler::getRemoteResource($config->download_server, $body, 3, "POST", "application/xml");
 		$xml_lUpdate = new XmlParser();
 		$lUpdateDoc = $xml_lUpdate->parse($buff);
 		$updateDate = $lUpdateDoc->response->updatedate->body;

--- a/modules/admin/admin.admin.view.php
+++ b/modules/admin/admin.admin.view.php
@@ -104,8 +104,8 @@ class adminAdminView extends admin
 			return;
 		}
 
-		$oModel = getAdminModel('autoinstall');
-		$config = $oModel->getAutoInstallAdminModuleConfig();
+		$oAdminModel = getAdminModel('autoinstall');
+		$config = $oAdminModel->getAutoInstallAdminModuleConfig();
 
 		$oAutoinstallModel = getModel('autoinstall');
 		$params = array();

--- a/modules/admin/admin.admin.view.php
+++ b/modules/admin/admin.admin.view.php
@@ -104,11 +104,16 @@ class adminAdminView extends admin
 			return;
 		}
 
+		$oModuleModel = getModel('module');
+		$module_info = $oModuleModel->getModuleConfig('autoinstall');
+		$location_site = $module_info->location_site ? $module_info->location_site : 'https://xe1.xpressengine.com/';
+		$download_server = $module_info->download_server ? $module_info->download_server : 'https://download.xpressengine.com/';
+
 		$oAutoinstallModel = getModel('autoinstall');
 		$params = array();
 		$params["act"] = "getResourceapiLastupdate";
 		$body = XmlGenerater::generate($params);
-		$buff = FileHandler::getRemoteResource(_XE_DOWNLOAD_SERVER_, $body, 3, "POST", "application/xml");
+		$buff = FileHandler::getRemoteResource($download_server, $body, 3, "POST", "application/xml");
 		$xml_lUpdate = new XmlParser();
 		$lUpdateDoc = $xml_lUpdate->parse($buff);
 		$updateDate = $lUpdateDoc->response->updatedate->body;

--- a/modules/admin/admin.admin.view.php
+++ b/modules/admin/admin.admin.view.php
@@ -104,8 +104,8 @@ class adminAdminView extends admin
 			return;
 		}
 
-		$oAdminModel = getAdminModel('autoinstall');
-		$config = $oAdminModel->getAutoInstallAdminModuleConfig();
+		$oAutoinstallAdminModel = getAdminModel('autoinstall');
+		$config = $oAutoinstallAdminModel->getAutoInstallAdminModuleConfig();
 
 		$oAutoinstallModel = getModel('autoinstall');
 		$params = array();

--- a/modules/autoinstall/autoinstall.admin.controller.php
+++ b/modules/autoinstall/autoinstall.admin.controller.php
@@ -434,9 +434,21 @@ class autoinstallAdminController extends autoinstall
 
 	function procAutoinstallAdminInsertConfig()
 	{
+		// if end of string does not have a slash, add it
+		$_location_site = Context::get('location_site');
+		if(substr($_location_site, -1) != '/')
+		{
+			$_location_site .= '/';
+		}
+		$_download_server = Context::get('download_server');
+		if(substr($_download_server, -1) != '/')
+		{
+			$_download_server .= '/';
+		}
+		
 		$args = new stdClass();
-		$args->location_site = Context::get('location_site');
-		$args->download_server = Context::get('download_server');
+		$args->location_site = $_location_site;
+		$args->download_server = $_download_server;
 
 		$oModuleController = getController('module');
 		$output = $oModuleController->updateModuleConfig('autoinstall', $args);

--- a/modules/autoinstall/autoinstall.admin.controller.php
+++ b/modules/autoinstall/autoinstall.admin.controller.php
@@ -415,7 +415,7 @@ class autoinstallAdminController extends autoinstall
 		$module_info = $oModuleModel->getModuleConfig('autoinstall');
 		$location_site = $module_info->location_site;
 		$download_server = $module_info->download_server;
-		
+
 		$oModuleInstaller->setServerUrl($download_server);
 
 		$oModuleInstaller->setPassword($ftp_password);
@@ -440,18 +440,11 @@ class autoinstallAdminController extends autoinstall
 
 		$oModuleController = getController('module');
 		$output = $oModuleController->updateModuleConfig('autoinstall', $args);
-
-		// init. autoinstall DB data
-		$oDB = DB::getInstance();
-		// truncate table rx_ai_installed_packages
-		$sql_a = 'truncate table '.$oDB->prefix.'ai_installed_packages';
-		$oDB->_query($sql_a);
-		// truncate table rx_ai_remote_categories
-		$sql_b = 'truncate table '.$oDB->prefix.'ai_remote_categories';
-		$oDB->_query($sql_b);
-		// truncate table rx_autoinstall_packages
-		$sql_c = 'truncate table '.$oDB->prefix.'autoinstall_packages';
-		$oDB->_query($sql_c);
+	
+		// init. DB tables
+		executeQuery("autoinstall.deletePackages");
+		executeQuery("autoinstall.deleteCategory");
+		executeQuery("autoinstall.deleteInstalledPackage");
 		
 		// default setting end
 		$this->setMessage('success_updated');

--- a/modules/autoinstall/autoinstall.admin.controller.php
+++ b/modules/autoinstall/autoinstall.admin.controller.php
@@ -75,8 +75,8 @@ class autoinstallAdminController extends autoinstall
 			'ssl_verify_host' => FALSE
 		);
 
-		$oModel = getAdminModel('autoinstall');
-		$config = $oModel->getAutoInstallAdminModuleConfig();
+		$oAdminModel = getAdminModel('autoinstall');
+		$config = $oAdminModel->getAutoInstallAdminModuleConfig();
 
 		$buff = FileHandler::getRemoteResource($config->download_server, $body, 3, "POST", "application/xml", array(), array(), array(), $request_config);
 		$xml = new XmlParser();
@@ -227,8 +227,8 @@ class autoinstallAdminController extends autoinstall
 				$oModuleInstaller = new FTPModuleInstaller($package);
 			}
 
-			$oModel = getAdminModel('autoinstall');
-			$config = $oModel->getAutoInstallAdminModuleConfig();
+			$oAdminModel = getAdminModel('autoinstall');
+			$config = $oAdminModel->getAutoInstallAdminModuleConfig();
 
 			$oModuleInstaller->setServerUrl($config->download_server);
 			$oModuleInstaller->setPassword($ftp_password);
@@ -403,8 +403,8 @@ class autoinstallAdminController extends autoinstall
 			$oModuleInstaller = new FTPModuleInstaller($package);
 		}
 
-		$oModel = getAdminModel('autoinstall');
-		$config = $oModel->getAutoInstallAdminModuleConfig();
+		$oAdminModel = getAdminModel('autoinstall');
+		$config = $oAdminModel->getAutoInstallAdminModuleConfig();
 
 		$oModuleInstaller->setServerUrl($config->download_server);
 

--- a/modules/autoinstall/autoinstall.admin.controller.php
+++ b/modules/autoinstall/autoinstall.admin.controller.php
@@ -16,10 +16,6 @@ class autoinstallAdminController extends autoinstall
 	 */
 	function init()
 	{
-		$oModuleModel = getModel('module');
-		$module_info = $oModuleModel->getModuleConfig('autoinstall');
-		$location_site = $module_info->location_site ? $module_info->location_site : 'https://xe1.xpressengine.com/';
-		$download_server = $module_info->download_server ? $module_info->download_server : 'https://download.xpressengine.com/';
 	}
 
 	/**
@@ -79,12 +75,10 @@ class autoinstallAdminController extends autoinstall
 			'ssl_verify_host' => FALSE
 		);
 
-		$oModuleModel = getModel('module');
-		$module_info = $oModuleModel->getModuleConfig('autoinstall');
-		$location_site = $module_info->location_site;
-		$download_server = $module_info->download_server;
+		$oModel = getAdminModel('autoinstall');
+		$config = $oModel->getAutoInstallAdminModuleConfig();
 
-		$buff = FileHandler::getRemoteResource($download_server, $body, 3, "POST", "application/xml", array(), array(), array(), $request_config);
+		$buff = FileHandler::getRemoteResource($config->download_server, $body, 3, "POST", "application/xml", array(), array(), array(), $request_config);
 		$xml = new XmlParser();
 		$xmlDoc = $xml->parse($buff);
 		$this->updateCategory($xmlDoc);
@@ -233,12 +227,10 @@ class autoinstallAdminController extends autoinstall
 				$oModuleInstaller = new FTPModuleInstaller($package);
 			}
 
-			$oModuleModel = getModel('module');
-			$module_info = $oModuleModel->getModuleConfig('autoinstall');
-			$location_site = $module_info->location_site;
-			$download_server = $module_info->download_server;
+			$oModel = getAdminModel('autoinstall');
+			$config = $oModel->getAutoInstallAdminModuleConfig();
 
-			$oModuleInstaller->setServerUrl($download_server);
+			$oModuleInstaller->setServerUrl($config->download_server);
 			$oModuleInstaller->setPassword($ftp_password);
 			$output = $oModuleInstaller->install();
 			if(!$output->toBool())
@@ -411,12 +403,10 @@ class autoinstallAdminController extends autoinstall
 			$oModuleInstaller = new FTPModuleInstaller($package);
 		}
 
-		$oModuleModel = getModel('module');
-		$module_info = $oModuleModel->getModuleConfig('autoinstall');
-		$location_site = $module_info->location_site;
-		$download_server = $module_info->download_server;
+		$oModel = getAdminModel('autoinstall');
+		$config = $oModel->getAutoInstallAdminModuleConfig();
 
-		$oModuleInstaller->setServerUrl($download_server);
+		$oModuleInstaller->setServerUrl($config->download_server);
 
 		$oModuleInstaller->setPassword($ftp_password);
 		$output = $oModuleInstaller->uninstall();
@@ -436,12 +426,12 @@ class autoinstallAdminController extends autoinstall
 	{
 		// if end of string does not have a slash, add it
 		$_location_site = Context::get('location_site');
-		if(substr($_location_site, -1) != '/')
+		if(substr($_location_site, -1) != '/' && strlen($_location_site) > 0)
 		{
 			$_location_site .= '/';
 		}
 		$_download_server = Context::get('download_server');
-		if(substr($_download_server, -1) != '/')
+		if(substr($_download_server, -1) != '/' && strlen($_download_server) > 0)
 		{
 			$_download_server .= '/';
 		}

--- a/modules/autoinstall/autoinstall.admin.controller.php
+++ b/modules/autoinstall/autoinstall.admin.controller.php
@@ -18,10 +18,8 @@ class autoinstallAdminController extends autoinstall
 	{
 		$oModuleModel = getModel('module');
 		$module_info = $oModuleModel->getModuleConfig('autoinstall');
-		$location_site = $module_info->location_site;
-		$download_server = $module_info->download_server;
-		define('_XE_LOCATION_SITE_', $location_site ? $location_site : 'https://xe1.xpressengine.com/');
-		define('_XE_DOWNLOAD_SERVER_', $download_server ? $download_server : 'https://download.xpressengine.com/');
+		$location_site = $module_info->location_site ? $module_info->location_site : 'https://xe1.xpressengine.com/';
+		$download_server = $module_info->download_server ? $module_info->download_server : 'https://download.xpressengine.com/';
 	}
 
 	/**
@@ -80,7 +78,13 @@ class autoinstallAdminController extends autoinstall
 			'ssl_verify_peer' => FALSE,
 			'ssl_verify_host' => FALSE
 		);
-		$buff = FileHandler::getRemoteResource(_XE_DOWNLOAD_SERVER_, $body, 3, "POST", "application/xml", array(), array(), array(), $request_config);
+
+		$oModuleModel = getModel('module');
+		$module_info = $oModuleModel->getModuleConfig('autoinstall');
+		$location_site = $module_info->location_site;
+		$download_server = $module_info->download_server;
+
+		$buff = FileHandler::getRemoteResource($download_server, $body, 3, "POST", "application/xml", array(), array(), array(), $request_config);
 		$xml = new XmlParser();
 		$xmlDoc = $xml->parse($buff);
 		$this->updateCategory($xmlDoc);
@@ -229,7 +233,12 @@ class autoinstallAdminController extends autoinstall
 				$oModuleInstaller = new FTPModuleInstaller($package);
 			}
 
-			$oModuleInstaller->setServerUrl(_XE_DOWNLOAD_SERVER_);
+			$oModuleModel = getModel('module');
+			$module_info = $oModuleModel->getModuleConfig('autoinstall');
+			$location_site = $module_info->location_site;
+			$download_server = $module_info->download_server;
+
+			$oModuleInstaller->setServerUrl($download_server);
 			$oModuleInstaller->setPassword($ftp_password);
 			$output = $oModuleInstaller->install();
 			if(!$output->toBool())
@@ -402,7 +411,12 @@ class autoinstallAdminController extends autoinstall
 			$oModuleInstaller = new FTPModuleInstaller($package);
 		}
 
-		$oModuleInstaller->setServerUrl(_XE_DOWNLOAD_SERVER_);
+		$oModuleModel = getModel('module');
+		$module_info = $oModuleModel->getModuleConfig('autoinstall');
+		$location_site = $module_info->location_site;
+		$download_server = $module_info->download_server;
+		
+		$oModuleInstaller->setServerUrl($download_server);
 
 		$oModuleInstaller->setPassword($ftp_password);
 		$output = $oModuleInstaller->uninstall();

--- a/modules/autoinstall/autoinstall.admin.controller.php
+++ b/modules/autoinstall/autoinstall.admin.controller.php
@@ -16,7 +16,12 @@ class autoinstallAdminController extends autoinstall
 	 */
 	function init()
 	{
-
+		$oModuleModel = getModel('module');
+		$module_info = $oModuleModel->getModuleConfig('autoinstall');
+		$location_site = $module_info->location_site;
+		$download_server = $module_info->download_server;
+		define('_XE_LOCATION_SITE_', $location_site ? $location_site : 'https://xe1.xpressengine.com/');
+		define('_XE_DOWNLOAD_SERVER_', $download_server ? $download_server : 'https://download.xpressengine.com/');
 	}
 
 	/**
@@ -411,6 +416,34 @@ class autoinstallAdminController extends autoinstall
 		$this->setMessage('success_deleted', 'update');
 
 		return new BaseObject();
+	}
+
+	function procAutoinstallAdminInsertConfig()
+	{
+		$args = new stdClass();
+		$args->location_site = Context::get('location_site');
+		$args->download_server = Context::get('download_server');
+
+		$oModuleController = getController('module');
+		$output = $oModuleController->updateModuleConfig('autoinstall', $args);
+
+		// init. autoinstall DB data
+		$oDB = DB::getInstance();
+		// truncate table rx_ai_installed_packages
+		$sql_a = 'truncate table '.$oDB->prefix.'ai_installed_packages';
+		$oDB->_query($sql_a);
+		// truncate table rx_ai_remote_categories
+		$sql_b = 'truncate table '.$oDB->prefix.'ai_remote_categories';
+		$oDB->_query($sql_b);
+		// truncate table rx_autoinstall_packages
+		$sql_c = 'truncate table '.$oDB->prefix.'autoinstall_packages';
+		$oDB->_query($sql_c);
+		
+		// default setting end
+		$this->setMessage('success_updated');
+
+		$returnUrl = Context::get('success_return_url') ? Context::get('success_return_url') : getNotEncodedUrl('', 'module', 'admin', 'act', 'dispAutoinstallAdminConfig');
+		$this->setRedirectUrl($returnUrl);
 	}
 
 }

--- a/modules/autoinstall/autoinstall.admin.model.php
+++ b/modules/autoinstall/autoinstall.admin.model.php
@@ -423,32 +423,15 @@ class autoinstallAdminModel extends autoinstall
 	public function getAutoInstallAdminModuleConfig()
 	{
 		$oModuleModel = getModel('module');
-		$module_info = $oModuleModel->getModuleConfig('autoinstall');
+		$config_info = $oModuleModel->getModuleConfig('autoinstall');
 		$_location_site = 'https://xe1.xpressengine.com/';
 		$_download_server = 'https://download.xpressengine.com/';
-		if($module_info->location_site && $module_info->download_server)
-		{
-			$location_site = $module_info->location_site;
-			$download_server = $module_info->download_server;
-		}
-		else
-		{
-			$args = new stdClass();
-			$args->location_site = $_location_site;
-			$args->download_server = $_download_server;
 
-			$oModuleController = getController('module');
-			$output = $oModuleController->updateModuleConfig('autoinstall', $args);
-
-			$location_site = $module_info->location_site;
-			$download_server = $module_info->download_server;
-		}
-
-		$obj = new stdClass();
-		$obj->location_site = $location_site ? $location_site : $_location_site;
-		$obj->download_server = $download_server ? $download_server : $_download_server;
+		$config = new stdClass();
+		$config->location_site = $config_info->location_site ? $config_info->location_site : $_location_site;
+		$config->download_server = $config_info->download_server ? $config_info->download_server : $_download_server;
 		
-		return $obj;
+		return $config;
 	}
 
 }

--- a/modules/autoinstall/autoinstall.admin.model.php
+++ b/modules/autoinstall/autoinstall.admin.model.php
@@ -420,6 +420,37 @@ class autoinstallAdminModel extends autoinstall
 		return new BaseObject();
 	}
 
+	public function getAutoInstallAdminModuleConfig()
+	{
+		$oModuleModel = getModel('module');
+		$module_info = $oModuleModel->getModuleConfig('autoinstall');
+		$_location_site = 'https://xe1.xpressengine.com/';
+		$_download_server = 'https://download.xpressengine.com/';
+		if($module_info->location_site && $module_info->download_server)
+		{
+			$location_site = $module_info->location_site;
+			$download_server = $module_info->download_server;
+		}
+		else
+		{
+			$args = new stdClass();
+			$args->location_site = $_location_site;
+			$args->download_server = $_download_server;
+
+			$oModuleController = getController('module');
+			$output = $oModuleController->updateModuleConfig('autoinstall', $args);
+
+			$location_site = $module_info->location_site;
+			$download_server = $module_info->download_server;
+		}
+
+		$obj = new stdClass();
+		$obj->location_site = $location_site ? $location_site : $_location_site;
+		$obj->download_server = $download_server ? $download_server : $_download_server;
+		
+		return $obj;
+	}
+
 }
 /* End of file autoinstall.admin.model.php */
 /* Location: ./modules/autoinstall/autoinstall.admin.model.php */

--- a/modules/autoinstall/autoinstall.admin.view.php
+++ b/modules/autoinstall/autoinstall.admin.view.php
@@ -617,9 +617,9 @@ class autoinstallAdminView extends autoinstall
 	 */
 	function dispAutoinstallAdminConfig()
 	{
-		$oModuleModel = getModel('module');
-		$module_info = $oModuleModel->getModuleConfig('autoinstall');
-		Context::set('config', $module_info);
+		$oAdminModel = getAdminModel('autoinstall');
+        $config = $oAdminModel->getAutoInstallAdminModuleConfig();
+		Context::set('config', $config);
 		$this->setTemplateFile('config');
 	}
 }

--- a/modules/autoinstall/autoinstall.admin.view.php
+++ b/modules/autoinstall/autoinstall.admin.view.php
@@ -27,14 +27,12 @@ class autoinstallAdminView extends autoinstall
 	 */
 	function init()
 	{
-		$oModuleModel = getModel('module');
-		$module_info = $oModuleModel->getModuleConfig('autoinstall');
-		$location_site = $module_info->location_site ? $module_info->location_site : 'https://xe1.xpressengine.com/';
-		$download_server = $module_info->download_server ? $module_info->download_server : 'https://download.xpressengine.com/';
+		$oModel = getAdminModel('autoinstall');
+		$config = $oModel->getAutoInstallAdminModuleConfig();
 
 		$template_path = sprintf("%stpl/", $this->module_path);
-		Context::set('original_site', $location_site);
-		Context::set('uri', $download_server);
+		Context::set('original_site', $config->location_site);
+		Context::set('uri', $config->download_server);
 		$this->setTemplatePath($template_path);
 
 		$ftp_info = Context::getFTPInfo();
@@ -197,17 +195,15 @@ class autoinstallAdminView extends autoinstall
 
 		$depto = array();
 
-		$oModuleModel = getModel('module');
-		$module_info = $oModuleModel->getModuleConfig('autoinstall');
-		$location_site = $module_info->location_site;
-		$download_server = $module_info->download_server;
+		$oModel = getAdminModel('autoinstall');
+		$config = $oModel->getAutoInstallAdminModuleConfig();
 
 		foreach($items as $item)
 		{
 			$v = $this->rearrange($item, $targets);
-			$v->item_screenshot_url = str_replace('./', $download_server, $v->item_screenshot_url);
+			$v->item_screenshot_url = str_replace('./', $config->download_server, $v->item_screenshot_url);
 			$v->category = $this->categories[$v->category_srl]->title;
-			$v->url = $location_site . '?mid=download&package_srl=' . $v->package_srl;
+			$v->url = $config->location_site . '?mid=download&package_srl=' . $v->package_srl;
 
 			if($packages[$v->package_srl])
 			{
@@ -334,13 +330,11 @@ class autoinstallAdminView extends autoinstall
 			'ssl_verify_peer' => FALSE,
 			'ssl_verify_host' => FALSE
 		);
-		
-		$oModuleModel = getModel('module');
-		$module_info = $oModuleModel->getModuleConfig('autoinstall');
-		$location_site = $module_info->location_site;
-		$download_server = $module_info->download_server;
 
-		$buff = FileHandler::getRemoteResource($download_server, $body, 3, "POST", "application/xml", array(), array(), array(), $request_config);
+		$oModel = getAdminModel('autoinstall');
+		$config = $oModel->getAutoInstallAdminModuleConfig();
+
+		$buff = FileHandler::getRemoteResource($config->download_server, $body, 3, "POST", "application/xml", array(), array(), array(), $request_config);
 		$xml_lUpdate = new XmlParser();
 		$xmlDoc = $xml_lUpdate->parse($buff);
 		if($xmlDoc && $xmlDoc->response->packagelist->item)
@@ -434,12 +428,10 @@ class autoinstallAdminView extends autoinstall
 			'ssl_verify_host' => FALSE
 		);
 
-		$oModuleModel = getModel('module');
-		$module_info = $oModuleModel->getModuleConfig('autoinstall');
-		$location_site = $module_info->location_site;
-		$download_server = $module_info->download_server;
+		$oModel = getAdminModel('autoinstall');
+		$config = $oModel->getAutoInstallAdminModuleConfig();
 
-		$buff = FileHandler::getRemoteResource($download_server, $body, 3, "POST", "application/xml", array(), array(), array(), $request_config);
+		$buff = FileHandler::getRemoteResource($config->download_server, $body, 3, "POST", "application/xml", array(), array(), array(), $request_config);
 		$xml_lUpdate = new XmlParser();
 		$lUpdateDoc = $xml_lUpdate->parse($buff);
 		$updateDate = $lUpdateDoc->response->updatedate->body;
@@ -591,12 +583,10 @@ class autoinstallAdminView extends autoinstall
 			'ssl_verify_host' => FALSE
 		);
 
-		$oModuleModel = getModel('module');
-		$module_info = $oModuleModel->getModuleConfig('autoinstall');
-		$location_site = $module_info->location_site;
-		$download_server = $module_info->download_server;
+		$oModel = getAdminModel('autoinstall');
+		$config = $oModel->getAutoInstallAdminModuleConfig();
 
-		$buff = FileHandler::getRemoteResource($download_server, $body, 3, "POST", "application/xml", array(), array(), array(), $request_config);
+		$buff = FileHandler::getRemoteResource($config->download_server, $body, 3, "POST", "application/xml", array(), array(), array(), $request_config);
 		$xml_lUpdate = new XmlParser();
 		$xmlDoc = $xml_lUpdate->parse($buff);
 		if($xmlDoc && $xmlDoc->response->packagelist->item)

--- a/modules/autoinstall/autoinstall.admin.view.php
+++ b/modules/autoinstall/autoinstall.admin.view.php
@@ -211,7 +211,7 @@ class autoinstallAdminView extends autoinstall
 				$v->current_version = $packages[$v->package_srl]->current_version;
 				// if version is up
 				// insert Y
-				if($v->current_version < $v->item_version)
+				if(version_compare($v->item_version, $v->current_version, '>'))
 				{
 					$v->need_update = 'Y';
 				}

--- a/modules/autoinstall/autoinstall.admin.view.php
+++ b/modules/autoinstall/autoinstall.admin.view.php
@@ -27,8 +27,8 @@ class autoinstallAdminView extends autoinstall
 	 */
 	function init()
 	{
-		$oModel = getAdminModel('autoinstall');
-		$config = $oModel->getAutoInstallAdminModuleConfig();
+		$oAdminModel = getAdminModel('autoinstall');
+		$config = $oAdminModel->getAutoInstallAdminModuleConfig();
 
 		$template_path = sprintf("%stpl/", $this->module_path);
 		Context::set('original_site', $config->location_site);
@@ -195,8 +195,8 @@ class autoinstallAdminView extends autoinstall
 
 		$depto = array();
 
-		$oModel = getAdminModel('autoinstall');
-		$config = $oModel->getAutoInstallAdminModuleConfig();
+		$oAdminModel = getAdminModel('autoinstall');
+		$config = $oAdminModel->getAutoInstallAdminModuleConfig();
 
 		foreach($items as $item)
 		{
@@ -331,8 +331,8 @@ class autoinstallAdminView extends autoinstall
 			'ssl_verify_host' => FALSE
 		);
 
-		$oModel = getAdminModel('autoinstall');
-		$config = $oModel->getAutoInstallAdminModuleConfig();
+		$oAdminModel = getAdminModel('autoinstall');
+		$config = $oAdminModel->getAutoInstallAdminModuleConfig();
 
 		$buff = FileHandler::getRemoteResource($config->download_server, $body, 3, "POST", "application/xml", array(), array(), array(), $request_config);
 		$xml_lUpdate = new XmlParser();
@@ -428,8 +428,8 @@ class autoinstallAdminView extends autoinstall
 			'ssl_verify_host' => FALSE
 		);
 
-		$oModel = getAdminModel('autoinstall');
-		$config = $oModel->getAutoInstallAdminModuleConfig();
+		$oAdminModel = getAdminModel('autoinstall');
+		$config = $oAdminModel->getAutoInstallAdminModuleConfig();
 
 		$buff = FileHandler::getRemoteResource($config->download_server, $body, 3, "POST", "application/xml", array(), array(), array(), $request_config);
 		$xml_lUpdate = new XmlParser();
@@ -583,8 +583,8 @@ class autoinstallAdminView extends autoinstall
 			'ssl_verify_host' => FALSE
 		);
 
-		$oModel = getAdminModel('autoinstall');
-		$config = $oModel->getAutoInstallAdminModuleConfig();
+		$oAdminModel = getAdminModel('autoinstall');
+		$config = $oAdminModel->getAutoInstallAdminModuleConfig();
 
 		$buff = FileHandler::getRemoteResource($config->download_server, $body, 3, "POST", "application/xml", array(), array(), array(), $request_config);
 		$xml_lUpdate = new XmlParser();

--- a/modules/autoinstall/autoinstall.admin.view.php
+++ b/modules/autoinstall/autoinstall.admin.view.php
@@ -29,14 +29,12 @@ class autoinstallAdminView extends autoinstall
 	{
 		$oModuleModel = getModel('module');
 		$module_info = $oModuleModel->getModuleConfig('autoinstall');
-		$location_site = $module_info->location_site;
-		$download_server = $module_info->download_server;
-		define('_XE_LOCATION_SITE_', $location_site ? $location_site : 'https://xe1.xpressengine.com/');
-		define('_XE_DOWNLOAD_SERVER_', $download_server ? $download_server : 'https://download.xpressengine.com/');
+		$location_site = $module_info->location_site ? $module_info->location_site : 'https://xe1.xpressengine.com/';
+		$download_server = $module_info->download_server ? $module_info->download_server : 'https://download.xpressengine.com/';
 
 		$template_path = sprintf("%stpl/", $this->module_path);
-		Context::set('original_site', _XE_LOCATION_SITE_);
-		Context::set('uri', _XE_DOWNLOAD_SERVER_);
+		Context::set('original_site', $location_site);
+		Context::set('uri', $download_server);
 		$this->setTemplatePath($template_path);
 
 		$ftp_info = Context::getFTPInfo();
@@ -199,12 +197,17 @@ class autoinstallAdminView extends autoinstall
 
 		$depto = array();
 
+		$oModuleModel = getModel('module');
+		$module_info = $oModuleModel->getModuleConfig('autoinstall');
+		$location_site = $module_info->location_site;
+		$download_server = $module_info->download_server;
+
 		foreach($items as $item)
 		{
 			$v = $this->rearrange($item, $targets);
-			$v->item_screenshot_url = str_replace('./', _XE_DOWNLOAD_SERVER_, $v->item_screenshot_url);
+			$v->item_screenshot_url = str_replace('./', $download_server, $v->item_screenshot_url);
 			$v->category = $this->categories[$v->category_srl]->title;
-			$v->url = _XE_LOCATION_SITE_ . '?mid=download&package_srl=' . $v->package_srl;
+			$v->url = $location_site . '?mid=download&package_srl=' . $v->package_srl;
 
 			if($packages[$v->package_srl])
 			{
@@ -233,11 +236,7 @@ class autoinstallAdminView extends autoinstall
 
 				if($v->type == "core")
 				{
-					// if default, hide core
-					if(strpos(_XE_DOWNLOAD_SERVER_, 'xpressengine.com')!==false)
-					{
-						continue;
-					}
+					continue;
 				}
 				else if($v->type == "module")
 				{
@@ -335,7 +334,13 @@ class autoinstallAdminView extends autoinstall
 			'ssl_verify_peer' => FALSE,
 			'ssl_verify_host' => FALSE
 		);
-		$buff = FileHandler::getRemoteResource(_XE_DOWNLOAD_SERVER_, $body, 3, "POST", "application/xml", array(), array(), array(), $request_config);
+		
+		$oModuleModel = getModel('module');
+		$module_info = $oModuleModel->getModuleConfig('autoinstall');
+		$location_site = $module_info->location_site;
+		$download_server = $module_info->download_server;
+
+		$buff = FileHandler::getRemoteResource($download_server, $body, 3, "POST", "application/xml", array(), array(), array(), $request_config);
 		$xml_lUpdate = new XmlParser();
 		$xmlDoc = $xml_lUpdate->parse($buff);
 		if($xmlDoc && $xmlDoc->response->packagelist->item)
@@ -428,7 +433,13 @@ class autoinstallAdminView extends autoinstall
 			'ssl_verify_peer' => FALSE,
 			'ssl_verify_host' => FALSE
 		);
-		$buff = FileHandler::getRemoteResource(_XE_DOWNLOAD_SERVER_, $body, 3, "POST", "application/xml", array(), array(), array(), $request_config);
+
+		$oModuleModel = getModel('module');
+		$module_info = $oModuleModel->getModuleConfig('autoinstall');
+		$location_site = $module_info->location_site;
+		$download_server = $module_info->download_server;
+
+		$buff = FileHandler::getRemoteResource($download_server, $body, 3, "POST", "application/xml", array(), array(), array(), $request_config);
 		$xml_lUpdate = new XmlParser();
 		$lUpdateDoc = $xml_lUpdate->parse($buff);
 		$updateDate = $lUpdateDoc->response->updatedate->body;
@@ -579,7 +590,13 @@ class autoinstallAdminView extends autoinstall
 			'ssl_verify_peer' => FALSE,
 			'ssl_verify_host' => FALSE
 		);
-		$buff = FileHandler::getRemoteResource(_XE_DOWNLOAD_SERVER_, $body, 3, "POST", "application/xml", array(), array(), array(), $request_config);
+
+		$oModuleModel = getModel('module');
+		$module_info = $oModuleModel->getModuleConfig('autoinstall');
+		$location_site = $module_info->location_site;
+		$download_server = $module_info->download_server;
+
+		$buff = FileHandler::getRemoteResource($download_server, $body, 3, "POST", "application/xml", array(), array(), array(), $request_config);
 		$xml_lUpdate = new XmlParser();
 		$xmlDoc = $xml_lUpdate->parse($buff);
 		if($xmlDoc && $xmlDoc->response->packagelist->item)

--- a/modules/autoinstall/autoinstall.admin.view.php
+++ b/modules/autoinstall/autoinstall.admin.view.php
@@ -27,6 +27,13 @@ class autoinstallAdminView extends autoinstall
 	 */
 	function init()
 	{
+		$oModuleModel = getModel('module');
+		$module_info = $oModuleModel->getModuleConfig('autoinstall');
+		$location_site = $module_info->location_site;
+		$download_server = $module_info->download_server;
+		define('_XE_LOCATION_SITE_', $location_site ? $location_site : 'https://xe1.xpressengine.com/');
+		define('_XE_DOWNLOAD_SERVER_', $download_server ? $download_server : 'https://download.xpressengine.com/');
+
 		$template_path = sprintf("%stpl/", $this->module_path);
 		Context::set('original_site', _XE_LOCATION_SITE_);
 		Context::set('uri', _XE_DOWNLOAD_SERVER_);
@@ -202,7 +209,17 @@ class autoinstallAdminView extends autoinstall
 			if($packages[$v->package_srl])
 			{
 				$v->current_version = $packages[$v->package_srl]->current_version;
-				$v->need_update = $packages[$v->package_srl]->need_update;
+				// if version is up
+				// insert Y
+				if($v->current_version < $v->item_version)
+				{
+					$v->need_update = 'Y';
+				}
+				else
+				{
+					$v->need_update = 'N';
+				}
+				//$v->need_update = $packages[$v->package_srl]->need_update;
 				$v->type = $oModel->getTypeFromPath($packages[$v->package_srl]->path);
 
 				if($this->ftp_set && $v->depfrom)
@@ -216,7 +233,11 @@ class autoinstallAdminView extends autoinstall
 
 				if($v->type == "core")
 				{
-					continue;
+					// if default, hide core
+					if(strpos(_XE_DOWNLOAD_SERVER_, 'xpressengine.com')!==false)
+					{
+						continue;
+					}
 				}
 				else if($v->type == "module")
 				{
@@ -583,6 +604,17 @@ class autoinstallAdminView extends autoinstall
 		}
 	}
 
+	/**
+	 * Display config
+	 * 
+	 */
+	function dispAutoinstallAdminConfig()
+	{
+		$oModuleModel = getModel('module');
+		$module_info = $oModuleModel->getModuleConfig('autoinstall');
+		Context::set('config', $module_info);
+		$this->setTemplateFile('config');
+	}
 }
 /* End of file autoinstall.admin.view.php */
 /* Location: ./modules/autoinstall/autoinstall.admin.view.php */

--- a/modules/autoinstall/autoinstall.admin.view.php
+++ b/modules/autoinstall/autoinstall.admin.view.php
@@ -29,7 +29,8 @@ class autoinstallAdminView extends autoinstall
 	{
 		$oAdminModel = getAdminModel('autoinstall');
 		$config = $oAdminModel->getAutoInstallAdminModuleConfig();
-
+		Context::set('config', $config);
+		
 		$template_path = sprintf("%stpl/", $this->module_path);
 		Context::set('original_site', $config->location_site);
 		Context::set('uri', $config->download_server);
@@ -617,9 +618,6 @@ class autoinstallAdminView extends autoinstall
 	 */
 	function dispAutoinstallAdminConfig()
 	{
-		$oAdminModel = getAdminModel('autoinstall');
-        $config = $oAdminModel->getAutoInstallAdminModuleConfig();
-		Context::set('config', $config);
 		$this->setTemplateFile('config');
 	}
 }

--- a/modules/autoinstall/autoinstall.class.php
+++ b/modules/autoinstall/autoinstall.class.php
@@ -44,7 +44,13 @@ class XmlGenerater
 			'ssl_verify_peer' => FALSE,
 			'ssl_verify_host' => FALSE
 		);
-		$buff = FileHandler::getRemoteResource(_XE_DOWNLOAD_SERVER_, $body, 3, "POST", "application/xml", array(), array(), array(), $request_config);
+
+		$oModuleModel = getModel('module');
+		$module_info = $oModuleModel->getModuleConfig('autoinstall');
+		$location_site = $module_info->location_site;
+		$download_server = $module_info->download_server;
+
+		$buff = FileHandler::getRemoteResource($download_server, $body, 3, "POST", "application/xml", array(), array(), array(), $request_config);
 		if(!$buff)
 		{
 			return;

--- a/modules/autoinstall/conf/module.xml
+++ b/modules/autoinstall/conf/module.xml
@@ -13,6 +13,7 @@
 		<action name="getAutoinstallAdminSkinPackageList" type="model" />
 		<action name="getAutoinstallAdminIsAuthed" type="model" />
 		<action name="getAutoInstallAdminInstallInfo" type="model" />
+		<action name="getAutoInstallAdminModuleConfig" type="model" />
 		
 		<action name="procAutoinstallAdminUpdateinfo" type="controller" />
 		<action name="procAutoinstallAdminPackageinstall" type="controller" ruleset="ftp" />

--- a/modules/autoinstall/conf/module.xml
+++ b/modules/autoinstall/conf/module.xml
@@ -6,7 +6,8 @@
 		<action name="dispAutoinstallAdminInstall" type="view" menu_name="easyInstall" />
 		<action name="dispAutoinstallAdminUninstall" type="view" menu_name="easyInstall" />
 		<action name="dispAutoinstallAdminInstalledPackages" type="view" menu_name="easyInstall" />
-		
+		<action name="dispAutoinstallAdminConfig" type="view" menu_name="easyInstall" />
+
 		<action name="getAutoinstallAdminMenuPackageList" type="model" />
 		<action name="getAutoinstallAdminLayoutPackageList" type="model" />
 		<action name="getAutoinstallAdminSkinPackageList" type="model" />
@@ -16,6 +17,8 @@
 		<action name="procAutoinstallAdminUpdateinfo" type="controller" />
 		<action name="procAutoinstallAdminPackageinstall" type="controller" ruleset="ftp" />
 		<action name="procAutoinstallAdminUninstallPackage" type="controller" ruleset="ftp" />
+		<action name="procAutoinstallAdminInsertConfig" type="controller" />
+		
 	</actions>
 	<menus>
 		<menu name="easyInstall">

--- a/modules/autoinstall/lang/en.php
+++ b/modules/autoinstall/lang/en.php
@@ -54,7 +54,6 @@ $lang->typename['skin'] = 'Skin';
 $lang->typename['widgetstyle'] = 'Widget style';
 $lang->typename['style'] = 'Document style';
 
-$lang->config = 'Config';
 $lang->location_site = 'Location Site';
 $lang->about_location_site = 'Please type your location site. ex)https://xe1.xpressengine.com/';
 $lang->download_server = 'Download Server';

--- a/modules/autoinstall/lang/en.php
+++ b/modules/autoinstall/lang/en.php
@@ -54,7 +54,7 @@ $lang->typename['skin'] = 'Skin';
 $lang->typename['widgetstyle'] = 'Widget style';
 $lang->typename['style'] = 'Document style';
 
-$lang->location_site = 'Location Site';
-$lang->about_location_site = 'Please type your location site. ex)https://xe1.xpressengine.com/';
+$lang->location_site = 'Download Homepage';
+$lang->about_location_site = 'Please type your download homepage. ex)https://xe1.xpressengine.com/';
 $lang->download_server = 'Download Server';
 $lang->about_download_server = 'Please type your download server. ex)https://download.xpressengine.com/';

--- a/modules/autoinstall/lang/en.php
+++ b/modules/autoinstall/lang/en.php
@@ -53,3 +53,9 @@ $lang->typename['m.skin'] = 'Mobile Skin';
 $lang->typename['skin'] = 'Skin';
 $lang->typename['widgetstyle'] = 'Widget style';
 $lang->typename['style'] = 'Document style';
+
+$lang->config = 'Config';
+$lang->location_site = 'Location Site';
+$lang->about_location_site = 'Please type your location site. ex)https://xe1.xpressengine.com/';
+$lang->download_server = 'Download Server';
+$lang->about_download_server = 'Please type your download server. ex)https://download.xpressengine.com/';

--- a/modules/autoinstall/lang/ko.php
+++ b/modules/autoinstall/lang/ko.php
@@ -55,3 +55,9 @@ $lang->typename['m.skin'] = '모바일 스킨';
 $lang->typename['skin'] = '스킨';
 $lang->typename['widgetstyle'] = '위젯스타일';
 $lang->typename['style'] = '문서스타일';
+
+$lang->config = '설정';
+$lang->location_site = '로케이션 사이트';
+$lang->about_location_site = '로케이션 사이트를 입력해 주세요. 예)https://xe1.xpressengine.com/';
+$lang->download_server = '다운로드 서버';
+$lang->about_download_server = '다운로드 서버를 입력해 주세요. 예)https://download.xpressengine.com/';

--- a/modules/autoinstall/lang/ko.php
+++ b/modules/autoinstall/lang/ko.php
@@ -56,7 +56,6 @@ $lang->typename['skin'] = '스킨';
 $lang->typename['widgetstyle'] = '위젯스타일';
 $lang->typename['style'] = '문서스타일';
 
-$lang->config = '설정';
 $lang->location_site = '로케이션 사이트';
 $lang->about_location_site = '로케이션 사이트를 입력해 주세요. 예)https://xe1.xpressengine.com/';
 $lang->download_server = '다운로드 서버';

--- a/modules/autoinstall/lang/ko.php
+++ b/modules/autoinstall/lang/ko.php
@@ -56,7 +56,8 @@ $lang->typename['skin'] = '스킨';
 $lang->typename['widgetstyle'] = '위젯스타일';
 $lang->typename['style'] = '문서스타일';
 
-$lang->location_site = '로케이션 사이트';
-$lang->about_location_site = '로케이션 사이트를 입력해 주세요. 예)https://xe1.xpressengine.com/';
+$lang->location_site = '다운로드 홈페이지';
+$lang->about_location_site = '다운로드 홈페이지를 입력해 주세요. 예)https://xe1.xpressengine.com/';
 $lang->download_server = '다운로드 서버';
 $lang->about_download_server = '다운로드 서버를 입력해 주세요. 예)https://download.xpressengine.com/';
+

--- a/modules/autoinstall/queries/deletePackages.xml
+++ b/modules/autoinstall/queries/deletePackages.xml
@@ -1,0 +1,5 @@
+<query id="deletePackages" action="delete">
+	<tables>
+        <table name="autoinstall_packages" />
+    </tables>
+</query>

--- a/modules/autoinstall/queries/deletePackages.xml
+++ b/modules/autoinstall/queries/deletePackages.xml
@@ -1,5 +1,5 @@
 <query id="deletePackages" action="delete">
 	<tables>
-        <table name="autoinstall_packages" />
-    </tables>
+		<table name="autoinstall_packages" />
+	</tables>
 </query>

--- a/modules/autoinstall/tpl/category.html
+++ b/modules/autoinstall/tpl/category.html
@@ -1,7 +1,7 @@
 <ul class="x_nav x_nav-tabs">
 	<li class="x_active"|cond="$act == 'dispAutoinstallAdminIndex'"><a href="{getUrl('', 'module', 'admin', 'act', 'dispAutoinstallAdminIndex')}">{lang('all')} ({$tCount})</a></li>
 	<li class="x_active"|cond="$act == 'dispAutoinstallAdminInstalledPackages'"><a href="{getUrl('', 'module', 'admin', 'act', 'dispAutoinstallAdminInstalledPackages')}">Installed({$iCount})</a></li>
-	<li class="x_active"|cond="$act == 'dispAutoinstallAdminConfig'"><a href="{getUrl('', 'module', 'admin', 'act', 'dispAutoinstallAdminConfig')}">{lang('config')}</a></li>
+	<li class="x_active"|cond="$act == 'dispAutoinstallAdminConfig'"><a href="{getUrl('', 'module', 'admin', 'act', 'dispAutoinstallAdminConfig')}">{lang('cmd_setup')}</a></li>
 </ul>
 
 <nav cond="$act == 'dispAutoinstallAdminIndex'" class="x_thumbnail x_clearfix category">

--- a/modules/autoinstall/tpl/category.html
+++ b/modules/autoinstall/tpl/category.html
@@ -1,6 +1,7 @@
 <ul class="x_nav x_nav-tabs">
 	<li class="x_active"|cond="$act == 'dispAutoinstallAdminIndex'"><a href="{getUrl('', 'module', 'admin', 'act', 'dispAutoinstallAdminIndex')}">{lang('all')} ({$tCount})</a></li>
 	<li class="x_active"|cond="$act == 'dispAutoinstallAdminInstalledPackages'"><a href="{getUrl('', 'module', 'admin', 'act', 'dispAutoinstallAdminInstalledPackages')}">Installed({$iCount})</a></li>
+	<li class="x_active"|cond="$act == 'dispAutoinstallAdminConfig'"><a href="{getUrl('', 'module', 'admin', 'act', 'dispAutoinstallAdminConfig')}">{lang('config')}</a></li>
 </ul>
 
 <nav cond="$act == 'dispAutoinstallAdminIndex'" class="x_thumbnail x_clearfix category">

--- a/modules/autoinstall/tpl/config.html
+++ b/modules/autoinstall/tpl/config.html
@@ -1,0 +1,36 @@
+<include target="header.html" />
+<include target="category.html" />
+{@
+	$from_id = array(
+		'modules/autoinstall/tpl/config/1' => 1
+	);
+}
+<div cond="$XE_VALIDATOR_MESSAGE && isset($from_id[$XE_VALIDATOR_ID])" class="message {$XE_VALIDATOR_MESSAGE_TYPE}">
+	<p>{$XE_VALIDATOR_MESSAGE}</p>
+</div>
+
+<form action="./" class="x_form-horizontal" ruleset="insert_config" method="post">
+	<input type="hidden" name="module" value="autoinstall" />
+	<input type="hidden" name="act" value="procAutoinstallAdminInsertConfig" />
+	<input type="hidden" name="success_return_url" value="{getUrl('', 'module', 'admin', 'act', $act)}" />
+	<input type="hidden" name="xe_validator_id" value="modules/autoinstall/tpl/config/1" />
+
+	<div class="x_control-group">
+		<label class="x_control-label" for="location_site">{$lang->location_site}</label>
+		<div class="x_controls">
+			<input type="url" id="location_site" name="location_site" style="min-width:90%" value="{$config->location_site ? $config->location_site : 'https://xe1.xpressengine.com/'}" />
+			<p class="x_help-block">{$lang->about_location_site}</p>
+		</div>
+	</div>
+	<div class="x_control-group">
+		<label class="x_control-label" for="download_server">{$lang->download_server}</label>
+		<div class="x_controls">
+			<input type="url" id="download_server" name="download_server" style="min-width:90%" value="{$config->download_server ? $config->download_server : 'https://download.xpressengine.com/'}" />
+			<p class="x_help-block">{$lang->about_download_server}</p>
+		</div>
+	</div>
+	<div class="x_clearfix btnArea">
+		<span class="x_pull-right"><input class="x_btn x_btn-primary" type="submit" value="{$lang->cmd_save}" /></span>
+	</div>
+</form>
+

--- a/modules/autoinstall/tpl/config.html
+++ b/modules/autoinstall/tpl/config.html
@@ -18,14 +18,14 @@
 	<div class="x_control-group">
 		<label class="x_control-label" for="location_site">{$lang->location_site}</label>
 		<div class="x_controls">
-			<input type="url" id="location_site" name="location_site" style="min-width:90%" value="{$config->location_site ? $config->location_site : 'https://xe1.xpressengine.com/'}" />
+			<input type="url" id="location_site" name="location_site" style="min-width:90%" value="{$config->location_site}" />
 			<p class="x_help-block">{$lang->about_location_site}</p>
 		</div>
 	</div>
 	<div class="x_control-group">
 		<label class="x_control-label" for="download_server">{$lang->download_server}</label>
 		<div class="x_controls">
-			<input type="url" id="download_server" name="download_server" style="min-width:90%" value="{$config->download_server ? $config->download_server : 'https://download.xpressengine.com/'}" />
+			<input type="url" id="download_server" name="download_server" style="min-width:90%" value="{$config->download_server}" />
 			<p class="x_help-block">{$lang->about_download_server}</p>
 		</div>
 	</div>

--- a/modules/autoinstall/tpl/filter/insert_config.xml
+++ b/modules/autoinstall/tpl/filter/insert_config.xml
@@ -1,6 +1,7 @@
 <filter name="insert_config" module="autoinstall" act="procAutoinstallAdminInsertConfig" confirm_msg_code="confirm_submit">
     <form>
-        <node target="ftp_root_path" required="true" />
+        <node target="location_site" required="true" />
+        <node target="download_server" required="true" />
     </form>
     <response>
         <tag name="error" />

--- a/modules/menu/menu.admin.model.php
+++ b/modules/menu/menu.admin.model.php
@@ -326,6 +326,9 @@ class menuAdminModel extends menu
 
 		Context::loadLang('modules/page/lang');
 
+		$oAutoinstallAdminModel = getAdminModel('autoinstall');
+		$config = $oAutoinstallAdminModel->getAutoInstallAdminModuleConfig();
+		
 		foreach($_allModules as $module_name)
 		{
 			$module = $oModuleModel->getModuleInfoXml($module_name);
@@ -345,10 +348,6 @@ class menuAdminModel extends menu
 			$module->defaultMobileSkin = new stdClass();
 			$module->defaultMobileSkin->skin = $defaultMobileSkin;
 			$module->defaultMobileSkin->title = $mobileSkinInfo->title ? $mobileSkinInfo->title : $defaultMobileSkin;
-			
-			$oAdminModel = getAdminModel('autoinstall');
-			$config = $oAdminModel->getAutoInstallAdminModuleConfig();
-
 			$module->package_srl = $oAutoinstallModel->getPackageSrlByPath('./modules/' . $module_name);
 			$module->url = $config->location_site . '?mid=download&package_srl=' . $module->package_srl;
 

--- a/modules/menu/menu.admin.model.php
+++ b/modules/menu/menu.admin.model.php
@@ -346,8 +346,8 @@ class menuAdminModel extends menu
 			$module->defaultMobileSkin->skin = $defaultMobileSkin;
 			$module->defaultMobileSkin->title = $mobileSkinInfo->title ? $mobileSkinInfo->title : $defaultMobileSkin;
 			
-			$oModel = getAdminModel('autoinstall');
-			$config = $oModel->getAutoInstallAdminModuleConfig();
+			$oAdminModel = getAdminModel('autoinstall');
+			$config = $oAdminModel->getAutoInstallAdminModuleConfig();
 
 			$module->package_srl = $oAutoinstallModel->getPackageSrlByPath('./modules/' . $module_name);
 			$module->url = $config->location_site . '?mid=download&package_srl=' . $module->package_srl;

--- a/modules/menu/menu.admin.model.php
+++ b/modules/menu/menu.admin.model.php
@@ -345,9 +345,14 @@ class menuAdminModel extends menu
 			$module->defaultMobileSkin = new stdClass();
 			$module->defaultMobileSkin->skin = $defaultMobileSkin;
 			$module->defaultMobileSkin->title = $mobileSkinInfo->title ? $mobileSkinInfo->title : $defaultMobileSkin;
+			
+			$oModuleModel = getModel('module');
+			$module_info = $oModuleModel->getModuleConfig('autoinstall');
+			$location_site = $module_info->location_site ? $module_info->location_site : 'https://xe1.xpressengine.com/';
+			$download_server = $module_info->download_server ? $module_info->download_server : 'https://download.xpressengine.com/';
 
 			$module->package_srl = $oAutoinstallModel->getPackageSrlByPath('./modules/' . $module_name);
-			$module->url = _XE_LOCATION_SITE_ . '?mid=download&package_srl=' . $module->package_srl;
+			$module->url = $location_site . '?mid=download&package_srl=' . $module->package_srl;
 
 			if($module_name == 'page')
 			{

--- a/modules/menu/menu.admin.model.php
+++ b/modules/menu/menu.admin.model.php
@@ -346,13 +346,11 @@ class menuAdminModel extends menu
 			$module->defaultMobileSkin->skin = $defaultMobileSkin;
 			$module->defaultMobileSkin->title = $mobileSkinInfo->title ? $mobileSkinInfo->title : $defaultMobileSkin;
 			
-			$oModuleModel = getModel('module');
-			$module_info = $oModuleModel->getModuleConfig('autoinstall');
-			$location_site = $module_info->location_site ? $module_info->location_site : 'https://xe1.xpressengine.com/';
-			$download_server = $module_info->download_server ? $module_info->download_server : 'https://download.xpressengine.com/';
+			$oModel = getAdminModel('autoinstall');
+			$config = $oModel->getAutoInstallAdminModuleConfig();
 
 			$module->package_srl = $oAutoinstallModel->getPackageSrlByPath('./modules/' . $module_name);
-			$module->url = $location_site . '?mid=download&package_srl=' . $module->package_srl;
+			$module->url = $config->location_site . '?mid=download&package_srl=' . $module->package_srl;
 
 			if($module_name == 'page')
 			{


### PR DESCRIPTION
- common/constants.php 의 XE1 의 경로를 주석처리했습니다.
- '설정' 탭을 추가하여 다운로드 서버의 경로를 커스텀하게 설정할 수 있도록 했습니다.(디폴트 : XE1)
- 설정 완료 후에는 쉬운설치가 데이터베이스를 포함하여 자동으로 초기화 됩니다.
- XE1 코어가 아닌 rhymix 코어인 경우는 목록에 아이템이 노출되도록 하였습니다.
- 쉬운설치에서 '업데이트' 기능을 살렸습니다.

테스트 서버 주소 : https://dl.xeb.io/
- 마지막에 / 슬래쉬를 꼭 붙여 주세요
- ggtest 모듈을 설치 후 폴더를 지운 다음 캐시파일 재생성을 누르면 다시 모듈 미설치 상태로 돌아갑니다.