### PR TITLE
신고 내역을 세션에 기록하는 방식 개선

### DIFF
--- a/modules/document/document.controller.php
+++ b/modules/document/document.controller.php
@@ -1651,8 +1651,8 @@ class documentController extends document
 	 */
 	function declaredDocument($document_srl, $declare_message = '')
 	{
-		// Fail if session information already has a reported document
-		if($_SESSION['declared_document'][$document_srl])
+		// Fail if session already tried to report the document
+		if(isset($_SESSION['declared_document'][$document_srl]))
 		{
 			return new BaseObject(-1, 'failed_declared');
 		}
@@ -1687,6 +1687,7 @@ class documentController extends document
 		// Pass if the author's IP address is as same as visitor's.
 		if($oDocument->get('ipaddress') == \RX_CLIENT_IP)
 		{
+			$_SESSION['declared_document'][$document_srl] = false;
 			return new BaseObject(-1, 'failed_declared');
 		}
 
@@ -1699,6 +1700,7 @@ class documentController extends document
 			// Pass after registering a session if author's information is same as the currently logged-in user's.
 			if($member_srl && $member_srl == abs($oDocument->get('member_srl')))
 			{
+				$_SESSION['declared_document'][$document_srl] = false;
 				return new BaseObject(-1, 'failed_declared');
 			}
 		}
@@ -1717,6 +1719,7 @@ class documentController extends document
 		$output = executeQuery('document.getDocumentDeclaredLogInfo', $args);
 		if($output->data->count)
 		{
+			$_SESSION['declared_document'][$document_srl] = false;
 			return new BaseObject(-1, 'failed_declared');
 		}
 		
@@ -1832,7 +1835,7 @@ class documentController extends document
 		
 		if($output->data->count <= 0 || !isset($output->data->count))
 		{
-			$_SESSION['declared_document'][$document_srl] = false;
+			unset($_SESSION['declared_document'][$document_srl]);
 			return new BaseObject(-1, 'failed_declared_cancel');
 		}
 		
@@ -1908,7 +1911,7 @@ class documentController extends document
 		$trigger_obj->declared_count = $declared_count - 1;
 		ModuleHandler::triggerCall('document.declaredDocumentCancel', 'after', $trigger_obj);
 
-		$_SESSION['declared_document'][$document_srl] = false;
+		unset($_SESSION['declared_document'][$document_srl]);
 
 		$this->setMessage('success_declared_cancel');
 	}

--- a/modules/document/document.controller.php
+++ b/modules/document/document.controller.php
@@ -1687,7 +1687,6 @@ class documentController extends document
 		// Pass if the author's IP address is as same as visitor's.
 		if($oDocument->get('ipaddress') == \RX_CLIENT_IP)
 		{
-			$_SESSION['declared_document'][$document_srl] = true;
 			return new BaseObject(-1, 'failed_declared');
 		}
 
@@ -1700,7 +1699,6 @@ class documentController extends document
 			// Pass after registering a session if author's information is same as the currently logged-in user's.
 			if($member_srl && $member_srl == abs($oDocument->get('member_srl')))
 			{
-				$_SESSION['declared_document'][$document_srl] = true;
 				return new BaseObject(-1, 'failed_declared');
 			}
 		}
@@ -1719,7 +1717,6 @@ class documentController extends document
 		$output = executeQuery('document.getDocumentDeclaredLogInfo', $args);
 		if($output->data->count)
 		{
-			$_SESSION['declared_document'][$document_srl] = true;
 			return new BaseObject(-1, 'failed_declared');
 		}
 		

--- a/modules/document/document.item.php
+++ b/modules/document/document.item.php
@@ -558,7 +558,7 @@ class documentItem extends BaseObject
 			return $_SESSION['declared_document'][$this->document_srl] = $declaredCount;
 		}
 		
-		return $_SESSION['declared_document'][$this->document_srl] = false;
+		return false;
 	}
 
 	function getTitle($cut_size = 0, $tail = '...')


### PR DESCRIPTION
신고에 실패한 글에서 "신고 취소" 팝업 메뉴를 표시하는 현상을 수정합니다.

`getDeclared` 메서드가 `$_SESSION['declared_document']`을 통해 신고 여부를 판별하는 만큼 명확한 경우에만 세션에 기록하는 것이 좋을 것 같다고 판단했습니다.

자세한 내용은 #1513 이슈에 기록해 두었습니다.