### PR TITLE
DB query의 operator 중 'search'에서 따옴표 및 AND, OR 사용

### DIFF
--- a/common/framework/parsers/dbquery/variablebase.php
+++ b/common/framework/parsers/dbquery/variablebase.php
@@ -237,7 +237,9 @@ class VariableBase
 				}
 				break;
 			case 'search':
-				list($where, $params[]) = $this->_parseSearchKeywords($column, $value);
+				$parsed_keywords = $this->_parseSearchKeywords($column, $value);
+				$where = $parsed_keywords[0];
+				$params = array_merge($params, $parsed_keywords[1]);
 				break;
 			case 'plus':
 				$where = sprintf('%s = %s + %s', $column, $column, $is_expression ? $value : '?');

--- a/common/framework/parsers/dbquery/variablebase.php
+++ b/common/framework/parsers/dbquery/variablebase.php
@@ -436,7 +436,7 @@ class VariableBase
 	 * @param string $value
 	 * @return object
 	 */
-	private function _parseSearchKeywords() ($value)
+	private function _parseSearchKeywords($value)
 	{
 		// parse the value (text)
 		$keywords = preg_split('/("[^"]*")|[\s,]+/', trim($value), 10, \PREG_SPLIT_NO_EMPTY | \PREG_SPLIT_DELIM_CAPTURE);

--- a/common/framework/parsers/dbquery/variablebase.php
+++ b/common/framework/parsers/dbquery/variablebase.php
@@ -237,9 +237,7 @@ class VariableBase
 				}
 				break;
 			case 'search':
-				$parsed_keywords = $this->_parseSearchKeywords($value);
-				$where = $parsed_keywords[0];
-				$params = array_merge($params, $parsed_keywords[1]);
+				list($where, $params) = $this->_parseSearchKeywords($value);
 				break;
 			case 'plus':
 				$where = sprintf('%s = %s + %s', $column, $column, $is_expression ? $value : '?');
@@ -436,7 +434,7 @@ class VariableBase
 	 * @param string $value
 	 * @return object
 	 */
-	private function _parseSearchKeywords($value)
+	protected function _parseSearchKeywords($value)
 	{
 		// Initialze the return values.
 		$where = '';

--- a/common/framework/parsers/dbquery/variablebase.php
+++ b/common/framework/parsers/dbquery/variablebase.php
@@ -237,7 +237,7 @@ class VariableBase
 				}
 				break;
 			case 'search':
-				list($where, $params) = $this->_parseSearchKeywords($value);
+				list($where, $params[]) = $this->_parseSearchKeywords($value);
 				break;
 			case 'plus':
 				$where = sprintf('%s = %s + %s', $column, $column, $is_expression ? $value : '?');

--- a/common/framework/parsers/dbquery/variablebase.php
+++ b/common/framework/parsers/dbquery/variablebase.php
@@ -237,7 +237,7 @@ class VariableBase
 				}
 				break;
 			case 'search':
-				$parsed_keywords = $this->_parseSearchKeywords($value)
+				$parsed_keywords = $this->_parseSearchKeywords($value);
 				$where = $parsed_keywords->where;
 				$params = $parsed_keywords->params;
 				break;

--- a/common/framework/parsers/dbquery/variablebase.php
+++ b/common/framework/parsers/dbquery/variablebase.php
@@ -459,7 +459,7 @@ class VariableBase
 			// treat parenthesis
 			if (strlen($item) > 2 && substr($item, 0, 1) === '(' && substr($item, -1) === ')')
 			{
-				$parsed_keywords = $this->_parseSearchKeywords(substr($item, 1, -1));
+				$parsed_keywords = $this->_parseSearchKeywords($column, substr($item, 1, -1));
 				$conditions[] = "(". $parsed_keywords[0] . ")";
 				$conditions[] = 'AND';
 				$params = array_merge($params, $parsed_keywords[1]);

--- a/common/framework/parsers/dbquery/variablebase.php
+++ b/common/framework/parsers/dbquery/variablebase.php
@@ -442,7 +442,14 @@ class VariableBase
 		$where = '';
 		$params = array();
 		
-		// parse the value (text)
+		// flag to mark transformed quotation mark.
+		$escaped_quot = false;
+		// parse the value (text);
+		if (strpos ($value, '&quot;'))
+		{
+			$escaped_quot = true;
+			$value = str_replace('&quot;', '"', $value);
+		}
 		$keywords = preg_split('/(\([^\)]*\))|("[^"]*")|[\s,]+/', trim($value), 10, \PREG_SPLIT_NO_EMPTY | \PREG_SPLIT_DELIM_CAPTURE);
 		$conditions = array();
 		$operators = array('AND', 'OR', '|');
@@ -473,6 +480,12 @@ class VariableBase
 			if (trim($item) === "")
 			{
 				continue;
+			}
+			
+			if($escaped_quot === true)
+			{
+				$value = str_replace('"', '&quot;', $value);
+				$escaped_quot = false;
 			}
 			
 			// process 'AND' or 'OR' operator

--- a/common/framework/parsers/dbquery/variablebase.php
+++ b/common/framework/parsers/dbquery/variablebase.php
@@ -237,7 +237,7 @@ class VariableBase
 				}
 				break;
 			case 'search':
-				list($where, $params[]) = $this->_parseSearchKeywords($value);
+				list($where, $params[]) = $this->_parseSearchKeywords($column, $value);
 				break;
 			case 'plus':
 				$where = sprintf('%s = %s + %s', $column, $column, $is_expression ? $value : '?');
@@ -434,7 +434,7 @@ class VariableBase
 	 * @param string $value
 	 * @return object
 	 */
-	protected function _parseSearchKeywords($value)
+	protected function _parseSearchKeywords($column, $value)
 	{
 		// Initialze the return values.
 		$where = '';

--- a/common/framework/parsers/dbquery/variablebase.php
+++ b/common/framework/parsers/dbquery/variablebase.php
@@ -445,7 +445,7 @@ class VariableBase
 		// flag to mark transformed quotation mark.
 		$escaped_quot = false;
 		// parse the value (text);
-		if (strpos ($value, '&quot;'))
+		if (strpos ($value, '&quot;') !== false)
 		{
 			$escaped_quot = true;
 			$value = str_replace('&quot;', '"', $value);

--- a/common/framework/parsers/dbquery/variablebase.php
+++ b/common/framework/parsers/dbquery/variablebase.php
@@ -238,8 +238,8 @@ class VariableBase
 				break;
 			case 'search':
 				$parsed_keywords = $this->_parseSearchKeywords($value);
-				$where = $parsed_keywords->where;
-				$params = $parsed_keywords->params;
+				$where = $parsed_keywords[0];
+				$params = $parsed_keywords[1];
 				break;
 			case 'plus':
 				$where = sprintf('%s = %s + %s', $column, $column, $is_expression ? $value : '?');
@@ -436,7 +436,7 @@ class VariableBase
 	 * @param string $value
 	 * @return object
 	 */
-	private function _parseSearchKeywords($value)
+	private function _parseSearchKeywords() ($value)
 	{
 		// parse the value (text)
 		$keywords = preg_split('/("[^"]*")|[\s,]+/', trim($value), 10, \PREG_SPLIT_NO_EMPTY | \PREG_SPLIT_DELIM_CAPTURE);
@@ -491,9 +491,6 @@ class VariableBase
 		$conditions = implode(' ', $conditions);
 		$where = count($keywords) === 1 ? $conditions : "($conditions)";
 		
-		return (object) array (
-			'where' => $where,
-			'params' => $params
-		);
+		return [$where, $params];
 	}
 }

--- a/common/framework/parsers/dbquery/variablebase.php
+++ b/common/framework/parsers/dbquery/variablebase.php
@@ -433,8 +433,9 @@ class VariableBase
 	/**
 	 * Parse the search text.
 	 * 
+	 * @param string $column
 	 * @param string $value
-	 * @return object
+	 * @return array
 	 */
 	protected function _parseSearchKeywords($column, $value)
 	{

--- a/common/framework/parsers/dbquery/variablebase.php
+++ b/common/framework/parsers/dbquery/variablebase.php
@@ -237,7 +237,7 @@ class VariableBase
 				}
 				break;
 			case 'search':
-				$keywords = preg_split('/("[^"]*")|[\s,]+/', $value, 10, \PREG_SPLIT_NO_EMPTY);
+				$keywords = preg_split('/("[^"]*")|[\s,]+/', $value, 10, \PREG_SPLIT_NO_EMPTY | \PREG_SPLIT_DELIM_CAPTURE);
 				$conditions = array();
 				$operators = array('AND', 'OR', '|');
 				$placeholders = implode(', ', array_fill(0, count($keywords), '?'));

--- a/common/framework/parsers/dbquery/variablebase.php
+++ b/common/framework/parsers/dbquery/variablebase.php
@@ -260,7 +260,7 @@ class VariableBase
 					}
 					
 					// process 'AND' or 'OR' operator
-					if (in_array($item, $operators) 
+					if (in_array($item, $operators))
 					{
 						if ($item === '|')
 						{


### PR DESCRIPTION
구글이 될 수는 없지만, 큰 부담이 되지 않는 선에서 검색에 유용한 기능을 몇가지 더합니다.
(빼기 기호를 처리하는 것을 보고서 추가로 있으면 좋겠다 생각했던 내용을 추가합니다)

1. 구, 절과 같이 연속되는 단어의 검색
  - `"I SEOUL U"`와 같은 구문을 `"U I SEOUL"`과 구분해서 검색할 수 있습니다. 따옴표로 묶어주세요.
2. AND, OR 검색
  - 검색어에 `-`와 함께 많이 사용하는 `AND`, `OR`을 추가합니다. 기본 값은 `AND`이지만, `OR` 검색을 원하는 경우 `OR`을 입력하세요.
  - 예) `"Min-Soo" OR "Min Soo"`
3. <strike>괄호도 있으면 좋겠지만, 저는 괄호까지는 잘 사용하지 않아서 제 검색 사용 경험상 추가하지 않았습니다.</strike>괄호도 추가되었습니다.