### PR TITLE
템플릿 내 srcset의 상대경로를 절대경로로 변환하도록 개선

### DIFF
--- a/classes/template/TemplateHandler.class.php
+++ b/classes/template/TemplateHandler.class.php
@@ -384,7 +384,7 @@ class TemplateHandler
 	}
 
 	/**
-	 * preg_replace_callback hanlder
+	 * preg_replace_callback handler
 	 *
 	 * replace image path
 	 * @param array $match
@@ -434,7 +434,7 @@ class TemplateHandler
 	}
 
 	/**
-	 * preg_replace_callback hanlder
+	 * preg_replace_callback handler
 	 *
 	 * replace srcset string with multiple paths
 	 * @param array $match
@@ -577,7 +577,7 @@ class TemplateHandler
 	}
 
 	/**
-	 * preg_replace_callback hanlder
+	 * preg_replace_callback handler
 	 * replace php code.
 	 * @param array $m
 	 * @return string changed result

--- a/classes/template/TemplateHandler.class.php
+++ b/classes/template/TemplateHandler.class.php
@@ -449,7 +449,7 @@ class TemplateHandler
 		foreach ($url_list as &$url) {
 			// replace if url is not starting with the pattern
 			$url = preg_replace_callback(
-				'/^(?!(?:https?|file):\/\/|[\/\{])([^"]+)/is',
+				'/^(?!(?:https?|file):\/\/|[\/\{])(\S+)/i',
 				array($this, '_replaceRelativePath'),
 				trim($url)
 			);

--- a/classes/template/TemplateHandler.class.php
+++ b/classes/template/TemplateHandler.class.php
@@ -235,6 +235,9 @@ class TemplateHandler
 		// replace value of src in img/input/script tag
 		$buff = preg_replace_callback('/<(?:img|input|script)(?:[^<>]*?)(?(?=cond=")(?:cond="[^"]+"[^<>]*)+|)[^<>]* src="(?!(?:https?|file):\/\/|[\/\{])([^"]+)"/is', array($this, '_replacePath'), $buff);
 
+		// replace value of srcset in img/source/link tag
+		$buff = preg_replace_callback('/<(?:img|source|link)(?:[^<>]*?)(?(?=cond=")(?:cond="[^"]+"[^<>]*)+|)[^<>]* srcset="([^"]+)"/is', array($this, '_replaceSrcsetPath'), $buff);
+
 		// replace loop and cond template syntax
 		$buff = $this->_parseInline($buff);
 
@@ -390,7 +393,19 @@ class TemplateHandler
 	 */
 	private function _replacePath($match)
 	{
-		//return origin conde when src value started '${'.
+		$src = $this->_replaceRelativePath($match);
+		return substr($match[0], 0, -strlen($match[1]) - 6) . "src=\"{$src}\"";
+	}
+
+	/**
+	 * replace relative path
+	 * @param array $match
+	 *
+	 * @return string changed result
+	 */
+	private function _replaceRelativePath($match)
+	{
+		//return origin code when src value started '${'.
 		if(preg_match('@^\${@', $match[1]))
 		{
 			return $match[0];
@@ -415,7 +430,33 @@ class TemplateHandler
 			$src = $tmp;
 		}
 
-		return substr($match[0], 0, -strlen($match[1]) - 6) . "src=\"{$src}\"";
+		return $src;
+	}
+
+	/**
+	 * preg_replace_callback hanlder
+	 *
+	 * replace srcset string with multiple paths
+	 * @param array $match
+	 *
+	 * @return string changed result
+	 */
+	private function _replaceSrcsetPath($match)
+	{
+		// explode urls by comma
+		$url_list = explode(",", $match[1]);
+
+		foreach ($url_list as &$url) {
+			// replace if url is not starting with the pattern
+			$url = preg_replace_callback(
+				'/^(?!(?:https?|file):\/\/|[\/\{])([^"]+)/is',
+				array($this, '_replaceRelativePath'),
+				trim($url)
+			);
+		}
+		$srcset = implode(", ", $url_list);
+
+		return substr($match[0], 0, -strlen($match[1]) - 9) . "srcset=\"{$srcset}\"";
 	}
 
 	/**

--- a/tests/unit/classes/TemplateHandlerTest.php
+++ b/tests/unit/classes/TemplateHandlerTest.php
@@ -276,6 +276,11 @@ class TemplateHandlerTest extends \Codeception\TestCase\Test
                 '<input>asdf src="../img/img.gif" asdf</input>',
                 '?><input>asdf src="../img/img.gif" asdf</input>'
             ),
+            // srcset (PR #1544)
+            array(
+                '<img src="./img/sticker_banner_960w.png" alt="this is a test image." srcset="https://abc.com/static/img/test@2x.png 2x,  http://abc.com/static/test@2.5x.png 2.5x,../img/test@3x.png 3x, ../img/test_960w.png  960w, {$mid}/image.png 480w">',
+                '?><img src="/rhymix/tests/unit/classes/template/img/sticker_banner_960w.png" alt="this is a test image." srcset="https://abc.com/static/img/test@2x.png 2x, http://abc.com/static/test@2.5x.png 2.5x, /rhymix/tests/unit/classes/img/test@3x.png 3x, /rhymix/tests/unit/classes/img/test_960w.png  960w, <?php echo $__Context->mid ?>/image.png 480w">'
+            ),
 			// Rhymix improvements (PR #604)
             array(
                 '<span>{$_SERVER["REMOTE_ADDR"]}</span>',


### PR DESCRIPTION
#1543 이슈를 해결합니다.

`srcset` attribute를 처리하기 위해 `_replaceSrcsetPath` 메서드를 새로 만들었습니다.

WHATWG의 HTML Standard에 따르면, [srcset attribute를 가질 수 있는 태그](https://html.spec.whatwg.org/multipage/images.html#srcset-attribute)는 `img`, `source`, `link`입니다. 따라서 `img`, `source`, `link` 태그에 대해 srcset 처리를 하도록 정규식을 구성했습니다.

상대경로를 절대경로로 바꿔주는 작업은 `_replacePath`를 이용해 처리하고 있었으나, 마지막에 원래 `<img src="`를 다시 붙여서 리턴하기 때문에 재사용하기 어려웠습니다.

다만 상대경로를 절대경로로 바꾸는 로직 자체는 동일하기 때문에, 향후 유지보수성 등을 감안하여 `_replaceRelativePath`라는 메서드로 독립시키고 이미지를 처리하는 `_replacePath`와 `_replaceSrcsetPath`가 이를 사용하도록 개선하였습니다.


### 테스트

```HTML
<img src="./img/sticker_banner_960w.png" alt="this is a test image." srcset="https://abc.com/static/img/test@2x.png 2x,  http://abc.com/static/test@2.5x.png 2.5x,./img/test@3x.png 3x, ./img/test_960w.png  960w, {$mid}/image.png 480w">
```

상대경로, 절대경로, https로 시작하는 경로, http로 시작하는 경로, {$mid} 등 변수로 시작하는 경우, 띄어쓰기가 없거나 두 번 이상 된 경우 등으로 구성했습니다.

**결과물**
```HTML
<img src="/modules/sticker/skins/default/img/sticker_banner_960w.png" alt="this is a test image." srcset="https://abc.com/static/img/test@2x.png 2x, http://abc.com/static/test@2.5x.png 2.5x, /modules/sticker/skins/default/img/test@3x.png 3x, /modules/sticker/skins/default/img/test_960w.png  960w, sticker/image.png 480w">
```