### PR TITLE
통합검색 모듈에서 검색어가 이중으로 escape 되는 문제 수정

### DIFF
--- a/modules/file/file.admin.model.php
+++ b/modules/file/file.admin.model.php
@@ -10,7 +10,7 @@ class fileAdminModel extends file
 	 * Initialization
 	 * @return void
 	 */
-	function init()
+	public function init()
 	{
 	}
 
@@ -62,7 +62,7 @@ class fileAdminModel extends file
 	 * @param array $columnList Column list to get from DB
 	 * @return Object Object contains query result
 	 */
-	function getFileList($obj, $columnList = array())
+	public function getFileList($obj, $columnList = array())
 	{
 		$args = new stdClass();
 		$this->_makeSearchParam($obj, $args);
@@ -75,9 +75,9 @@ class fileAdminModel extends file
 		elseif($obj->direct_download == 'N') $args->direct_download= 'N';
 		// Set variables
 		$args->sort_index = $obj->sort_index;
-		$args->page = $obj->page?$obj->page:1;
-		$args->list_count = $obj->list_count?$obj->list_count:20;
-		$args->page_count = $obj->page_count?$obj->page_count:10;
+		$args->page = $obj->page?? 1;
+		$args->list_count = $obj->list_count?? 20;
+		$args->page_count = $obj->page_count?? 10;
 		$args->s_module_srl = $obj->module_srl;
 		$args->exclude_module_srl = $obj->exclude_module_srl;
 		if(toBool($obj->exclude_secret))
@@ -124,7 +124,7 @@ class fileAdminModel extends file
 	 * @param object $obj Search options (not used...)
 	 * @return array
 	 */
-	function getFilesCountByGroupValid($obj = '')
+	public function getFilesCountByGroupValid($obj = '')
 	{
 		//$this->_makeSearchParam($obj, $args);
 
@@ -138,7 +138,7 @@ class fileAdminModel extends file
 	 * @param string $date Date string
 	 * @return int
 	 */
-	function getFilesCountByDate($date = '')
+	public function getFilesCountByDate($date = '')
 	{
 		$args = new stdClass();
 		if($date)
@@ -162,11 +162,11 @@ class fileAdminModel extends file
 	 * @param object $args Result searach options
 	 * @return void
 	 */
-	function _makeSearchParam(&$obj, &$args)
+	protected function _makeSearchParam(&$obj, &$args)
 	{
 		// Search options
-		$search_target = $obj->search_target?$obj->search_target:trim(Context::get('search_target'));
-		$search_keyword = $obj->search_keyword?$obj->search_keyword:trim(Context::get('search_keyword'));
+		$search_target = $obj->search_target ?? trim(Context::get('search_target'));
+		$search_keyword = $obj->search_keyword ?? trim(Context::get('search_keyword'));
 
 		if($search_target && $search_keyword)
 		{

--- a/modules/file/queries/getFileList.xml
+++ b/modules/file/queries/getFileList.xml
@@ -20,15 +20,15 @@
         <condition operation="equal" column="files.direct_download" var="direct_download" pipe="and" />
 		<condition operation="below" column="files.regdate" var="regdate_before" pipe="and" />
         <group pipe="and">
-            <condition operation="like" column="files.source_filename" var="s_filename" pipe="or" />
+            <condition operation="search" column="files.source_filename" var="s_filename" pipe="or" />
             <condition operation="more" column="files.file_size" var="s_filesize_more" pipe="or" />
             <condition operation="less" column="files.file_size" var="s_filesize_less" pipe="or" />
             <condition operation="more" column="files.download_count" var="s_download_count" pipe="or" />
             <condition operation="like_prefix" column="files.regdate" var="s_regdate" pipe="or" />
             <condition operation="like_prefix" column="files.ipaddress" var="s_ipaddress" pipe="or" />
-            <condition operation="like" column="member.user_id" var="s_user_id" pipe="or" />
-            <condition operation="like" column="member.user_name" var="s_user_name" pipe="or" />
-            <condition operation="like" column="member.nick_name" var="s_nick_name" pipe="or" />
+            <condition operation="search" column="member.user_id" var="s_user_id" pipe="or" />
+            <condition operation="search" column="member.user_name" var="s_user_name" pipe="or" />
+            <condition operation="search" column="member.nick_name" var="s_nick_name" pipe="or" />
         </group>
     </conditions>
     <navigation>

--- a/modules/file/queries/getFileListByTargetStatus.xml
+++ b/modules/file/queries/getFileListByTargetStatus.xml
@@ -1,4 +1,4 @@
-<query id="getFileList" action="select">
+<query id="getFileListByTargetStatus" action="select">
     <tables>
         <table name="files" alias="files" />
         <table name="member" type="left join">
@@ -35,15 +35,15 @@
 			<condition operation="null" column="comments.is_secret" pipe="or" />
 		</group>
         <group pipe="and">
-            <condition operation="like" column="files.source_filename" var="s_filename" pipe="or" />
+            <condition operation="search" column="files.source_filename" var="s_filename" pipe="or" />
             <condition operation="more" column="files.file_size" var="s_filesize_more" pipe="or" />
             <condition operation="less" column="files.file_size" var="s_filesize_less" pipe="or" />
             <condition operation="more" column="files.download_count" var="s_download_count" pipe="or" />
             <condition operation="like_prefix" column="files.regdate" var="s_regdate" pipe="or" />
             <condition operation="like_prefix" column="files.ipaddress" var="s_ipaddress" pipe="or" />
-            <condition operation="like" column="member.user_id" var="s_user_id" pipe="or" />
-            <condition operation="like" column="member.user_name" var="s_user_name" pipe="or" />
-            <condition operation="like" column="member.nick_name" var="s_nick_name" pipe="or" />
+            <condition operation="search" column="member.user_id" var="s_user_id" pipe="or" />
+            <condition operation="search" column="member.user_name" var="s_user_name" pipe="or" />
+            <condition operation="search" column="member.nick_name" var="s_nick_name" pipe="or" />
         </group>
     </conditions>
     <navigation>

--- a/modules/integration_search/integration_search.view.php
+++ b/modules/integration_search/integration_search.view.php
@@ -23,7 +23,7 @@ class integration_searchView extends integration_search
 	 *
 	 * @return void
 	 */
-	function init()
+	public function init()
 	{
 	}
 
@@ -32,7 +32,7 @@ class integration_searchView extends integration_search
 	 *
 	 * @return Object
 	 */
-	function IS()
+	public function IS()
 	{
 		$oFile = getClass('file');
 		$oModuleModel = getModel('module');
@@ -114,7 +114,8 @@ class integration_searchView extends integration_search
 
 		// Set a variable for search keyword
 		$is_keyword = Context::get('is_keyword');
-		$is_keyword = escape(trim(utf8_normalize_spaces($is_keyword)));
+		// As the variables from GET or POST will be escaped by setRequestArguments method at Context class, the double_escape variable should be "FALSE", and also the escape function might be useful when this method was called from the other way (for not escaped keyword).
+		$is_keyword = escape(trim(utf8_normalize_spaces($is_keyword)), false);
 		if (mb_strlen($is_keyword, 'UTF-8') > 40)
 		{
 			$is_keyword = mb_substr($is_keyword, 0, 40);


### PR DESCRIPTION
GET이나 POST로 입력되는 모든 변수는 `Context` class의 `setRequestArguments` 메소드를 통해 `escape()` 됩니다. (`classes/context/Context.class.php` 1180번째 줄)

```classes/context/Context.class.php
1175		// Filter all arguments and set them to Context.
1176		foreach($request_args as $key => $val)
1177		{
1178			if($val !== '' && !isset(self::$_reserved_keys[$key]) && !self::get($key))
1179			{
1180				$key = escape($key);
1181				$val = self::_filterRequestVar($key, $val);
1182				self::set($key, $val, true);
1183			}
1184		}
```

하지만, 당연히 이를 거치지 않았을 가능성이 있기 때문에 통합검색 모듈에서 해당 변수를 escape 하는 것은 필요하다 생각합니다.

따라서, 이미 escape 된 변수와 아닌 변수를 구분해줄 필요가 있을 것 같습니다.

다행히도, 라이믹스의 escape 함수는 `$double_escape` 변수를 통해서 이중으로 escape 되는 상황을 방지할 수 있도록 설계되었습니다.

이를 활용한 PR 입니다.

+ 고치는 김에, visibility 속성도 추가해주었습니다.
+ 고치는 김에, files 모듈의 검색 기능에서도 search operator를 사용하도록 수정했습니다.

감사합니다.