### PR TITLE
알림센터Lite 모듈의 시험용 알림 생성 기능의 오류 수정

### DIFF
--- a/modules/ncenterlite/ncenterlite.admin.controller.php
+++ b/modules/ncenterlite/ncenterlite.admin.controller.php
@@ -131,6 +131,7 @@ class ncenterliteAdminController extends ncenterlite
 			$args->member_srl = $logged_info->member_srl;
 			$args->srl = 1;
 			$args->target_srl = 1;
+			$args->target_p_srl = 1;
 			$args->type = $this->_TYPE_TEST;
 			$args->target_type = $this->_TYPE_TEST;
 			$args->target_url = getUrl('');
@@ -169,6 +170,7 @@ class ncenterliteAdminController extends ncenterlite
 		$args->member_srl = $logged_info->member_srl;
 		$args->srl = 1;
 		$args->target_srl = 1;
+		$args->target_p_srl = 1;
 		$args->type = $this->_TYPE_DOCUMENT;
 		$args->target_type = $this->_TYPE_COMMENT;
 		$args->target_url = getUrl('');


### PR DESCRIPTION
알림센터Lite 모듈에서 관리페이지의 시험용 알림 생성 기능이 동작하지 않는 문제를 수정합니다.

```
01. Query Error: Prepared statement failed: Field 'target_p_srl' doesn't have a default value (code -1)
    - modules/ncenterlite/ncenterlite.admin.controller.php line 141
```
