### PR TITLE
코어에 포함된 애드온, 모듈, 위젯 등의 버전을 별도로 표기하지 않음

### DIFF
--- a/addons/adminlogging/conf/info.xml
+++ b/addons/adminlogging/conf/info.xml
@@ -13,8 +13,8 @@
     <description xml:lang="zh-TW">
 		管理選單訪問紀錄及登入日誌。
     </description>
-    <version>1.7</version>
-    <date>2013-11-27</date>
+    <version>RX_VERSION</version>
+    <date>RX_CORE</date>
 
     <author email_address="developers@xpressengine.com" link="http://xpressengine.com/">
         <name xml:lang="ko">NAVER</name>

--- a/addons/autolink/conf/info.xml
+++ b/addons/autolink/conf/info.xml
@@ -36,8 +36,8 @@
     <description xml:lang="zh-TW">
         是種可將文章及回覆內容中的 URL 網址字串自動轉換成連結的附加元件。
     </description>
-    <version>1.7</version>
-    <date>2013-11-27</date>
+    <version>RX_VERSION</version>
+    <date>RX_CORE</date>
 
     <author email_address="developers@xpressengine.com" link="http://xpressengine.com/">
         <name xml:lang="ko">NAVER</name>

--- a/addons/counter/conf/info.xml
+++ b/addons/counter/conf/info.xml
@@ -45,8 +45,8 @@
         使用XE的網站訪問統計模組記錄網站訪問資料。
         將狀態設置成"使用"時，才會紀錄網站訪問資料。
     </description>
-    <version>1.7</version>
-    <date>2013-11-27</date>
+    <version>RX_VERSION</version>
+    <date>RX_CORE</date>
 
     <author email_address="developers@xpressengine.com" link="http://xpressengine.com/">
         <name xml:lang="ko">NAVER</name>

--- a/addons/member_extra_info/conf/info.xml
+++ b/addons/member_extra_info/conf/info.xml
@@ -36,8 +36,8 @@
     <description xml:lang="zh-TW">
         可將用戶資料中的暱稱圖片、用戶圖示、簽名檔等資料顯示到頁面當中。
     </description>
-    <version>1.7</version>
-    <date>2013-11-27</date>
+    <version>RX_VERSION</version>
+    <date>RX_CORE</date>
 
     <author email_address="developers@xpressengine.com" link="http://xpressengine.com/">
         <name xml:lang="ko">NAVER</name>

--- a/addons/photoswipe/conf/info.xml
+++ b/addons/photoswipe/conf/info.xml
@@ -9,8 +9,8 @@
 		Swipe your images of an document on your screens.
 	</description>
 	<license>MIT License (codes from http://photoswipe.com/), GPLv2 (other codes by Rhymix contributors)</license>
-	<version>1.0.1</version>
-	<date>2016-04-27</date>
+	<version>RX_VERSION</version>
+	<date>RX_CORE</date>
 
 	<author email_address="misol.kr@gmail.com" link="https://github.com/misol">
 		<name xml:lang="ko">misol</name>

--- a/addons/point_level_icon/conf/info.xml
+++ b/addons/point_level_icon/conf/info.xml
@@ -45,8 +45,8 @@
         使用點數系統時，可以在用戶名前顯示等級圖案。
         等級圖案可以在模組 &gt; 點數系統中進行選擇。
     </description>
-    <version>1.7</version>
-    <date>2013-11-27</date>
+    <version>RX_VERSION</version>
+    <date>RX_CORE</date>
 
     <author email_address="developers@xpressengine.com" link="http://xpressengine.com/">
         <name xml:lang="ko">NAVER</name>

--- a/addons/resize_image/conf/info.xml
+++ b/addons/resize_image/conf/info.xml
@@ -36,8 +36,8 @@
     <description xml:lang="zh-TW">
         自動調整文章内的圖片大小，點擊圖片後會顯示原始大小。
     </description>
-    <version>1.7</version>
-    <date>2013-11-27</date>
+    <version>RX_VERSION</version>
+    <date>RX_CORE</date>
 
     <author email_address="developers@xpressengine.com" link="http://xpressengine.com/">
         <name xml:lang="ko">NAVER</name>

--- a/common/framework/parsers/moduleinfoparser.php
+++ b/common/framework/parsers/moduleinfoparser.php
@@ -39,7 +39,7 @@ class ModuleInfoParser extends BaseParser
 			$info->version = trim($xml->version);
 			$info->homepage = trim($xml->homepage);
 			$info->category = trim($xml->category) ?: 'service';
-			$info->date = date('Ymd', strtotime($xml->date . 'T12:00:00Z'));
+			$info->date = ($xml->date === 'RX_CORE') ? '' : date('Ymd', strtotime($xml->date . 'T12:00:00Z'));
 			$info->license = trim($xml->license);
 			$info->license_link = trim($xml->license['link']);
 			$info->author = array();

--- a/modules/addon/addon.admin.model.php
+++ b/modules/addon/addon.admin.model.php
@@ -211,10 +211,16 @@ class addonAdminModel extends addon
 		if($xml_obj->version && $xml_obj->attrs->version == '0.2')
 		{
 			// addon format v0.2
-			$date_obj = new stdClass();
-			sscanf($xml_obj->date->body, '%d-%d-%d', $date_obj->y, $date_obj->m, $date_obj->d);
-			$addon_info->date = sprintf('%04d%02d%02d', $date_obj->y, $date_obj->m, $date_obj->d);
-
+			if ($xml_obj->date->body === 'RX_CORE')
+			{
+				$addon_info->date = '';
+			}
+			else
+			{
+				$date_obj = new stdClass();
+				sscanf($xml_obj->date->body, '%d-%d-%d', $date_obj->y, $date_obj->m, $date_obj->d);
+				$addon_info->date = sprintf('%04d%02d%02d', $date_obj->y, $date_obj->m, $date_obj->d);
+			}
 			$addon_info->addon_name = $addon;
 			$addon_info->title = $xml_obj->title->body;
 			$addon_info->description = trim($xml_obj->description->body);

--- a/modules/addon/conf/info.xml
+++ b/modules/addon/conf/info.xml
@@ -20,8 +20,8 @@
 	<description xml:lang="ru">Этот модуль служит для управления аддонами, использование которых Вы можете включать и выключать.</description>
 	<description xml:lang="zh-TW">設定附加元件「登錄、啟用、禁用」的管理模組。</description>
 	<description xml:lang="tr">Bu modül, kullanımı değişebilecek veya kullanım dışı kalabilecek eklentileri korumak içindir.</description>
-	<version>1.7</version>
-	<date>2013-11-27</date>
+	<version>RX_VERSION</version>
+	<date>RX_CORE</date>
 	<category>utility</category>
 
 	<author email_address="developers@xpressengine.com" link="http://xpressengine.com/">

--- a/modules/addon/tpl/addon_info.html
+++ b/modules/addon/tpl/addon_info.html
@@ -2,7 +2,7 @@
 <table class="x_table x_table-striped x_table-hover">
 	<tr>
 		<th scope="row">{$lang->title}</th>
-		<td>{$addon_info->title} ver. {$addon_info->version}</td>
+		<td>{$addon_info->title} ver. {$addon->version === 'RX_VERSION' ? 'CORE' : $addon->version}</td>
 	</tr>
 	<tr>
 		<th scope="row">{$lang->author}</th>

--- a/modules/addon/tpl/addon_list.html
+++ b/modules/addon/tpl/addon_list.html
@@ -40,7 +40,13 @@
 						{$lang->msg_avail_easy_update} <a href="{$addon->update_url}&amp;return_url={urlencode(getRequestUriByServerEnviroment())}">{$lang->msg_do_you_like_update}</a>
 					</p>
 				</td>
-				<td><span style="color:#aaa"|cond="$addon->isBlacklisted">{$addon->version}</span></td>
+				<td>
+					<!--@if($addon->version === 'RX_VERSION')-->
+						<img src="{\RX_BASEURL}common/img/icon.png" class="core_symbol" alt="Rhymix Core" title="Rhymix Core" />
+					<!--@else-->
+						<span style="color:#aaa"|cond="$addon->isBlacklisted">{$addon->version}</span>
+					<!--@endif-->
+				</td>
 				<td class="nowr rx_detail_marks">
 					<block loop="$addon->author => $author">
 						<a cond="$author->homepage" href="{$author->homepage}" target="_blank">{$author->name}</a>
@@ -53,7 +59,7 @@
 				</td>
 				<td><input type="checkbox" name="pc_on[]" title="PC" value="{escape($addon->addon_name, false)}" checked="checked"|cond="$addon->activated && !$addon->isBlacklisted" disabled="disabled"|cond="$addon->isBlacklisted" /></td>
 				<td><input type="checkbox" name="mobile_on[]" title="Mobile" value="{escape($addon->addon_name, false)}" checked="checked"|cond="$addon->mactivated && !$addon->isBlacklisted" disabled="disabled"|cond="$addon->isBlacklisted" /></td>
-				<td><a cond="$addon->remove_url" href="{$addon->remove_url}&amp;return_url={urlencode(getRequestUriByServerEnviroment())}">{$lang->cmd_delete}</a></td>
+				<td><a cond="$addon->remove_url && $addon->version !== 'RX_VERSION'" href="{$addon->remove_url}&amp;return_url={urlencode(getRequestUriByServerEnviroment())}">{$lang->cmd_delete}</a></td>
 			</tr>
 		</tbody>
 	</table>

--- a/modules/addon/tpl/setup_addon.html
+++ b/modules/addon/tpl/setup_addon.html
@@ -7,7 +7,10 @@
 	<tbody>
 		<tr>
 			<th class="nowr">{$lang->version}</th>
-			<td>{$addon_info->version} ({zdate($addon_info->date, 'Y-m-d')})</td>
+			<td>
+				{$addon_info->version === 'RX_VERSION' ? 'CORE' : $addon_info->version}
+				<!--@if($addon_info->date)-->({zdate($addon_info->date, 'Y-m-d')})<!--@endif-->
+			</td>
 		</tr>
 		<tr>
 			<th class="nowr">{$lang->author}</th>

--- a/modules/admin/conf/info.xml
+++ b/modules/admin/conf/info.xml
@@ -18,8 +18,8 @@
 	<description xml:lang="ru">Этот модуль показывает список возможностей каждого модуля, и позволяет Вам использовать несколько менеджеров, применяя лейаут для администратора.</description>
 	<description xml:lang="zh-TW">列出各模組的功能及使用管理員版面，並可使用管理功能的模組。</description>
 	<description xml:lang="tr">Bu modül size, her modülün özelliklerini barındıran bir liste gösterir ve yöneticiler için yerleşim düzeni uygulayarak, yöneticilerin birkaçını kullanma imkanı sunar.</description>
-	<version>1.7</version>
-	<date>2013-11-27</date>
+	<version>RX_VERSION</version>
+	<date>RX_CORE</date>
 	<category>system</category>
 
 	<author email_address="developers@xpressengine.com" link="http://xpressengine.com/">

--- a/modules/admin/tpl/css/admin.css
+++ b/modules/admin/tpl/css/admin.css
@@ -2316,6 +2316,12 @@ html[lang="id"] .x .g11n.active>[disabled],
 	white-space: pre-wrap;
 	font-family: Consolas, Courier New, monospace;
 }
+.core_symbol {
+	display: inline-block;
+	margin: 0 2px;
+	width: 14px;
+	height: 14px;
+}
 
 /* language specific styles */
 /* English admin_en.css */

--- a/modules/adminlogging/conf/info.xml
+++ b/modules/adminlogging/conf/info.xml
@@ -6,8 +6,8 @@
 	<description xml:lang="ko"></description>
 	<description xml:lang="en"></description>
 	<description xml:lang="jp"></description>
-	<version>1.7</version>
-	<date>2013-11-27</date>
+	<version>RX_VERSION</version>
+	<date>RX_CORE</date>
 	<category>system</category>
 
 	<author email_address="developers@xpressengine.com" link="http://xpressengine.com/">

--- a/modules/advanced_mailer/conf/info.xml
+++ b/modules/advanced_mailer/conf/info.xml
@@ -8,8 +8,8 @@
 	<description xml:lang="en">
 		Log and test e-mails, SMS, and push notifications sent from Rhymix.
 	</description>
-	<version>2.2.0</version>
-	<date>2020-06-25</date>
+	<version>RX_VERSION</version>
+	<date>RX_CORE</date>
 	<author link="https://www.poesis.org">
 		<name xml:lang="ko">포에시스</name>
 		<name xml:lang="en">POESIS</name>

--- a/modules/autoinstall/conf/info.xml
+++ b/modules/autoinstall/conf/info.xml
@@ -15,8 +15,8 @@
 	<description xml:lang="zh-CN">很方便的在线安装/更新XE相关模块(模块/皮肤/布局/控件/控件样式等)。</description>
 	<description xml:lang="jp">管理者モードにてクリックすることだけでモジュール/スキン/レイアウト/ウィジェット/ウィジェットスタイルのインストールを可能にするモジュールです。</description>
 	<description xml:lang="tr">Bu modülle; modüller, dış görünümler, yerleşim düzenleri vs. gibi programlarınızı www.xpressengine.com adresinden tek tıkla kurabilir ve sürümlerini yükseltebilirsiniz. </description>
-	<version>1.7</version>
-	<date>2013-11-27</date>
+	<version>RX_VERSION</version>
+	<date>RX_CORE</date>
 	<category>system</category>
 	<author email_address="developers@xpressengine.com" link="http://xpressengine.com/">
 		<name xml:lang="ko">NAVER</name>

--- a/modules/board/conf/info.xml
+++ b/modules/board/conf/info.xml
@@ -18,8 +18,8 @@
 	<description xml:lang="ru">Модуль для функционирования форума. Также включает в себя функции администратора такие как создание/управление форумами.</description>
 	<description xml:lang="zh-TW">提供用戶相對應的討論板功能，包含建立/新增及管理等功能。</description>
 	<description xml:lang="tr">Pano yapılandırmaları için kullanılan modüldür. Ayrıca oluşturma/yönetme gibi yönetici özellikleri de içerir.</description>
-	<version>1.7.2</version>
-	<date>2014-03-20</date>
+	<version>RX_VERSION</version>
+	<date>RX_CORE</date>
 	<category>service</category>
 
 	<author email_address="developers@xpressengine.com" link="http://xpressengine.com/">

--- a/modules/comment/conf/info.xml
+++ b/modules/comment/conf/info.xml
@@ -18,8 +18,8 @@
 	<description xml:lang="ru">Модуль для управления комментариями форума/блога.</description>
 	<description xml:lang="zh-TW">管理討論板或部落格回覆的模組。</description>
 	<description xml:lang="tr">Pano ve blog yorumlarını yönetme modülü</description>
-	<version>1.7</version>
-	<date>2013-11-27</date>
+	<version>RX_VERSION</version>
+	<date>RX_CORE</date>
 	<category>content</category>
 
 	<author email_address="developers@xpressengine.com" link="http://xpressengine.com/">

--- a/modules/communication/conf/info.xml
+++ b/modules/communication/conf/info.xml
@@ -16,8 +16,8 @@
 	<description xml:lang="ru">This module is for managing message, friend functions.</description>
 	<description xml:lang="zh-TW">管理線上會員間短訊及好友功能的模組。</description>
 	<description xml:lang="tr">Bu modül mesaj ve arkadaşlık özelliklerini yönetmek içindir.</description>
-	<version>1.7</version>
-	<date>2013-11-27</date>
+	<version>RX_VERSION</version>
+	<date>RX_CORE</date>
 	<category>member</category>
 
 	<author email_address="developers@xpressengine.com" link="http://xpressengine.com/">

--- a/modules/counter/conf/info.xml
+++ b/modules/counter/conf/info.xml
@@ -18,8 +18,8 @@
 	<description xml:lang="ru">Базовая программа статистики подключений.</description>
 	<description xml:lang="zh-TW">預設的統計程式。</description>
 	<description xml:lang="tr">Temel bağlantı istatistik programı.</description>
-	<version>1.7</version>
-	<date>2013-11-27</date>
+	<version>RX_VERSION</version>
+	<date>RX_CORE</date>
 	<category>statistics</category>
 
 	<author email_address="developers@xpressengine.com" link="http://xpressengine.com/">

--- a/modules/document/conf/info.xml
+++ b/modules/document/conf/info.xml
@@ -18,8 +18,8 @@
 	<description xml:lang="ru">Модуль для управления документами в форуме, блоге и прочее.</description>
 	<description xml:lang="zh-TW">管理討論板，部落格等主題的模組。 </description>
 	<description xml:lang="tr">Panoda, blogda, vb., kullanılan belgeleri yönetmek için olan modüldür.</description>
-	<version>1.7</version>
-	<date>2013-11-27</date>
+	<version>RX_VERSION</version>
+	<date>RX_CORE</date>
 	<category>content</category>
 
 	<author email_address="developers@xpressengine.com" link="http://xpressengine.com/">

--- a/modules/editor/conf/info.xml
+++ b/modules/editor/conf/info.xml
@@ -18,8 +18,8 @@
 	<description xml:lang="ru">Модуль для отображения WYSIWYG-редактора и управления/смены записей редактора.</description>
 	<description xml:lang="zh-TW">顯示網頁編輯器或管理/傳遞編輯器組件的模組。</description>
 	<description xml:lang="tr">WYSIWYG editörünü görüntüleme ve editör bileşenlerini düzenleme/aktarma için kullanılan modüldür. </description>
-	<version>1.7</version>
-	<date>2013-11-27</date>
+	<version>RX_VERSION</version>
+	<date>RX_CORE</date>
 	<category>utility</category>
 
 	<author email_address="developers@xpressengine.com" link="http://xpressengine.com/">

--- a/modules/file/conf/info.xml
+++ b/modules/file/conf/info.xml
@@ -18,8 +18,8 @@
 	<description xml:lang="ru">Модуль для управления вложениями.</description>
 	<description xml:lang="zh-TW">管理附加檔案的模組。</description>
 	<description xml:lang="tr">Ekleri yönetmek için kullanılan modüldür.</description>
-	<version>1.7</version>
-	<date>2013-11-27</date>
+	<version>RX_VERSION</version>
+	<date>RX_CORE</date>
 	<category>content</category>
 
 	<author email_address="developers@xpressengine.com" link="http://xpressengine.com/">

--- a/modules/importer/conf/info.xml
+++ b/modules/importer/conf/info.xml
@@ -18,8 +18,8 @@
 	<description xml:lang="ru">Запись информации пользователей или форума, используя XML-файл.</description>
 	<description xml:lang="zh-TW">利用 XML 檔案匯入會員或討論板資料。</description>
 	<description xml:lang="tr">Bu modül, XML dosyasından üye ve makale verilerinin içeri aktarımı içindir.</description>
-	<version>1.7</version>
-	<date>2013-11-27</date>
+	<version>RX_VERSION</version>
+	<date>RX_CORE</date>
 	<category>migration</category>
 
 	<author email_address="developers@xpressengine.com" link="http://xpressengine.com/">

--- a/modules/install/conf/info.xml
+++ b/modules/install/conf/info.xml
@@ -18,8 +18,8 @@
 	<description xml:lang="ru">Модуль для управления установкой</description>
 	<description xml:lang="zh-TW">安裝管理模組</description>
 	<description xml:lang="tr">Kurulumu yönetmek için olan modüldür</description>
-	<version>1.7</version>
-	<date>2013-11-27</date>
+	<version>RX_VERSION</version>
+	<date>RX_CORE</date>
 	<category>system</category>
 
 	<author email_address="developers@xpressengine.com" link="http://xpressengine.com/">

--- a/modules/integration_search/conf/info.xml
+++ b/modules/integration_search/conf/info.xml
@@ -45,8 +45,8 @@
 		將所選擇的模組當作搜尋對象進行搜尋。
 		所搜尋的模組中，如有私密文章時將不會被搜尋，因此請注意選擇。
 	</description>
-	<version>1.7</version>
-	<date>2013-11-27</date>
+	<version>RX_VERSION</version>
+	<date>RX_CORE</date>
 	<category>service</category>
 
 	<author email_address="developers@xpressengine.com" link="http://xpressengine.com/">

--- a/modules/krzip/conf/info.xml
+++ b/modules/krzip/conf/info.xml
@@ -2,8 +2,8 @@
 <module version="0.2">
 	<title xml:lang="ko">한국 우편번호</title>
 	<description xml:lang="ko">공개 API를 이용해 우편번호 검색 서비스를 이용합니다.</description>
-	<version>1.8.0</version>
-	<date>2015-03-10</date>
+	<version>RX_VERSION</version>
+	<date>RX_CORE</date>
 	
 	<author email_address="developers@xpressengine.com" link="http://www.xpressengine.com/">
 		<name xml:lang="ko">NAVER</name>

--- a/modules/layout/conf/info.xml
+++ b/modules/layout/conf/info.xml
@@ -18,8 +18,8 @@
 	<description xml:lang="ru">Этот модуль служит для создания/управления лейаутами.</description>
 	<description xml:lang="zh-TW">建立/管理版面的模組。</description>
 	<description xml:lang="tr">Bu modül yerleşim düzenleri(layout) oluşturmak ve yönetmek içindir.</description>
-	<version>1.7</version>
-	<date>2013-11-27</date>
+	<version>RX_VERSION</version>
+	<date>RX_CORE</date>
 	<category>construction</category>
 
 	<author email_address="developers@xpressengine.com" link="http://xpressengine.com/">

--- a/modules/member/conf/info.xml
+++ b/modules/member/conf/info.xml
@@ -18,8 +18,8 @@
 	<description xml:lang="ru">Этот модуль служит для управления и конфигурирования пользователей.</description>
 	<description xml:lang="zh-TW">對會員進行管理與相關設置的模組。</description>
 	<description xml:lang="tr">Bu modül üyeleri yönetmek/yapılandırmak için kullanılır</description>
-	<version>1.7</version>
-	<date>2013-11-27</date>
+	<version>RX_VERSION</version>
+	<date>RX_CORE</date>
 	<category>member</category>
 
 	<author email_address="developers@xpressengine.com" link="http://xpressengine.com/">

--- a/modules/menu/conf/info.xml
+++ b/modules/menu/conf/info.xml
@@ -18,8 +18,8 @@
 	<description xml:lang="ru">Этот модуль служит для создания/управления меню, соединяюще лейауты и модули.</description>
 	<description xml:lang="zh-TW">可建立並管理連結版面和模組的選單。</description>
 	<description xml:lang="tr">Bu modül, yerleşim düzenlerine ya da modüllere bağlı menüleri oluşturmak/yönetmek içindir.</description>
-	<version>1.7</version>
-	<date>2013-11-27</date>
+	<version>RX_VERSION</version>
+	<date>RX_CORE</date>
 	<category>construction</category>
 
 	<author email_address="developers@xpressengine.com" link="http://xpressengine.com/">

--- a/modules/message/conf/info.xml
+++ b/modules/message/conf/info.xml
@@ -18,8 +18,8 @@
 	<description xml:lang="ru">Этот модуль управляет ошибками и системными сообщениями.</description>
 	<description xml:lang="zh-TW">管理錯誤訊息及各種系統訊息的模組。</description>
 	<description xml:lang="tr">Bu modül, hataları ve sistem mesajlarını yönetir.</description>
-	<version>1.7</version>
-	<date>2013-11-27</date>
+	<version>RX_VERSION</version>
+	<date>RX_CORE</date>
 	<category>system</category>
 
 	<author email_address="developers@xpressengine.com" link="http://xpressengine.com/">

--- a/modules/module/conf/info.xml
+++ b/modules/module/conf/info.xml
@@ -18,8 +18,8 @@
 	<description xml:lang="ru">Этот модуль служит для создания/управления другими модулями.</description>
 	<description xml:lang="zh-TW">用於建立與管理其他模組。</description>
 	<description xml:lang="tr">Bu modül, başka modüller oluşturmak ve yönetmek içindir.</description>
-	<version>1.7</version>
-	<date>2013-11-27</date>
+	<version>RX_VERSION</version>
+	<date>RX_CORE</date>
 	<category>system</category>
 
 	<author email_address="developers@xpressengine.com" link="http://xpressengine.com/">

--- a/modules/module/tpl/module_list.html
+++ b/modules/module/tpl/module_list.html
@@ -40,7 +40,13 @@
 				<p cond="$val->need_update" class="x_alert x_alert-info">{$lang->msg_avail_update} <button class="text" type="button" onclick="doUpdateModule('{$val->module}')">{$lang->msg_do_you_like_update}</button></p>
 				<p cond="$val->need_autoinstall_update == 'Y'" class="x_alert x_alert-info">{$lang->msg_avail_easy_update} <a href="{$val->update_url}&amp;return_url={urlencode(getRequestUriByServerEnviroment())}">{$lang->msg_do_you_like_update}</a></p>
 			</td>
-			<td>{$val->version}</td>
+			<td>
+				<!--@if($val->version === 'RX_VERSION')-->
+					<img src="{\RX_BASEURL}common/img/icon.png" class="core_symbol" alt="Rhymix Core" title="Rhymix Core" />
+				<!--@else-->
+					<span style="color:#aaa"|cond="Context::isBlacklistedPlugin($val->module)">{$val->version}</span>
+				<!--@endif-->
+			</td>
 			<td class="nowr rx_detail_marks">
 				<!--@foreach($val->author as $author)-->
 					<!--@if($author->homepage)-->
@@ -52,7 +58,7 @@
 			</td>
 			<td class="rx_detail_marks">{$val->path}</td>
 			<td class="rx_detail_marks">
-				<a href="{$val->delete_url}&amp;return_url={urlencode(getRequestUriByServerEnviroment())}" cond="$val->delete_url">{$lang->cmd_delete}</a>
+				<a href="{$val->delete_url}&amp;return_url={urlencode(getRequestUriByServerEnviroment())}" cond="$val->delete_url && $val->version !== 'RX_VERSION'">{$lang->cmd_delete}</a>
 			</td>
 		</tr>
 	</tbody>

--- a/modules/ncenterlite/conf/info.xml
+++ b/modules/ncenterlite/conf/info.xml
@@ -4,9 +4,9 @@
 	<title xml:lang="en">Notification Center Lite</title>
 	<description xml:lang="ko">사이트 사용자간의 커뮤니케이션에 대한 정보를 알려주는 모듈입니다.</description>
 	<description xml:lang="en">This module notify users of information about new documents, comments and/or messages that call them. This module will enhance communication beween site users.</description>
-	<version>3.1</version>
-	<date>2016-09-10</date>
-	<category>content</category>
+	<version>RX_VERSION</version>
+	<date>RX_CORE</date>
+	<category>service</category>
 	<author link="http://github.com/xe-public">
 		<name xml:lang="ko">XE Public</name>
 		<name xml:lang="en">XE Public</name>

--- a/modules/page/conf/info.xml
+++ b/modules/page/conf/info.xml
@@ -18,8 +18,8 @@
 	<description xml:lang="ru">Этот модуль служит для создания страниц, чтобы связать их с содержимым.</description>
 	<description xml:lang="zh-TW">製作頁面並連結內容的模組。</description>
 	<description xml:lang="tr">Bu modül içeriklere bağlanacak sayfaları oluşturmak içindir.</description>
-	<version>1.7</version>
-	<date>2013-11-27</date>
+	<version>RX_VERSION</version>
+	<date>RX_CORE</date>
 	<category>service</category>
 
 	<author email_address="developers@xpressengine.com" link="http://xpressengine.com/">

--- a/modules/point/conf/info.xml
+++ b/modules/point/conf/info.xml
@@ -54,8 +54,8 @@
 		也能以點數設置等級，並在用戶名稱前顯示等級圖示。
 		但是必須先啟用點數系統才能使用。
 	</description>
-	<version>1.7</version>
-	<date>2013-11-27</date>
+	<version>RX_VERSION</version>
+	<date>RX_CORE</date>
 	<category>member</category>
 
 	<author email_address="developers@xpressengine.com" link="http://xpressengine.com/">

--- a/modules/poll/conf/info.xml
+++ b/modules/poll/conf/info.xml
@@ -18,8 +18,8 @@
 	<description xml:lang="ru">Этот модуль служит для управления опросами.</description>
 	<description xml:lang="zh-TW">管理投票調查的模組。</description>
 	<description xml:lang="tr">Oylamaları düzenlemek için kullanılan modüldür.</description>
-	<version>2.0</version>
-	<date>2015-06-09</date>
+	<version>RX_VERSION</version>
+	<date>RX_CORE</date>
 	<category>content</category>
 
 	<author email_address="developers@xpressengine.com" link="http://xpressengine.com/">

--- a/modules/rss/conf/info.xml
+++ b/modules/rss/conf/info.xml
@@ -10,8 +10,8 @@
 	<description xml:lang="ru">Этот модуль служит для печати RSS.</description>
 	<description xml:lang="zh-TW">負責輸出 RSS 的模組。</description>
 	<description xml:lang="tr">Bu modül RSS çıktısı almak içindir.</description>
-	<version>2.0</version>
-	<date>2017-09-01</date>
+	<version>RX_VERSION</version>
+	<date>RX_CORE</date>
 	<category>utility</category>
 
 	<author email_address="developers@xpressengine.com" link="http://xpressengine.com/">

--- a/modules/session/conf/info.xml
+++ b/modules/session/conf/info.xml
@@ -35,8 +35,8 @@
 		管理線上會員SESSION功能的模組。
 		提供最基本的SESSION設置和使用，且還可以獲得此功能的線上會員資料。
 	</description>
-	<version>1.7</version>
-	<date>2013-11-27</date>
+	<version>RX_VERSION</version>
+	<date>RX_CORE</date>
 	<category>system</category>
 
 	<author email_address="developers@xpressengine.com" link="http://xpressengine.com/">

--- a/modules/spamfilter/conf/info.xml
+++ b/modules/spamfilter/conf/info.xml
@@ -18,8 +18,8 @@
 	<description xml:lang="ru">Стандартный фильтр спама XE.</description>
 	<description xml:lang="zh-TW">XE的基本垃圾過濾模組。</description>
 	<description xml:lang="tr">XE\'nin varsayılan spam filtreleyicisidir.</description>
-	<version>1.7</version>
-	<date>2013-11-27</date>
+	<version>RX_VERSION</version>
+	<date>RX_CORE</date>
 	<category>accessory</category>
 
 	<author email_address="developers@xpressengine.com" link="http://xpressengine.com/">

--- a/modules/tag/conf/info.xml
+++ b/modules/tag/conf/info.xml
@@ -18,8 +18,8 @@
 	<description xml:lang="ru">Модуль для управления тегами.</description>
 	<description xml:lang="zh-TW">標籤管理模組。</description>
 	<description xml:lang="tr">Etiketleri yönetme modülü.</description>
-	<version>1.7</version>
-	<date>2013-11-27</date>
+	<version>RX_VERSION</version>
+	<date>RX_CORE</date>
 	<category>content</category>
 
 	<author email_address="developers@xpressengine.com" link="http://xpressengine.com/">

--- a/modules/trash/conf/info.xml
+++ b/modules/trash/conf/info.xml
@@ -6,8 +6,8 @@
 	<title xml:lang="zh-TW">回收桶</title>
 	<description xml:lang="ko">문서, 댓글 등을 완전히 삭제하지 않고 복구 가능한 상태로 만들어 관리합니다.</description>
 	<description xml:lang="jp">ドミュメンと、コメントなどを完全に削除せずに復旧可能な状態に作って管理します。</description>
-	<version>1.7</version>
-	<date>2013-11-27</date>
+	<version>RX_VERSION</version>
+	<date>RX_CORE</date>
 	<category>content</category>
 	
 	<author email_address="developers@xpressengine.com" link="http://xpressengine.com/">

--- a/modules/widget/conf/info.xml
+++ b/modules/widget/conf/info.xml
@@ -18,8 +18,8 @@
 	<description xml:lang="ru">Модуль для управления виджетами.</description>
 	<description xml:lang="zh-TW">Widget 管理模組。</description>
 	<description xml:lang="tr">Widgetları yönetmek için kullanılan modüldür.</description>
-	<version>1.7</version>
-	<date>2013-11-27</date>
+	<version>RX_VERSION</version>
+	<date>RX_CORE</date>
 	<category>construction</category>
 
 	<author email_address="developers@xpressengine.com" link="http://xpressengine.com/">

--- a/modules/widget/tpl/downloaded_widget_list.html
+++ b/modules/widget/tpl/downloaded_widget_list.html
@@ -26,7 +26,13 @@
 					{$lang->msg_avail_easy_update} <a href="{$widget->update_url}&amp;return_url={urlencode(getRequestUriByServerEnviroment())}">{$lang->msg_do_you_like_update}</a>
 				</p>
 			</td>
-			<td>{$widget->version}</td>
+			<td>
+				<!--@if($widget->version === 'RX_VERSION')-->
+					<img src="{\RX_BASEURL}common/img/icon.png" class="core_symbol" alt="Rhymix Core" title="Rhymix Core" />
+				<!--@else-->
+					<span style="color:#aaa"|cond="$widget->isBlacklisted">{$widget->version}</span>
+				<!--@endif-->
+			</td>
 			<td class="rx_detail_marks">
 				<block loop="$widget->author => $author">
 					<a cond="$author->homepage" href="{$author->homepage}" target="_blank">{$author->name}</a>

--- a/modules/widget/widget.model.php
+++ b/modules/widget/widget.model.php
@@ -152,9 +152,16 @@ class widgetModel extends widget
 			$buff .= sprintf('$widget_info->title = %s;', var_export($xml_obj->title->body, true));
 			$buff .= sprintf('$widget_info->description = %s;', var_export($xml_obj->description->body, true));
 			$buff .= sprintf('$widget_info->version = %s;', var_export($xml_obj->version->body, true));
-			$date_obj = new stdClass;
-			sscanf($xml_obj->date->body, '%d-%d-%d', $date_obj->y, $date_obj->m, $date_obj->d);
-			$date = sprintf('%04d%02d%02d', $date_obj->y, $date_obj->m, $date_obj->d);
+			if($xml_obj->date->body === 'RX_CORE')
+			{
+				$date = '';
+			}
+			else
+			{
+				$date_obj = new stdClass;
+				sscanf($xml_obj->date->body, '%d-%d-%d', $date_obj->y, $date_obj->m, $date_obj->d);
+				$date = sprintf('%04d%02d%02d', $date_obj->y, $date_obj->m, $date_obj->d);
+			}
 			$buff .= sprintf('$widget_info->date = %s;', var_export($date, true));
 			$buff .= sprintf('$widget_info->homepage = %s;', var_export($xml_obj->link->body, true));
 			$buff .= sprintf('$widget_info->license = %s;', var_export($xml_obj->license->body, true));
@@ -295,9 +302,16 @@ class widgetModel extends widget
 		$buff[] = sprintf('$widgetStyle_info->title = %s;', var_export($xml_obj->title->body, true));
 		$buff[] = sprintf('$widgetStyle_info->description = %s;', var_export($xml_obj->description->body, true));
 		$buff[] = sprintf('$widgetStyle_info->version = %s;', var_export($xml_obj->version->body, true));
-		$date_obj = new stdClass;
-		sscanf($xml_obj->date->body, '%d-%d-%d', $date_obj->y, $date_obj->m, $date_obj->d);
-		$date = sprintf('%04d%02d%02d', $date_obj->y, $date_obj->m, $date_obj->d);
+		if($xml_obj->date->body === 'RX_CORE')
+		{
+			$date = '';
+		}
+		else
+		{
+			$date_obj = new stdClass;
+			sscanf($xml_obj->date->body, '%d-%d-%d', $date_obj->y, $date_obj->m, $date_obj->d);
+			$date = sprintf('%04d%02d%02d', $date_obj->y, $date_obj->m, $date_obj->d);
+		}
 		$buff[] = sprintf('$widgetStyle_info->date = %s;', var_export($date, true));
 		$buff[] = sprintf('$widgetStyle_info->homepage = %s;', var_export($xml_obj->link->body, true));
 		$buff[] = sprintf('$widgetStyle_info->license = %s;', var_export($xml_obj->license->body, true));

--- a/widgets/content/conf/info.xml
+++ b/widgets/content/conf/info.xml
@@ -16,8 +16,8 @@
     <description xml:lang="zh-TW">這個 Widget 可輸出討論板、評論，附加檔案等內容。</description>
     <description xml:lang="jp">掲示板の書き込み、コメント、添付ファイルなどコンテンツを出力するウィジェットです。</description>
     <description xml:lang="tr">Bu görsel bileşen yazılar, yorumlar ve ekli dosyalar gibi içerikleri görüntüler.</description>
-    <version>1.7</version>
-    <date>2013-11-27</date>
+    <version>RX_VERSION</version>
+    <date>RX_CORE</date>
     <author email_address="developers@xpressengine.com" link="http://xpressengine.com/">
         <name xml:lang="ko">NAVER</name>
         <name xml:lang="zh-CN">NAVER</name>

--- a/widgets/counter_status/conf/info.xml
+++ b/widgets/counter_status/conf/info.xml
@@ -50,8 +50,8 @@
         Ayrıca toplam sayıyı da görüntüler.
         Bu özelliği edinmek için, sayaç modülü kurulmalı ve sayaç eklentileri etkin hale getirilmelidir.
     </description>
-    <version>1.7</version>
-    <date>2013-11-27</date>
+    <version>RX_VERSION</version>
+    <date>RX_CORE</date>
 
     <author email_address="developers@xpressengine.com" link="http://xpressengine.com/">
         <name xml:lang="ko">NAVER</name>

--- a/widgets/language_select/conf/info.xml
+++ b/widgets/language_select/conf/info.xml
@@ -18,8 +18,8 @@
     <description xml:lang="ru">Этот виджет отображает форму для выбора пользовательского языка.</description>
     <description xml:lang="zh-TW">可選擇其他語言。</description>
     <description xml:lang="tr">Bu görsel bileşen, kullanıcı dili değişikliğindeki mevcut şekli görüntüler.</description>
-    <version>1.7</version>
-    <date>2013-11-27</date>
+    <version>RX_VERSION</version>
+    <date>RX_CORE</date>
 
     <author email_address="developers@xpressengine.com" link="http://xpressengine.com/">
         <name xml:lang="ko">NAVER</name>

--- a/widgets/login_info/conf/info.xml
+++ b/widgets/login_info/conf/info.xml
@@ -18,8 +18,8 @@
     <description xml:lang="ru">Этот виджет отображает форму логина или информацию входа.</description>
     <description xml:lang="zh-TW">可顯示登入表格或登入資料。</description>
     <description xml:lang="tr">Bu görsel bileşen giriş şeklini veya giriş bilgilerini görüntüler.</description>
-    <version>1.7</version>
-    <date>2013-11-27</date>
+    <version>RX_VERSION</version>
+    <date>RX_CORE</date>
     <author email_address="developers@xpressengine.com" link="http://xpressengine.com/">
         <name xml:lang="ko">NAVER</name>
         <name xml:lang="zh-CN">NAVER</name>

--- a/widgets/mcontent/conf/info.xml
+++ b/widgets/mcontent/conf/info.xml
@@ -14,8 +14,8 @@
     <description xml:lang="zh-TW">這個 Widget 可輸出討論板、評論，附加檔案等內容。</description>
     <description xml:lang="jp">掲示板の書き込み、コメント、添付ファイルなどコンテンツを出力するウィジェットです。</description>
     <description xml:lang="tr">Bu görsel bileşen, yazılar, yorumlar ve ekli dosyalar gibi İçerikleri görüntüler.</description>
-    <version>1.7</version>
-    <date>2013-11-27</date>
+    <version>RX_VERSION</version>
+    <date>RX_CORE</date>
 
     <author email_address="developers@xpressengine.com" link="http://xpressengine.com/">
         <name xml:lang="ko">NAVER</name>

--- a/widgets/pollWidget/conf/info.xml
+++ b/widgets/pollWidget/conf/info.xml
@@ -2,8 +2,8 @@
 <widget version="0.2">
     <title xml:lang="ko">설문조사 위젯</title>
     <description xml:lang="ko">설문조사를 표시하는 위젯입니다.</description>
-    <version>2.0</version>
-    <date>2015-06-09</date>
+    <version>RX_VERSION</version>
+    <date>RX_CORE</date>
 
     <author email_address="developers@xpressengine.com" link="http://xpressengine.com/">
         <name xml:lang="ko">NAVER</name>

--- a/widgetstyles/simple/skin.xml
+++ b/widgetstyles/simple/skin.xml
@@ -14,8 +14,8 @@
     <description xml:lang="zh-TW">簡單的 Widget 線條樣式。</description>
     <description xml:lang="jp">線一つだけのウィジェットスタイルです。</description>
     <description xml:lang="tr">Tek bir basit sırayla düzenlenmiş görsel bileşen şekli.</description>
-    <version>1.7</version>
-    <date>2013-11-27</date>
+    <version>RX_VERSION</version>
+    <date>RX_CORE</date>
     <preview>preview.gif</preview>
 
     <author email_address="developers@xpressengine.com" link="http://xpressengine.com/">


### PR DESCRIPTION
예전에 서드파티로 배포되었던 자료들이 라이믹스 코어에 흡수되면서 어느 것이 코어에 포함된 자료이고 어느 것이 서드파티 자료인지 혼란스러워하는 유저들이 있습니다. 라이믹스에 흡수된 자료는 기존에 XE 자료실에서 배포될 때 사용했던 버전을 따르지 않기 때문에 무엇이 더 최근에 나온 버전인지도 혼란스러울 수 있습니다. 이런 혼란은 자칫 코어 모듈을 삭제하거나 XE 자료실의 버전으로 덮어쓰는 실수를 유발할 수 있습니다.

코어와 함께 배포되는 대부분의 자료들이 지난 수년간 대폭 수정되었음에도 불구하고 버전이 여전히 1.7 (2013-11-27) 로 고정되어 있는 것도 이상하고, 반면에 뭔가 수정될 때마다 각 자료의 버전을 바꿔주는 것도 귀찮은 일입니다.

따라서 앞으로 라이믹스 코어에 포함된 애드온, 모듈, 위젯 등은 버전을 별도로 표기하지 않고 라이믹스 심볼로 대체합니다. 레이아웃과 각 모듈의 기본 스킨에도 점차 적용할 예정입니다.

저작권 표기는 #1271 이슈에 대해 아직 협의가 이루어지지 않았으므로 일단 그대로 유지합니다.

![screenshot](https://user-images.githubusercontent.com/164058/102507126-3eba5300-40c7-11eb-805e-2c3940824ad1.png)
