### PR TITLE
use_third_module_title 옵션 추가.

### DIFF
--- a/modules/board/board.view.php
+++ b/modules/board/board.view.php
@@ -571,7 +571,10 @@ class boardView extends board
 
 		// setup document list variables on context
 		$output = DocumentModel::getDocumentList($args, $this->except_notice, TRUE, $this->columnList);
-		$this->_fillModuleTitles($output->data);
+		if(!$output->use_third_module_title)
+		{
+			$this->_fillModuleTitles($output->data);
+		}
 		Context::set('document_list', $output->data);
 		Context::set('total_count', $output->total_count);
 		Context::set('total_page', $output->total_page);


### PR DESCRIPTION
getDocumentList 라는 트리거를 이용하다보면 한개의 게시판에서 여러개의 게시판의 게시글을 가져오는 경우가 있습니다.

라이믹스에 이미 통합게시판이라는 명칭으로 기능이 제공되고 있지만 이것보다 좀 더 다양한 옵션을 사용하면서 사용할 경우 서드파티에서 처리를 하게 됩니다.

그럴경우 라이믹스의 표준에 따라 $oDocument->module_title, 혹은 $document->module_title 을 그대로 사용할 수 있어야 합니다.

이 패치가 없다면 아무리 module_title 값을 추가하더라도 `_fillModuleTitles` 에서 덮어 씌우게되기 때문에 무용지물이 됩니다.

물론 서드파티에서 따로 추가하여 사용할 수 있지만, 라이믹스에서 기본 제공되는 기능을 사용할 수 있으면 스킨을 수정하지 않더라도 해당 기능을 제공해줄 필요가 있을 것 같아 해당 옵션을 채크하는 기능을 만들었습니다.

서드파티에는 최종 $output (디비 쿼리한 값 혹은 디비쿼리캐싱값)에 `$output->use_third_module_title = true;` 으로 전달해주면 됩니다.

그럼 서드파티에서 만들어둔 게시판이라는걸 인식하고 게시판 모듈에서는 `_fillModuleTitles` 를 실행하지 않고 서드파티 모듈에서 만든 값을 덮어 씌우지 않게 됩니다.