### PR TITLE
공지사항 리스트에도 트리거를 추가

### DIFF
--- a/modules/document/document.model.php
+++ b/modules/document/document.model.php
@@ -307,17 +307,17 @@ class documentModel extends document
 
 		// Call trigger (before)
 		// This trigger can be used to set an alternative output using a different search method
-		unset($obj->use_alternate_output);
-		$output = ModuleHandler::triggerCall('document.getNoticeList', 'before', $obj);
+		unset($args->use_alternate_output);
+		$output = ModuleHandler::triggerCall('document.getNoticeList', 'before', $args);
 		if ($output instanceof BaseObject && !$output->toBool())
 		{
 			return $output;
 		}
 
 		// If an alternate output is set, use it instead of running the default queries
-		if (isset($obj->use_alternate_output) && $obj->use_alternate_output instanceof BaseObject)
+		if (isset($args->use_alternate_output) && $args->use_alternate_output instanceof BaseObject)
 		{
-			$output = $obj->use_alternate_output;
+			$output = $args->use_alternate_output;
 		}
 		else
 		{

--- a/modules/document/document.model.php
+++ b/modules/document/document.model.php
@@ -304,7 +304,26 @@ class documentModel extends document
 		$args = new stdClass();
 		$args->module_srl = $obj->module_srl;
 		$args->category_srl = $obj->category_srl ?? null;
-		$output = executeQueryArray('document.getNoticeList', $args, $columnList);
+
+		// Call trigger (before)
+		// This trigger can be used to set an alternative output using a different search method
+		unset($obj->use_alternate_output);
+		$output = ModuleHandler::triggerCall('document.getNoticeList', 'before', $obj);
+		if ($output instanceof BaseObject && !$output->toBool())
+		{
+			return $output;
+		}
+
+		// If an alternate output is set, use it instead of running the default queries
+		if (isset($obj->use_alternate_output) && $obj->use_alternate_output instanceof BaseObject)
+		{
+			$output = $obj->use_alternate_output;
+		}
+		else
+		{
+			$output = executeQueryArray('document.getNoticeList', $args, $columnList);
+		}
+		
 		if(!$output->toBool() || !$result = $output->data)
 		{
 			return;
@@ -322,7 +341,10 @@ class documentModel extends document
 			$output->data[$attribute->document_srl] = $GLOBALS['XE_DOCUMENT_LIST'][$attribute->document_srl];
 		}
 		self::setToAllDocumentExtraVars();
-		
+
+		// Call trigger (after)
+		// This trigger can be used to modify search results
+		ModuleHandler::triggerCall('document.getNoticeList', 'after', $output);
 		return $output;
 	}
 


### PR DESCRIPTION
기존에 documentList 에 트리거를 추가하여 많은 모듈들이 이득을 보았습니다

이를 공지사항 리스트에도 트리거를 추가하여 서드파티가 입맛대로 구현하여 사용할 수 있도록 해봅니다.

동작 방식은 똑같이 `document.getNoticeList`라는 트리거를 호출하도록 하여 해당 document.getNoticeList에서 치환하는 방법없이 디비를 덮어 씌워줍니다.

사용방법은 documentList와 동일하게 트리거의 $obj->use_alternate_output 값을 그대로 넘겨주시면 됩니다.

일부 서드파티에서 공지사항을 약간 수정하고 덮어 씌우더라도 구현하는데 무리가 없으나 그래도 쿼리가 공지를 위해 두번 실행되는 비효율적인 부분을 쿼리 한번으로 마무리할 수 있도록 도와주기에 효율성이 아주 없다고 보기는 어려워 적용하게 되었습니다.