### PR TITLE
"Search" operation에 구문 묶기 기능 추가

### DIFF
--- a/common/framework/parsers/dbquery/variablebase.php
+++ b/common/framework/parsers/dbquery/variablebase.php
@@ -246,6 +246,10 @@ class VariableBase
 					{
 						$item = substr($item, 1, -1);
 					}
+					if (trim($item) === "")
+					{
+						continue;
+					}
 					if (substr($item, 0, 1) === '-')
 					{
 						$conditions[] = sprintf('%s NOT LIKE ?', $column);

--- a/common/framework/parsers/dbquery/variablebase.php
+++ b/common/framework/parsers/dbquery/variablebase.php
@@ -237,15 +237,11 @@ class VariableBase
 				}
 				break;
 			case 'search':
-				$keywords = str_getcsv(preg_replace('/[\s,]+/', ' ', $value), ' ');
+				$keywords = preg_split('/(\'[^\']*\')|("[^"]*")|[\s,]+/', $value, 10, \PREG_SPLIT_NO_EMPTY | \PREG_SPLIT_DELIM_CAPTURE);
 				$conditions = array();
 				$placeholders = implode(', ', array_fill(0, count($keywords), '?'));
 				foreach ($keywords as $item)
 				{
-					if (trim($item) !== "" || count($conditions) > 10)
-					{
-						continue;
-					}
 					if (substr($item, 0, 1) === '-')
 					{
 						$conditions[] = sprintf('%s NOT LIKE ?', $column);

--- a/common/framework/parsers/dbquery/variablebase.php
+++ b/common/framework/parsers/dbquery/variablebase.php
@@ -242,6 +242,10 @@ class VariableBase
 				$placeholders = implode(', ', array_fill(0, count($keywords), '?'));
 				foreach ($keywords as $item)
 				{
+					if (trim($item) !== "" || count($conditions) > 10)
+					{
+						continue;
+					}
 					if (substr($item, 0, 1) === '-')
 					{
 						$conditions[] = sprintf('%s NOT LIKE ?', $column);

--- a/common/framework/parsers/dbquery/variablebase.php
+++ b/common/framework/parsers/dbquery/variablebase.php
@@ -242,6 +242,9 @@ class VariableBase
 				$placeholders = implode(', ', array_fill(0, count($keywords), '?'));
 				foreach ($keywords as $item)
 				{
+					if ((substr($item, 0, 1) === substr($item, -1)) && (substr($item, -1) === '"' || substr($item, -1) === '\'')) {
+						$item = substr($item, 0, -1)
+					}
 					if (substr($item, 0, 1) === '-')
 					{
 						$conditions[] = sprintf('%s NOT LIKE ?', $column);

--- a/common/framework/parsers/dbquery/variablebase.php
+++ b/common/framework/parsers/dbquery/variablebase.php
@@ -242,8 +242,9 @@ class VariableBase
 				$placeholders = implode(', ', array_fill(0, count($keywords), '?'));
 				foreach ($keywords as $item)
 				{
-					if ((substr($item, 0, 1) === substr($item, -1)) && (substr($item, -1) === '"' || substr($item, -1) === '\'')) {
-						$item = substr($item, 0, -1)
+					if ((substr($item, 0, 1) === substr($item, -1)) && (substr($item, -1) === '"' || substr($item, -1) === '\''))
+					{
+						$item = substr($item, 1, -1);
 					}
 					if (substr($item, 0, 1) === '-')
 					{

--- a/common/framework/parsers/dbquery/variablebase.php
+++ b/common/framework/parsers/dbquery/variablebase.php
@@ -237,7 +237,7 @@ class VariableBase
 				}
 				break;
 			case 'search':
-				$keywords = preg_split('/[\s,]+/', $value, 10, \PREG_SPLIT_NO_EMPTY);
+				$keywords = str_getcsv(preg_replace('/[\s,]+/', ' ', $value), ' ');
 				$conditions = array();
 				$placeholders = implode(', ', array_fill(0, count($keywords), '?'));
 				foreach ($keywords as $item)


### PR DESCRIPTION
검색 엔진에 검색어를 입력할 때 순서가 상관 없는 텍스트일 때도 있지만, 구문의 순서가 필요한 순간도 있습니다.
보통 이럴 때 따옴표를 사용합니다. `"I SEOUL U"`
이를 위한 간단한 수정을 제안해봅니다.