### PR TITLE
간단한 통합게시판 기능 추가

### DIFF
--- a/classes/module/ModuleHandler.class.php
+++ b/classes/module/ModuleHandler.class.php
@@ -693,6 +693,11 @@ class ModuleHandler extends Handler
 				{
 					return null;
 				}
+				// If the requested mid is set to include documents from other modules, preserve the current mid.
+				elseif($this->mid && ($mid_info = ModuleModel::getModuleInfoByMid($this->mid)) && $mid_info->include_modules && in_array($module_info->module_srl, explode(',', $mid_info->include_modules)))
+				{
+					return $mid_info;
+				}
 				// If this is a GET request, redirect to the correct mid.
 				elseif(Context::getRequestMethod() === 'GET')
 				{

--- a/common/lang/en.php
+++ b/common/lang/en.php
@@ -167,6 +167,7 @@ $lang->regdate = 'Registered Date';
 $lang->anonymous = 'Anonymous';
 $lang->last_update = 'Last Update';
 $lang->last_post = 'Last Comment';
+$lang->module_title = 'Board Name';
 $lang->signup_date = 'Signup Date';
 $lang->last_login = 'Last Signin';
 $lang->first_page = 'First Page';

--- a/common/lang/ko.php
+++ b/common/lang/ko.php
@@ -169,6 +169,7 @@ $lang->regdate = '등록일';
 $lang->anonymous = '익명';
 $lang->last_update = '최근 수정일';
 $lang->last_post = '마지막 댓글';
+$lang->module_title = '게시판 이름';
 $lang->signup_date = '가입일';
 $lang->last_login = '최근 로그인';
 $lang->first_page = '첫 페이지';

--- a/modules/board/board.admin.controller.php
+++ b/modules/board/board.admin.controller.php
@@ -33,6 +33,12 @@ class boardAdminController extends board {
 		if(is_array($args->use_status)) $args->use_status = implode('|@|', $args->use_status);
 		unset($args->board_name);
 
+		// Get existing module info
+		if($args->module_srl)
+		{
+			$module_info = $oModuleModel->getModuleInfoByModuleSrl($args->module_srl);
+		}
+		
 		// setup extra_order_target
 		$extra_order_target = array();
 		if($args->module_srl)
@@ -62,9 +68,15 @@ class boardAdminController extends board {
 		$args->meta_description = trim(utf8_normalize_spaces($args->meta_description));
 
 		// if there is an existed module
-		if($args->module_srl) {
-			$module_info = $oModuleModel->getModuleInfoByModuleSrl($args->module_srl);
-			if($module_info->module_srl != $args->module_srl) unset($args->module_srl);
+		if ($args->module_srl && $module_info->module_srl != $args->module_srl)
+		{
+			unset($args->module_srl);
+		}
+		
+		// preserve existing config
+		if ($args->module_srl)
+		{
+			$args->include_modules = $module_info->include_modules;
 		}
 
 		// insert/update the board module based on module_srl

--- a/modules/board/board.admin.controller.php
+++ b/modules/board/board.admin.controller.php
@@ -12,13 +12,16 @@ class boardAdminController extends board {
 	/**
 	 * @brief initialization
 	 **/
-	function init() {
+	function init()
+	{
+		
 	}
 
 	/**
 	 * @brief insert borad module
 	 **/
-	function procBoardAdminInsertBoard($args = null) {
+	function procBoardAdminInsertBoard($args = null)
+	{
 		// generate module model/controller object
 		$oModuleController = getController('module');
 		$oModuleModel = getModel('module');
@@ -161,6 +164,42 @@ class boardAdminController extends board {
 		$this->add('module','board');
 		$this->add('page',Context::get('page'));
 		$this->setMessage('success_deleted');
+	}
+
+	/**
+	 * Save settings for combined board.
+	 */
+	public function procBoardAdminInsertCombinedConfig()
+	{
+		$vars = Context::getRequestVars();
+		$module_srl = intval($vars->target_module_srl);
+		$include_modules = array_map('intval', $vars->include_modules ?: []);
+		
+		$module_info = ModuleModel::getModuleInfoByModuleSrl($module_srl);
+		if (!$module_info)
+		{
+			throw new Rhymix\Framework\Exceptions\TargetNotFound;
+		}
+		
+		$module_info->include_modules = implode(',', array_filter($include_modules, function($item) {
+			return $item > 0;
+		}));
+		
+		$output = getController('module')->updateModule($module_info);
+		if (!$output->toBool())
+		{
+			return $output;
+		}
+		
+		$this->setMessage('success_updated');
+		if (Context::get('success_return_url'))
+		{
+			$this->setRedirectUrl(Context::get('success_return_url'));
+		}
+		else
+		{
+			$this->setRedirectUrl(getNotEncodedUrl('', 'module', 'admin', 'act', 'dispBoardAdminBoardAdditionSetup', 'module_srl', $module_srl));
+		}
 	}
 
 	function procBoardAdminSaveCategorySettings()

--- a/modules/board/board.admin.view.php
+++ b/modules/board/board.admin.view.php
@@ -205,6 +205,12 @@ class boardAdminView extends board {
 		ModuleHandler::triggerCall('module.dispAdditionSetup', 'after', $content);
 		Context::set('setup_content', $content);
 
+		// Get the list of boards to combine.
+		$args = new stdClass;
+		$args->list_count = 1000;
+		$output = executeQueryArray('board.getBoardList', $args, ['module_srl', 'mid', 'browser_title']);
+		Context::set('board_list', $output->data);
+		
 		// setup the template file
 		$this->setTemplateFile('addition_setup');
 	}

--- a/modules/board/board.controller.php
+++ b/modules/board/board.controller.php
@@ -167,6 +167,13 @@ class boardController extends board
 					}
 				}
 				
+				// Preserve module_srl if the document belongs to a module that is included in this board
+				if ($oDocument->get('module_srl') != $obj->module_srl && in_array($oDocument->get('module_srl'), explode(',', $this->module_info->include_modules ?: '')))
+				{
+					$obj->module_srl = $oDocument->get('module_srl');
+					$obj->category_srl = $oDocument->get('category_srl');
+				}
+				
 				// notice & document style same as before if not manager
 				if(!$this->grant->manager)
 				{

--- a/modules/board/board.model.php
+++ b/modules/board/board.model.php
@@ -24,7 +24,7 @@ class boardModel extends module
 		$list_config = ModuleModel::getModulePartConfig('board', $module_srl);
 		if(!is_array($list_config) || count($list_config) <= 0)
 		{
-			$list_config = array('no', 'title', 'nick_name','regdate','readed_count');
+			$list_config = array('no', 'title', 'nick_name', 'regdate', 'readed_count');
 		}
 
 		// get the extra variables
@@ -57,7 +57,7 @@ class boardModel extends module
 	public static function getDefaultListConfig($module_srl)
 	{
 		// add virtual srl, title, registered date, update date, nickname, ID, name, readed count, voted count etc.
-		$virtual_vars = array( 'no', 'title', 'regdate', 'last_update', 'last_post', 'nick_name',
+		$virtual_vars = array( 'no', 'title', 'regdate', 'last_update', 'last_post', 'module_title', 'nick_name',
 				'user_id', 'user_name', 'readed_count', 'voted_count', 'blamed_count', 'thumbnail', 'summary', 'comment_status');
 		foreach($virtual_vars as $key)
 		{

--- a/modules/board/board.view.php
+++ b/modules/board/board.view.php
@@ -36,6 +36,11 @@ class boardView extends board
 			$this->page_count = $this->module_info->page_count;
 		}
 		$this->except_notice = $this->module_info->except_notice == 'N' ? FALSE : TRUE;
+		$this->include_modules = $this->module_info->include_modules ? explode(',', $this->module_info->include_modules) : [];
+		if (count($this->include_modules) && !in_array($this->module_info->module_srl, $this->include_modules))
+		{
+			$this->include_modules[] = $this->module_info->module_srl;
+		}
 
 		// $this->_getStatusNameListecret option backward compatibility
 		$statusList = $this->_getStatusNameList();
@@ -244,7 +249,10 @@ class boardView extends board
 				// if the module srl is not consistent
 				if($oDocument->get('module_srl') != $this->module_info->module_srl && $oDocument->get('is_notice') !== 'A')
 				{
-					throw new Rhymix\Framework\Exceptions\TargetNotFound;
+					if (!in_array($oDocument->get('module_srl'), $this->include_modules))
+					{
+						throw new Rhymix\Framework\Exceptions\TargetNotFound;
+					}
 				}
 
 				// check the manage grant
@@ -466,7 +474,7 @@ class boardView extends board
 
 		// setup module_srl/page number/ list number/ page count
 		$args = new stdClass();
-		$args->module_srl = $this->module_srl;
+		$args->module_srl = $this->include_modules ?: $this->module_srl;
 		$args->page = intval(Context::get('page')) ?: null;
 		$args->list_count = $this->list_count;
 		$args->page_count = $this->page_count;

--- a/modules/board/board.view.php
+++ b/modules/board/board.view.php
@@ -452,7 +452,7 @@ class boardView extends board
 		}
 
 		$args = new stdClass();
-		$args->module_srl = $this->module_srl;
+		$args->module_srl = $this->include_modules ?: $this->module_srl;
 		$notice_output = DocumentModel::getNoticeList($args, $this->columnList);
 		Context::set('notice_list', $notice_output->data);
 	}

--- a/modules/board/conf/module.xml
+++ b/modules/board/conf/module.xml
@@ -128,6 +128,7 @@
 		<action name="procBoardAdminInsertBoard" type="controller" permission="manager" check_var="module_srl" ruleset="insertBoard" />
 		<action name="procBoardAdminDeleteBoard" type="controller" permission="manager" check_var="module_srl" />
 		<action name="procBoardAdminUpdateBoardFroBasic" type="controller" ruleset="insertBoardForBasic" />
+		<action name="procBoardAdminInsertCombinedConfig" type="controller" />
 		<action name="procBoardAdminSaveCategorySettings" type="controller" permission="manager" check_var="module_srl" ruleset="saveCategorySettings" />
 	</actions>
 	<menus>

--- a/modules/board/lang/en.php
+++ b/modules/board/lang/en.php
@@ -92,3 +92,6 @@ $lang->cmd_all_comment_message = 'Always';
 $lang->cmd_do_not_message = 'Never';
 $lang->delete_placeholder = 'Delete Placeholder';
 $lang->msg_document_notify_mail = '[%s] The new post : %s';
+$lang->cmd_board_combined_board = 'Combined Board';
+$lang->about_board_combined_board = 'You can use this board to view documents from other boards. Press the Ctrl key and click to select multiple boards.';
+$lang->cmd_board_include_modules = 'Include Boards';

--- a/modules/board/lang/en.php
+++ b/modules/board/lang/en.php
@@ -95,3 +95,4 @@ $lang->msg_document_notify_mail = '[%s] The new post : %s';
 $lang->cmd_board_combined_board = 'Combined Board';
 $lang->about_board_combined_board = 'You can use this board to view documents from other boards. Press the Ctrl key and click to select multiple boards.';
 $lang->cmd_board_include_modules = 'Include Boards';
+$lang->cmd_board_include_modules_none = '(None)';

--- a/modules/board/lang/ko.php
+++ b/modules/board/lang/ko.php
@@ -107,3 +107,4 @@ $lang->msg_not_target = '문서 또는 댓글의 추천인목록만 조회가능
 $lang->cmd_board_combined_board = '통합 게시판';
 $lang->about_board_combined_board = '다른 게시판의 글을 모아서 볼 수 있습니다. 여러 게시판을 선택하려면 Ctrl 키를 누르고 클릭하세요.';
 $lang->cmd_board_include_modules = '포함할 게시판 선택';
+$lang->cmd_board_include_modules_none = '(포함하지 않음)';

--- a/modules/board/lang/ko.php
+++ b/modules/board/lang/ko.php
@@ -104,3 +104,6 @@ $lang->msg_document_notify_mail = '[%s] 새로운 게시글이 등록되었습�
 $lang->cmd_document_vote_user = '이 글의 추천인 목록';
 $lang->cmd_comment_vote_user = '이 댓글의 추천인 목록';
 $lang->msg_not_target = '문서 또는 댓글의 추천인목록만 조회가능합니다.';
+$lang->cmd_board_combined_board = '통합 게시판';
+$lang->about_board_combined_board = '다른 게시판의 글을 모아서 볼 수 있습니다. 여러 게시판을 선택하려면 Ctrl 키를 누르고 클릭하세요.';
+$lang->cmd_board_include_modules = '포함할 게시판 선택';

--- a/modules/board/skins/default/list.html
+++ b/modules/board/skins/default/list.html
@@ -38,6 +38,9 @@
 					<block cond="$document_srl==$document->document_srl">&raquo;</block>
 					<block cond="$document_srl!=$document->document_srl">{$lang->notice}</block>
 				</td>
+				<td class="module_title" cond="$val->type=='module_title' && $val->idx==-1">
+					<a href="{getUrl('', 'mid', $document->get('mid'))}">{$document->get('module_title')}</a>
+				</td>
 				<td class="title" cond="$val->type=='title' && $val->idx==-1">
 					<a href="{getUrl('document_srl',$document->document_srl, 'listStyle', $listStyle, 'cpage','')}">
 						{$document->getTitle()}
@@ -80,6 +83,9 @@
 				<td class="no" cond="$val->type=='no' && $val->idx==-1">
 					<block cond="$document_srl==$document->document_srl">&raquo;</block>
 					<block cond="$document_srl!=$document->document_srl">{$no}</block>
+				</td>
+				<td class="module_title" cond="$val->type=='module_title' && $val->idx==-1">
+					<a href="{getUrl('', 'mid', $document->get('mid'))}">{$document->get('module_title')}</a>
 				</td>
 				<td class="title" cond="$val->type=='title' && $val->idx==-1">
 					<a href="{getUrl('document_srl',$document->document_srl, 'listStyle', $listStyle, 'cpage','')}">{$document->getTitle()}</a>

--- a/modules/board/skins/xedition/list.html
+++ b/modules/board/skins/xedition/list.html
@@ -15,6 +15,7 @@
 			<tr>
 				<block loop="$list_config=>$key,$val">
 				<th scope="col" cond="$val->type=='no' && $val->idx==-1"><span>{$lang->no}</span></th>
+				<th scope="col" cond="$val->type=='module_title' && $val->idx==-1"><span>{$lang->module_title}</span></th>
 				<th scope="col" class="title" cond="$val->type=='title' && $val->idx==-1"><span>{$lang->title}</span></th>
 				<th scope="col" cond="$val->type=='nick_name' && $val->idx==-1"><span>{$lang->writer}</span></th>
 				<th scope="col" cond="$val->type=='user_id' && $val->idx==-1"><span>{$lang->user_id}</span></th>
@@ -45,6 +46,9 @@
 				<td class="notice" cond="$val->type=='no' && $val->idx==-1">
 					<block cond="$document_srl==$document->document_srl">&raquo;</block>
 					<block cond="$document_srl!=$document->document_srl">{$lang->notice}</block>
+				</td>
+				<td class="module_title" cond="$val->type=='module_title' && $val->idx==-1">
+					<a href="{getUrl('', 'mid', $document->get('mid'))}">{$document->get('module_title')}</a>
 				</td>
 				<td class="title" cond="$val->type=='title' && $val->idx==-1">
 					<a href="{getUrl('document_srl',$document->document_srl, 'listStyle', $listStyle, 'cpage','')}">
@@ -88,6 +92,9 @@
 				<td class="no" cond="$val->type=='no' && $val->idx==-1">
 					<block cond="$document_srl==$document->document_srl">&raquo;</block>
 					<block cond="$document_srl!=$document->document_srl">{$no}</block>
+				</td>
+				<td class="module_title" cond="$val->type=='module_title' && $val->idx==-1">
+					<a href="{getUrl('', 'mid', $document->get('mid'))}">{$document->get('module_title')}</a>
 				</td>
 				<td class="title" cond="$val->type=='title' && $val->idx==-1">
 					<a href="{getUrl('document_srl',$document->document_srl, 'listStyle', $listStyle, 'cpage','')}">{$document->getTitle()}</a>

--- a/modules/board/tpl/addition_setup.html
+++ b/modules/board/tpl/addition_setup.html
@@ -17,6 +17,7 @@
 			<label for="use_history" class="x_control-label">{$lang->cmd_board_include_modules}</label>
 			<div class="x_controls">
 				<select name="include_modules[]" size="8" multiple="multiple">
+					<option value="">{$lang->cmd_board_include_modules_none}</option>
 					<!--@foreach($board_list as $board_info)-->
 						<option value="{$board_info->module_srl}" selected="selected"|cond="in_array($board_info->module_srl, $include_modules)">{$board_info->browser_title}</option>
 					<!--@endforeach-->

--- a/modules/board/tpl/addition_setup.html
+++ b/modules/board/tpl/addition_setup.html
@@ -3,4 +3,32 @@
 <div cond="$XE_VALIDATOR_MESSAGE" class="message {$XE_VALIDATOR_MESSAGE_TYPE}">
 	<p>{$XE_VALIDATOR_MESSAGE}</p>
 </div>
+
+<!--@if($logged_info->is_admin === 'Y')-->
+<section class="section">
+	<h1>{$lang->cmd_board_combined_board}</h1>
+	<form action="./" method="post" class="x_form-horizontal">
+		<input type="hidden" name="module" value="document" />
+		<input type="hidden" name="act" value="procBoardAdminInsertCombinedConfig" />
+		<input type="hidden" name="success_return_url" value="{getRequestUriByServerEnviroment()}" />
+		<input type="hidden" name="target_module_srl" value="{$module_info->module_srl}" />
+		{@ $include_modules = explode(',', $module_info->include_modules ?? '')}
+		<div class="x_control-group">
+			<label for="use_history" class="x_control-label">{$lang->cmd_board_include_modules}</label>
+			<div class="x_controls">
+				<select name="include_modules[]" size="8" multiple="multiple">
+					<!--@foreach($board_list as $board_info)-->
+						<option value="{$board_info->module_srl}" selected="selected"|cond="in_array($board_info->module_srl, $include_modules)">{$board_info->browser_title}</option>
+					<!--@endforeach-->
+				</select>
+				<p class="x_help-block">{$lang->about_board_combined_board}</p>
+			</div>
+		</div>
+		<div class="btnArea">
+			<button type="submit" class="x_btn x_btn-primary">{$lang->cmd_save}</button>
+		</div>
+	</form>
+</section>
+<!--@endif-->
+
 {$setup_content}

--- a/modules/module/module.model.php
+++ b/modules/module/module.model.php
@@ -463,12 +463,33 @@ class moduleModel extends module
 	 */
 	public static function getModulesInfo($module_srls, $columnList = array())
 	{
-		if(is_array($module_srls)) $module_srls = implode(',',$module_srls);
+		if (!is_array($module_srls))
+		{
+			$module_srls = explode(',', $module_srls);
+		}
+		if (!count($module_srls))
+		{
+			return [];
+		}
+		
+		$cache_key = 'site_and_module:modules_info:' . implode(',', $module_srls) . ':' . implode(',', $columnList ?: []);
+		$result = Rhymix\Framework\Cache::get($cache_key);
+		if ($result !== null)
+		{
+			return $result;
+		}
+		
 		$args = new stdClass();
 		$args->module_srls = $module_srls;
 		$output = executeQueryArray('module.getModulesInfo', $args, $columnList);
-		if(!$output->toBool()) return;
-		return self::addModuleExtraVars($output->data);
+		$result = $output->data ?: [];
+		if (!$columnList)
+		{
+			$result = self::addModuleExtraVars($result);
+		}
+		
+		Rhymix\Framework\Cache::set($cache_key, $result, 0, true);
+		return $result;
 	}
 
 	/**


### PR DESCRIPTION
코어의 게시판 모듈에 간단한 통합게시판 기능을 추가합니다.
다른 게시판에 등록된 글도 목록에 포함하여 열람, 수정, 댓글작성 등을 할 수 있습니다.
전체공지 기능과 함께, 라이믹스 2.0의 게시판 기능강화 프로젝트입니다.
관련 설정은 게시판의 "추가 설정" 화면에 있습니다.

### 주의사항

- 추천수 조건, 조회수 조건 등 타임라인 모듈의 자잘한 기능들은 적용할 계획이 없습니다.
- 글이 포함된 게시판 이름 정도는 표시할 수 있도록 지원할 예정입니다.
- 목록 추출 속도가 떨어질 수 있으나, 이후 슈퍼캐시 모듈에서 대응할 예정입니다.
- 기준이 되는 게시판의 권한이 일괄 적용되므로, 다른 권한이 적용되는 게시판을 포함할 경우 주의가 필요합니다.
- 다른 게시판의 카테고리 선택은 지원하지 않습니다.
