### PR TITLE
Travis를 Github Actions로 대체

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,8 @@ jobs:
     strategy:
       matrix:
         operating-system: [ ubuntu-16.04 ]
-        php: [ '7.0', '7.1', '7.2', '7.3', '7.4' ]
+        php: [ '7.0', '7.1', '7.2', '7.3', '7.4', '8.0' ]
+    
     name: PHP ${{ matrix.php }}
     steps:
     - uses: actions/checkout@v2
@@ -22,22 +23,28 @@ jobs:
         php-version: ${{ matrix.php }}
     
     - name: Start MySQL
+      if: matrix.php != '8.0'
       run: sudo systemctl start mysql.service
     
     - name: Create database
+      if: matrix.php != '8.0'
       run: mysql -uroot -proot -e "CREATE DATABASE rhymix CHARSET utf8mb4 COLLATE utf8mb4_unicode_ci"
     
     - name: Create user and set privileges
+      if: matrix.php != '8.0'
       run: mysql -uroot -proot -e "create user 'travis'@'localhost' identified by 'travis'; FLUSH PRIVILEGES" && mysql -uroot -proot -e "GRANT ALL PRIVILEGES ON rhymix.* TO travis@localhost"
     
     - name: Download codeception
+      if: matrix.php != '8.0'
       run: wget https://codeception.com/releases/2.3.9/codecept.phar
     
     - name: Run PHP development server
+      if: matrix.php != '8.0'
       run: php -S localhost:8000 &
 
     - name: PHP Lint
       run: if find . -name "*.php" ! -path "./vendor/*" -print0 | xargs -0 -n 1 -P 8 php -l | grep -v "No syntax errors detected"; then exit 1; fi
     
     - name: Build and run codeception
+      if: matrix.php != '8.0'
       run: php codecept.phar build && php codecept.phar run --debug --fail-fast --env travis

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,0 +1,43 @@
+name: PHP Lint & Run codeception
+on:
+  push:
+    branches: [ master, develop ]
+  pull_request:
+    branches: [ develop ]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.operating-system }}
+    strategy:
+      matrix:
+        operating-system: [ ubuntu-16.04 ]
+        php: [ '7.0', '7.1', '7.2', '7.3', '7.4' ]
+    name: PHP ${{ matrix.php }}
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup PHP
+      uses: nanasess/setup-php@master
+      if: matrix.php != '7.4'
+      with:
+        php-version: ${{ matrix.php }}
+    
+    - name: Start MySQL
+      run: sudo systemctl start mysql.service
+    
+    - name: Create database
+      run: mysql -uroot -proot -e "CREATE DATABASE rhymix CHARSET utf8mb4 COLLATE utf8mb4_unicode_ci"
+    
+    - name: Create user and set privileges
+      run: mysql -uroot -proot -e "create user 'travis'@'localhost' identified by 'travis'; FLUSH PRIVILEGES" && mysql -uroot -proot -e "GRANT ALL PRIVILEGES ON rhymix.* TO travis@localhost"
+    
+    - name: Download codeception
+      run: wget https://codeception.com/releases/2.3.9/codecept.phar
+    
+    - name: Run PHP development server
+      run: php -S localhost:8000 &
+
+    - name: PHP Lint
+      run: if find . -name "*.php" ! -path "./vendor/*" -print0 | xargs -0 -n 1 -P 8 php -l | grep -v "No syntax errors detected"; then exit 1; fi
+    
+    - name: Build and run codeception
+      run: php codecept.phar build && php codecept.phar run --debug --fail-fast --env travis


### PR DESCRIPTION
현재 라이믹스 프로젝트에서 사용중인 Travis CI의 경우 높은 부하 등으로 가동에 시간이 오래 걸리거나, 테스트 중 타임아웃 발생으로 오류 처리되는 경우가 종종 발생합니다.(기록상 무려 두시간 가량 걸린 테스트도 있을 정도입니다 - https://travis-ci.org/github/rhymix/rhymix/builds/747002617)

이를 Github Actions으로 대체합니다. Github Actions의 경우 모든 버전의 테스트에 약 1분 가량 소요됩니다.(https://github.com/Lastorder-DC/rhymix/actions/runs/395516012)

현재 master, develop 브랜치 대상으로만 테스트하며 PR의 경우 develop 브랜치를 대상으로 하는것만 테스트하도록 설정했습니다만 이는 변경 가능합니다.(일단 임의로 설정해 봤습니다) 또한 아직 travis를 제외하지는 않았습니다만 이건 actions 테스트 완료 후 지워도 될 부분으로 생각해서 일단 두었습니다.

이외 테스트 부분은 travis와 최대한 동일하게 맞추어 두었습니다(ubuntu 16.04 사용, php 7.0~7.4 대상 테스트 등)