### PR TITLE
파일 모듈에서 검색시에 search operator 사용하도록 수정

### DIFF
--- a/modules/file/file.admin.model.php
+++ b/modules/file/file.admin.model.php
@@ -75,9 +75,9 @@ class fileAdminModel extends file
 		elseif($obj->direct_download == 'N') $args->direct_download= 'N';
 		// Set variables
 		$args->sort_index = $obj->sort_index;
-		$args->page = $obj->page?? 1;
-		$args->list_count = $obj->list_count?? 20;
-		$args->page_count = $obj->page_count?? 10;
+		$args->page = $obj->page?$obj->page:1;
+		$args->list_count = $obj->list_count?$obj->list_count:20;
+		$args->page_count = $obj->page_count?$obj->page_count:10;
 		$args->s_module_srl = $obj->module_srl;
 		$args->exclude_module_srl = $obj->exclude_module_srl;
 		if(toBool($obj->exclude_secret))
@@ -165,8 +165,8 @@ class fileAdminModel extends file
 	protected function _makeSearchParam(&$obj, &$args)
 	{
 		// Search options
-		$search_target = $obj->search_target ?? trim(Context::get('search_target'));
-		$search_keyword = $obj->search_keyword ?? trim(Context::get('search_keyword'));
+		$search_target = $obj->search_target?$obj->search_target:trim(Context::get('search_target'));
+		$search_keyword = $obj->search_keyword?$obj->search_keyword:trim(Context::get('search_keyword'));
 
 		if($search_target && $search_keyword)
 		{

--- a/modules/file/file.admin.model.php
+++ b/modules/file/file.admin.model.php
@@ -173,7 +173,6 @@ class fileAdminModel extends file
 			switch($search_target)
 			{
 				case 'filename' :
-					if($search_keyword) $search_keyword = str_replace(' ','%',$search_keyword);
 					$args->s_filename = $search_keyword;
 					break;
 				case 'filesize_more' :

--- a/modules/file/file.admin.model.php
+++ b/modules/file/file.admin.model.php
@@ -10,7 +10,7 @@ class fileAdminModel extends file
 	 * Initialization
 	 * @return void
 	 */
-	function init()
+	public function init()
 	{
 	}
 
@@ -62,7 +62,7 @@ class fileAdminModel extends file
 	 * @param array $columnList Column list to get from DB
 	 * @return Object Object contains query result
 	 */
-	function getFileList($obj, $columnList = array())
+	public function getFileList($obj, $columnList = array())
 	{
 		$args = new stdClass();
 		$this->_makeSearchParam($obj, $args);
@@ -75,9 +75,9 @@ class fileAdminModel extends file
 		elseif($obj->direct_download == 'N') $args->direct_download= 'N';
 		// Set variables
 		$args->sort_index = $obj->sort_index;
-		$args->page = $obj->page?$obj->page:1;
-		$args->list_count = $obj->list_count?$obj->list_count:20;
-		$args->page_count = $obj->page_count?$obj->page_count:10;
+		$args->page = $obj->page?? 1;
+		$args->list_count = $obj->list_count?? 20;
+		$args->page_count = $obj->page_count?? 10;
 		$args->s_module_srl = $obj->module_srl;
 		$args->exclude_module_srl = $obj->exclude_module_srl;
 		if(toBool($obj->exclude_secret))
@@ -124,7 +124,7 @@ class fileAdminModel extends file
 	 * @param object $obj Search options (not used...)
 	 * @return array
 	 */
-	function getFilesCountByGroupValid($obj = '')
+	public function getFilesCountByGroupValid($obj = '')
 	{
 		//$this->_makeSearchParam($obj, $args);
 
@@ -138,7 +138,7 @@ class fileAdminModel extends file
 	 * @param string $date Date string
 	 * @return int
 	 */
-	function getFilesCountByDate($date = '')
+	public function getFilesCountByDate($date = '')
 	{
 		$args = new stdClass();
 		if($date)
@@ -162,11 +162,11 @@ class fileAdminModel extends file
 	 * @param object $args Result searach options
 	 * @return void
 	 */
-	function _makeSearchParam(&$obj, &$args)
+	protected function _makeSearchParam(&$obj, &$args)
 	{
 		// Search options
-		$search_target = $obj->search_target?$obj->search_target:trim(Context::get('search_target'));
-		$search_keyword = $obj->search_keyword?$obj->search_keyword:trim(Context::get('search_keyword'));
+		$search_target = $obj->search_target ?? trim(Context::get('search_target'));
+		$search_keyword = $obj->search_keyword ?? trim(Context::get('search_keyword'));
 
 		if($search_target && $search_keyword)
 		{

--- a/modules/file/queries/getFileList.xml
+++ b/modules/file/queries/getFileList.xml
@@ -20,15 +20,15 @@
         <condition operation="equal" column="files.direct_download" var="direct_download" pipe="and" />
 		<condition operation="below" column="files.regdate" var="regdate_before" pipe="and" />
         <group pipe="and">
-            <condition operation="like" column="files.source_filename" var="s_filename" pipe="or" />
+            <condition operation="search" column="files.source_filename" var="s_filename" pipe="or" />
             <condition operation="more" column="files.file_size" var="s_filesize_more" pipe="or" />
             <condition operation="less" column="files.file_size" var="s_filesize_less" pipe="or" />
             <condition operation="more" column="files.download_count" var="s_download_count" pipe="or" />
             <condition operation="like_prefix" column="files.regdate" var="s_regdate" pipe="or" />
             <condition operation="like_prefix" column="files.ipaddress" var="s_ipaddress" pipe="or" />
-            <condition operation="like" column="member.user_id" var="s_user_id" pipe="or" />
-            <condition operation="like" column="member.user_name" var="s_user_name" pipe="or" />
-            <condition operation="like" column="member.nick_name" var="s_nick_name" pipe="or" />
+            <condition operation="search" column="member.user_id" var="s_user_id" pipe="or" />
+            <condition operation="search" column="member.user_name" var="s_user_name" pipe="or" />
+            <condition operation="search" column="member.nick_name" var="s_nick_name" pipe="or" />
         </group>
     </conditions>
     <navigation>

--- a/modules/file/queries/getFileListByTargetStatus.xml
+++ b/modules/file/queries/getFileListByTargetStatus.xml
@@ -1,4 +1,4 @@
-<query id="getFileList" action="select">
+<query id="getFileListByTargetStatus" action="select">
     <tables>
         <table name="files" alias="files" />
         <table name="member" type="left join">
@@ -35,15 +35,15 @@
 			<condition operation="null" column="comments.is_secret" pipe="or" />
 		</group>
         <group pipe="and">
-            <condition operation="like" column="files.source_filename" var="s_filename" pipe="or" />
+            <condition operation="search" column="files.source_filename" var="s_filename" pipe="or" />
             <condition operation="more" column="files.file_size" var="s_filesize_more" pipe="or" />
             <condition operation="less" column="files.file_size" var="s_filesize_less" pipe="or" />
             <condition operation="more" column="files.download_count" var="s_download_count" pipe="or" />
             <condition operation="like_prefix" column="files.regdate" var="s_regdate" pipe="or" />
             <condition operation="like_prefix" column="files.ipaddress" var="s_ipaddress" pipe="or" />
-            <condition operation="like" column="member.user_id" var="s_user_id" pipe="or" />
-            <condition operation="like" column="member.user_name" var="s_user_name" pipe="or" />
-            <condition operation="like" column="member.nick_name" var="s_nick_name" pipe="or" />
+            <condition operation="search" column="member.user_id" var="s_user_id" pipe="or" />
+            <condition operation="search" column="member.user_name" var="s_user_name" pipe="or" />
+            <condition operation="search" column="member.nick_name" var="s_nick_name" pipe="or" />
         </group>
     </conditions>
     <navigation>

--- a/modules/file/queries/getFilesCountByGroupValid.xml
+++ b/modules/file/queries/getFilesCountByGroupValid.xml
@@ -1,4 +1,4 @@
-<query id="getFilesCount" action="select">
+<query id="getFilesCountByGroupValid" action="select">
     <tables>
         <table name="files" />
     </tables>
@@ -12,7 +12,7 @@
         <condition operation="equal" column="isvalid" var="isvalid" pipe="and" />
         <condition operation="equal" column="direct_download" var="direct_download" pipe="and" />
         <group pipe="and">
-            <condition operation="like" column="source_filename" var="s_filename" pipe="or" />
+            <condition operation="search" column="source_filename" var="s_filename" pipe="or" />
             <condition operation="more" column="file_size" var="s_filesize_more" pipe="or" />
             <condition operation="less" column="file_size" var="s_filesize_less" pipe="or" />
             <condition operation="more" column="download_count" var="s_download_count" pipe="or" />

--- a/modules/integration_search/integration_search.view.php
+++ b/modules/integration_search/integration_search.view.php
@@ -23,7 +23,7 @@ class integration_searchView extends integration_search
 	 *
 	 * @return void
 	 */
-	function init()
+	public function init()
 	{
 	}
 
@@ -32,7 +32,7 @@ class integration_searchView extends integration_search
 	 *
 	 * @return Object
 	 */
-	function IS()
+	public function IS()
 	{
 		$oFile = getClass('file');
 		$oModuleModel = getModel('module');
@@ -114,7 +114,8 @@ class integration_searchView extends integration_search
 
 		// Set a variable for search keyword
 		$is_keyword = Context::get('is_keyword');
-		$is_keyword = escape(trim(utf8_normalize_spaces($is_keyword)));
+		// As the variables from GET or POST will be escaped by setRequestArguments method at Context class, the double_escape variable should be "FALSE", and also the escape function might be useful when this method was called from the other way (for not escaped keyword).
+		$is_keyword = escape(trim(utf8_normalize_spaces($is_keyword)), false);
 		if (mb_strlen($is_keyword, 'UTF-8') > 40)
 		{
 			$is_keyword = mb_substr($is_keyword, 0, 40);


### PR DESCRIPTION
파일 모듈에서 파일 이름 또는 그 외 검색어를 입력할 때, 기존의 like operator 대신 search 기능을 사용하도록 수정합니다.
추가로, 같은 파일 내의 visibility 를 설정합니다.
추가로, XML 쿼리 파일 내의 id가 실제 쿼리 id와 다르게 작성되어 있던 오타를 수정합니다.