### PR TITLE
관리자가 모든 모듈의 다크모드 설정을 제어하도록 합니다.

### DIFF
--- a/classes/context/Context.class.php
+++ b/classes/context/Context.class.php
@@ -2401,11 +2401,7 @@ class Context
 	public static function getBodyClass()
 	{
 		$class_list = self::$_instance->body_class;
-		if (($color_scheme = Rhymix\Framework\UA::getColorScheme()) !== 'auto')
-		{
-			$class_list[] = 'color_scheme_' . $color_scheme;
-		}
-
+		
 		return (count($class_list) > 0) ? sprintf(' class="%s"', implode(' ', array_unique($class_list))) : '';
 	}
 

--- a/classes/module/ModuleHandler.class.php
+++ b/classes/module/ModuleHandler.class.php
@@ -774,6 +774,12 @@ class ModuleHandler extends Handler
 		{
 			Context::addBodyClass('color_scheme_' . $color_scheme);
 		}
+		elseif ($site_module_info->settings->color_scheme === 'client_manual')
+		{
+			// When there was no cookie, and the color_scheme settings was 'client mannual', set a default cookie.
+			Rhymix\Framework\UA::setColorScheme('light');
+			Context::addBodyClass('color_scheme_light');
+		}
 	}
 	
 	

--- a/classes/module/ModuleHandler.class.php
+++ b/classes/module/ModuleHandler.class.php
@@ -770,6 +770,10 @@ class ModuleHandler extends Handler
 			$color_scheme = $color_scheme_array[$site_module_info->settings->color_scheme];
 			Context::addBodyClass('color_scheme_' . $color_scheme);
 		}
+		elseif ($color_scheme_array[$site_module_info->settings->color_scheme] === 'auto_light_dark' && (($color_scheme = Rhymix\Framework\UA::getColorScheme()) !== 'auto'))
+		{
+			Rhymix\Framework\UA::setColorScheme('auto');
+		}
 		elseif (($color_scheme = Rhymix\Framework\UA::getColorScheme()) !== 'auto')
 		{
 			Context::addBodyClass('color_scheme_' . $color_scheme);

--- a/classes/module/ModuleHandler.class.php
+++ b/classes/module/ModuleHandler.class.php
@@ -770,19 +770,9 @@ class ModuleHandler extends Handler
 			$color_scheme = $color_scheme_array[$site_module_info->settings->color_scheme];
 			Context::addBodyClass('color_scheme_' . $color_scheme);
 		}
-		elseif ($site_module_info->settings->color_scheme === 'auto_light_dark' && (($color_scheme = Rhymix\Framework\UA::getColorScheme()) !== 'auto'))
-		{
-			Rhymix\Framework\UA::setColorScheme('auto');
-		}
 		elseif (($color_scheme = Rhymix\Framework\UA::getColorScheme()) !== 'auto')
 		{
 			Context::addBodyClass('color_scheme_' . $color_scheme);
-		}
-		elseif ($site_module_info->settings->color_scheme === 'client_manual')
-		{
-			// When there was no cookie, and the color_scheme settings was 'client mannual', set a default cookie.
-			Rhymix\Framework\UA::setColorScheme('light');
-			Context::addBodyClass('color_scheme_light');
 		}
 	}
 	

--- a/classes/module/ModuleHandler.class.php
+++ b/classes/module/ModuleHandler.class.php
@@ -223,6 +223,7 @@ class ModuleHandler extends Handler
 			$this->mid = $module_info->mid;
 			$this->module_info = $module_info;
 			$this->_setModuleSEOInfo($module_info, $site_module_info);
+			$this->_setModuleColorScheme($site_module_info);
 			
 			// Check if the current request is from a mobile device.
 			$this->is_mobile = Mobile::isFromMobilePhone();
@@ -752,6 +753,29 @@ class ModuleHandler extends Handler
 		// Return the module info for further processing.
 		return $module_info;
 	}
+	
+	/**
+	 * Set color scheme.
+	 * 
+	 * @param object $site_module_info
+	 */
+	protected function _setModuleColorScheme($site_module_info)
+	{
+		$color_scheme = null;
+		
+		$color_scheme_array = array('off_light'=>'light', 'off_dark' => 'dark');
+		if (isset($color_scheme_array[$site_module_info->settings->color_scheme]))
+		{
+			Rhymix\Framework\UA::setColorScheme('auto');
+			$color_scheme = $color_scheme_array[$site_module_info->settings->color_scheme];
+			Context::addBodyClass('color_scheme_' . $color_scheme);
+		}
+		elseif (($color_scheme = Rhymix\Framework\UA::getColorScheme()) !== 'auto')
+		{
+			Context::addBodyClass('color_scheme_' . $color_scheme);
+		}
+	}
+	
 	
 	/**
 	 * Set SEO information to Context.

--- a/classes/module/ModuleHandler.class.php
+++ b/classes/module/ModuleHandler.class.php
@@ -770,7 +770,7 @@ class ModuleHandler extends Handler
 			$color_scheme = $color_scheme_array[$site_module_info->settings->color_scheme];
 			Context::addBodyClass('color_scheme_' . $color_scheme);
 		}
-		elseif ($color_scheme_array[$site_module_info->settings->color_scheme] === 'auto_light_dark' && (($color_scheme = Rhymix\Framework\UA::getColorScheme()) !== 'auto'))
+		elseif ($site_module_info->settings->color_scheme === 'auto_light_dark' && (($color_scheme = Rhymix\Framework\UA::getColorScheme()) !== 'auto'))
 		{
 			Rhymix\Framework\UA::setColorScheme('auto');
 		}

--- a/common/js/common.js
+++ b/common/js/common.js
@@ -351,10 +351,13 @@ jQuery(function($) {
 	
 	/* Detect color scheme */
 	var body_element = $('body');
-	var color_scheme_cookie = XE.cookie.get('rx_color_scheme');
-	var color_scheme_detected = (window.matchMedia && window.matchMedia('(prefers-color-scheme:dark)').matches) ? 'dark' : 'light';
-	if (!color_scheme_cookie || (!body_element.hasClass('color_scheme_light') && !body_element.hasClass('color_scheme_dark'))) {
-		body_element.addClass('color_scheme_' + color_scheme_detected).removeClass('color_scheme_' + (color_scheme_detected === 'dark' ? 'light' : 'dark'));
+	/* If there is color_scheme class in the body, color scheme settings were already applied. */
+	if(!body_element.hasClass('color_scheme_light') && !body_element.hasClass('color_scheme_dark')) {
+		var color_scheme_cookie = XE.cookie.get('rx_color_scheme');
+		var color_scheme_detected = (window.matchMedia && window.matchMedia('(prefers-color-scheme:dark)').matches) ? 'dark' : 'light';
+		if (!color_scheme_cookie) {
+			body_element.addClass('color_scheme_' + color_scheme_detected).removeClass('color_scheme_' + (color_scheme_detected === 'dark' ? 'light' : 'dark'));
+		}
 	}
 	
 	/* Editor preview replacement */

--- a/modules/admin/admin.admin.controller.php
+++ b/modules/admin/admin.admin.controller.php
@@ -1113,6 +1113,13 @@ class adminAdminController extends admin
 		$vars->html_header = utf8_trim($vars->html_header);
 		$vars->html_footer = utf8_trim($vars->html_footer);
 		
+		// Validate the color scheme setting.
+		$valid_color_scheme_options = array('off_light', 'off_dark', 'auto_light_dark', 'client_manual');
+		if (!in_array($vars->color_scheme, $valid_security_options))
+		{
+			$vars->color_scheme = 'off_light';
+		}
+		
 		// Merge all settings into an array.
 		$settings = array(
 			'title' => $vars->title,
@@ -1123,6 +1130,7 @@ class adminAdminController extends admin
 			'meta_description' => $vars->meta_description,
 			'html_header' => $vars->html_header,
 			'html_footer' => $vars->html_footer,
+			'color_scheme' => $vars->color_scheme,
 		);
 		
 		// Get the DB object and begin a transaction.

--- a/modules/admin/admin.admin.controller.php
+++ b/modules/admin/admin.admin.controller.php
@@ -1115,7 +1115,7 @@ class adminAdminController extends admin
 		
 		// Validate the color scheme setting.
 		$valid_color_scheme_options = array('off_light', 'off_dark', 'auto_light_dark', 'client_manual');
-		if (!in_array($vars->color_scheme, $valid_security_options))
+		if (!in_array($vars->color_scheme, $valid_color_scheme_options))
 		{
 			$vars->color_scheme = 'off_light';
 		}

--- a/modules/admin/admin.admin.controller.php
+++ b/modules/admin/admin.admin.controller.php
@@ -1114,7 +1114,7 @@ class adminAdminController extends admin
 		$vars->html_footer = utf8_trim($vars->html_footer);
 		
 		// Validate the color scheme setting.
-		$valid_color_scheme_options = array('off_light', 'off_dark', 'auto_light_dark', 'client_manual');
+		$valid_color_scheme_options = array('off_light', 'off_dark', 'auto_light_dark');
 		if (!in_array($vars->color_scheme, $valid_color_scheme_options))
 		{
 			$vars->color_scheme = 'off_light';
@@ -1130,7 +1130,7 @@ class adminAdminController extends admin
 			'meta_description' => $vars->meta_description,
 			'html_header' => $vars->html_header,
 			'html_footer' => $vars->html_footer,
-			'color_scheme' => $vars->color_scheme,
+			'color_scheme' => $vars->color_scheme
 		);
 		
 		// Get the DB object and begin a transaction.

--- a/modules/admin/admin.admin.view.php
+++ b/modules/admin/admin.admin.view.php
@@ -743,6 +743,14 @@ class adminAdminView extends admin
 			Context::set('favicon_url', $oAdminAdminModel->getFaviconUrl($domain_info->domain_srl));
 			Context::set('mobicon_url', $oAdminAdminModel->getMobileIconUrl($domain_info->domain_srl));
 			Context::set('default_image_url', $oAdminAdminModel->getSiteDefaultImageUrl($domain_info->domain_srl));
+			
+			// Get color scheme setting.
+			$valid_color_scheme_options = array('off_light', 'off_dark', 'auto_light_dark', 'client_manual');
+			if (!in_array($domain_info->settings->color_scheme, $valid_color_scheme_options))
+			{
+				$domain_info->settings->color_scheme = 'off_light';
+			}
+			Context::set('color_scheme', $domain_info->settings->color_scheme);
 		}
 		
 		$this->setTemplateFile('config_domains_edit');

--- a/modules/admin/admin.admin.view.php
+++ b/modules/admin/admin.admin.view.php
@@ -745,7 +745,7 @@ class adminAdminView extends admin
 			Context::set('default_image_url', $oAdminAdminModel->getSiteDefaultImageUrl($domain_info->domain_srl));
 			
 			// Get color scheme setting.
-			$valid_color_scheme_options = array('off_light', 'off_dark', 'auto_light_dark', 'client_manual');
+			$valid_color_scheme_options = array('off_light', 'off_dark', 'auto_light_dark');
 			if (!in_array($domain_info->settings->color_scheme, $valid_color_scheme_options))
 			{
 				$domain_info->settings->color_scheme = 'off_light';

--- a/modules/admin/lang/en.php
+++ b/modules/admin/lang/en.php
@@ -299,6 +299,14 @@ $lang->allow_use_mobile_icon = 'Home Screen Icon';
 $lang->detail_use_mobile_icon = 'The mobile icon should be 57x57 or 114x114, only png format.';
 $lang->cmd_site_default_image = 'Default Image';
 $lang->about_site_default_image = 'This image will be shown when your site is linked to in various social networks. It should be 200x200, either jpg or png format.';
+$lang->cmd_site_default_color_scheme = 'Color scheme';
+$lang->about_site_default_color_scheme = 'You can enable dark mode. The module skins, layouts, etc. that you use should be supported. For the developers, the standard can be refer to <a href="https://github.com/rhymix/rhymix/pull/1482" target="_blank">this page</a>.<dl><dt>Disable (default)</dt><dd>Turn off the dark mode function.</dd><dt>Dark mode (fixed)</dt><dd>Enable the dark mode, but fixed to the dark theme.</dd><dt>Automatic (refer to the client browser settings)</dt><dd>Enable the dark mode, and the clients can switch on or off the dark theme refer to the brower settings.</dd><dt>Mannual (refer to the client cookies)</dt><dd>Enable the dark mode, and the clients can switch on or off the dark theme refer to the cookies. The cookies can be modified.</dd></dl> ';
+$lang->site_default_color_scheme_options = array(
+		'off_light' => 'Disable (default)',
+		'off_dark' => 'Dark mode (fixed)',
+		'auto_light_dark' => 'Automatic (refer to the client browser settings)',
+		'client_manual' => 'Mannual (refer to the client cookies)'
+	);
 $lang->use_sso = 'Use <abbr title="Single Sign On">SSO</abbr>?';
 $lang->about_use_sso = 'Logging into one domain will automatically log the user into all domains.';
 $lang->about_arrange_session = 'Do you want to clean up session?';

--- a/modules/admin/lang/en.php
+++ b/modules/admin/lang/en.php
@@ -300,12 +300,11 @@ $lang->detail_use_mobile_icon = 'The mobile icon should be 57x57 or 114x114, onl
 $lang->cmd_site_default_image = 'Default Image';
 $lang->about_site_default_image = 'This image will be shown when your site is linked to in various social networks. It should be 200x200, either jpg or png format.';
 $lang->cmd_site_default_color_scheme = 'Color scheme';
-$lang->about_site_default_color_scheme = 'You can enable dark mode. The module skins, layouts, etc. that you use should be supported. For the developers, the standard can be refer to <a href="https://github.com/rhymix/rhymix/pull/1482" target="_blank">this page</a>.<dl><dt>Disable (default)</dt><dd>Turn off the dark mode function.</dd><dt>Dark mode (fixed)</dt><dd>Enable the dark mode, but fixed to the dark theme.</dd><dt>Automatic (refer to the client browser settings)</dt><dd>Enable the dark mode, and the clients can switch on or off the dark theme refer to the brower settings.</dd><dt>Mannual (refer to the client cookies)</dt><dd>Enable the dark mode, and the clients can switch on or off the dark theme refer to the cookies. The cookies can be modified.</dd></dl> ';
+$lang->about_site_default_color_scheme = 'You can enable dark mode. The module skins, layouts, etc. that you use should be supported. For the developers, the standard can be refer to <a href="https://github.com/rhymix/rhymix/pull/1482" target="_blank">this page</a>.<dl><dt>Disable (default)</dt><dd>Turn off the dark mode function.</dd><dt>Dark mode (fixed)</dt><dd>Enable the dark mode, but fixed to the dark theme.</dd><dt>Automatic (refer to the client browser settings)</dt><dd>Enable the dark mode, and the clients can switch on or off the dark theme refer to the brower settings or the cookies. The cookies can be modified.</dd></dl> ';
 $lang->site_default_color_scheme_options = array(
 		'off_light' => 'Disable (default)',
 		'off_dark' => 'Dark mode (fixed)',
-		'auto_light_dark' => 'Automatic (refer to the client browser settings)',
-		'client_manual' => 'Mannual (refer to the client cookies)'
+		'auto_light_dark' => 'Automatic (refer to the client settings)',
 	);
 $lang->use_sso = 'Use <abbr title="Single Sign On">SSO</abbr>?';
 $lang->about_use_sso = 'Logging into one domain will automatically log the user into all domains.';

--- a/modules/admin/lang/ko.php
+++ b/modules/admin/lang/ko.php
@@ -295,6 +295,14 @@ $lang->allow_use_mobile_icon = '모바일 홈 화면 아이콘';
 $lang->detail_use_mobile_icon = '57x57 또는 114x114 크기의 png 파일을 권장합니다.';
 $lang->cmd_site_default_image = '사이트 대표 이미지';
 $lang->about_site_default_image = 'SNS 등에 이 사이트가 링크되었을 때 표시되는 이미지입니다. 200x200 크기의 jpg 또는 png 파일을 권장합니다.';
+$lang->cmd_site_default_color_scheme = '사이트 색상 조합';
+$lang->about_site_default_color_scheme = '다크모드를 사용하도록 설정할 수 있습니다. 사용하는 모듈 스킨, 레이아웃 등이 지원해야 합니다. 표준은 <a href="https://github.com/rhymix/rhymix/pull/1482" target="_blank">여기</a>를 참고하세요.<dl><dt>사용 안 함 (기본)</dt><dd>다크모드 설정을 사용하지 않습니다.</dd><dt>어두운 색상 (고정)</dt><dd>항상 다크모드의 어두운 색상을 표시합니다.</dd><dt>자동 (접속자의 브라우저 설정)</dt><dd>사이트 접속자의 운영체제 또는 브라우저 설정을 따릅니다.</dd><dt>수동 (쿠키 활용)</dt><dd>접속자가 별도의 클릭을 하여 설정하도록 합니다. 쿠키는 자동, 밝음, 어두움 세 가지 선택지를 가집니다.</dd></dl> ';
+$lang->site_default_color_scheme_options = array(
+		'off_light' => '사용 안 함 (기본)',
+		'off_dark' => '어두운 색상 (고정)',
+		'auto_light_dark' => '자동 (접속자의 브라우저 설정)',
+		'client_manual' => '수동 (쿠키 활용)'
+	);
 $lang->use_sso = '<abbr title="Single Sign On">SSO</abbr> 사용';
 $lang->about_use_sso = '한 번만 로그인하면 모든 도메인에 로그인되도록 합니다.';
 $lang->about_arrange_session = '세션을 정리하시겠습니까?';

--- a/modules/admin/lang/ko.php
+++ b/modules/admin/lang/ko.php
@@ -296,12 +296,11 @@ $lang->detail_use_mobile_icon = '57x57 또는 114x114 크기의 png 파일을 �
 $lang->cmd_site_default_image = '사이트 대표 이미지';
 $lang->about_site_default_image = 'SNS 등에 이 사이트가 링크되었을 때 표시되는 이미지입니다. 200x200 크기의 jpg 또는 png 파일을 권장합니다.';
 $lang->cmd_site_default_color_scheme = '사이트 색상 조합';
-$lang->about_site_default_color_scheme = '다크모드를 사용하도록 설정할 수 있습니다. 사용하는 모듈 스킨, 레이아웃 등이 지원해야 합니다. 표준은 <a href="https://github.com/rhymix/rhymix/pull/1482" target="_blank">여기</a>를 참고하세요.<dl><dt>사용 안 함 (기본)</dt><dd>다크모드 설정을 사용하지 않습니다.</dd><dt>어두운 색상 (고정)</dt><dd>항상 다크모드의 어두운 색상을 표시합니다.</dd><dt>자동 (접속자의 브라우저 설정)</dt><dd>사이트 접속자의 운영체제 또는 브라우저 설정을 따릅니다.</dd><dt>수동 (쿠키 활용)</dt><dd>접속자가 별도의 클릭을 하여 설정하도록 합니다. 쿠키는 자동, 밝음, 어두움 세 가지 선택지를 가집니다.</dd></dl> ';
+$lang->about_site_default_color_scheme = '다크모드를 사용하도록 설정할 수 있습니다. 사용하는 모듈 스킨, 레이아웃 등이 지원해야 합니다. 표준은 <a href="https://github.com/rhymix/rhymix/pull/1482" target="_blank">여기</a>를 참고하세요.<dl><dt>사용 안 함 (기본)</dt><dd>다크모드 설정을 사용하지 않습니다.</dd><dt>어두운 색상 (고정)</dt><dd>항상 다크모드의 어두운 색상을 표시합니다.</dd><dt>자동 (접속자의 브라우저 설정)</dt><dd>사이트 접속자의 운영체제 또는 브라우저 설정 또는 쿠키의 설정을 따릅니다. 쿠키는 자동, 밝음, 어두움 세 가지 선택지를 가집니다.</dd></dl> ';
 $lang->site_default_color_scheme_options = array(
 		'off_light' => '사용 안 함 (기본)',
 		'off_dark' => '어두운 색상 (고정)',
-		'auto_light_dark' => '자동 (접속자의 브라우저 설정)',
-		'client_manual' => '수동 (쿠키 활용)'
+		'auto_light_dark' => '자동 (접속자의 설정)',
 	);
 $lang->use_sso = '<abbr title="Single Sign On">SSO</abbr> 사용';
 $lang->about_use_sso = '한 번만 로그인하면 모든 도메인에 로그인되도록 합니다.';

--- a/modules/admin/tpl/config_domains_edit.html
+++ b/modules/admin/tpl/config_domains_edit.html
@@ -167,6 +167,18 @@
 			</div>
 		</div>
 		
+		<div class="x_control-group">
+			<label class="x_control-label" for="color_scheme">{lang('admin.cmd_site_default_color_scheme')}</label>
+			<div class="x_controls">
+				<select id="color_scheme" name="color_scheme">
+					<!--@foreach(lang('admin.site_default_color_scheme_options') as $color_scheme_key => $color_scheme_val)-->
+						<option value="{$color_scheme_key}" selected="selected"|cond="$color_scheme === $color_scheme_key">{$color_scheme_val}</option>
+					<!--@end-->
+				</select>
+				<div class="x_help-block">{lang('admin.about_site_default_color_scheme')}</div>
+			</div>
+		</div>
+		
 		<div class="x_clearfix btnArea">
 			<div class="x_pull-right">
 				<button type="submit" class="x_btn x_btn-primary">{$lang->cmd_save}</button>

--- a/modules/module/module.model.php
+++ b/modules/module/module.model.php
@@ -155,7 +155,7 @@ class moduleModel extends module
 				$domain_info = $output->data;
 				$domain_info->site_srl = 0;
 				$domain_info->settings = $domain_info->settings ? json_decode($domain_info->settings) : new stdClass;
-				if(!isset($domain_info->settings->color_scheme) $domain_info->settings->color_scheme = 'off_light';
+				if(!isset($domain_info->settings->color_scheme)) $domain_info->settings->color_scheme = 'off_light';
 				$domain_info->default_language = $domain_info->settings->language ?: config('locale.default_lang');
 				Rhymix\Framework\Cache::set('site_and_module:domain_info:domain:' . $domain, $domain_info, 0, true);
 			}

--- a/modules/module/module.model.php
+++ b/modules/module/module.model.php
@@ -155,6 +155,7 @@ class moduleModel extends module
 				$domain_info = $output->data;
 				$domain_info->site_srl = 0;
 				$domain_info->settings = $domain_info->settings ? json_decode($domain_info->settings) : new stdClass;
+				if(!isset($domain_info->settings->color_scheme) $domain_info->settings->color_scheme = 'off_light';
 				$domain_info->default_language = $domain_info->settings->language ?: config('locale.default_lang');
 				Rhymix\Framework\Cache::set('site_and_module:domain_info:domain:' . $domain, $domain_info, 0, true);
 			}


### PR DESCRIPTION
https://github.com/rhymix/rhymix/pull/1482 에서 추가된 다크모드는 하나의 표준을 정했다는 면에서 대단히 의미 있는 일이었다 생각합니다. 레이아웃이나 스킨이 `body` 클래스만 참고하더라도 다크모드 적용 여부를 판단할 수 있습니다.
다만, 이 기능을 아예 끄는 옵션을 제공하지 않았었기 때문에 모듈마다 설정을 추가해야하는 문제가 있었습니다.
모듈마다 설정을 추가하는 것도 방법이지만, 도메인에 대한 전역 설정을 한 항목 추가하여 각 모듈 스킨 개발자가 모듈에서 지원하기 이전에도 다크모드를 편리하게 지원하도록 합니다.

*다크모드 표준은 변경되지 않습니다.* 사이트 관리자에게 편의 기능을 제공할 뿐입니다.

표준은 <a href="https://github.com/rhymix/rhymix/pull/1482" target="_blank">여기</a>를 참고하세요.<dl><dt>사용 안 함 (기본)</dt><dd>다크모드 설정을 사용하지 않습니다.</dd><dt>어두운 색상 (고정)</dt><dd>항상 다크모드의 어두운 색상을 표시합니다.</dd><dt>자동 (접속자의 브라우저 설정)</dt><dd>사이트 접속자의 운영체제 또는 브라우저 설정 또는 쿠키의 설정을 따릅니다. 쿠키는 자동, 밝음, 어두움 세 가지 선택지를 가집니다.</dd></dl>

기본 값은 이전 상태와 동일하도록 다크모드를 꺼둔 상태입니다.
사이트를 구성하는 대부분의 스킨이나 레이아웃이 다크모드를 지원하기 전에, "사용안함"을 선택했다가 구성이 완료되면 `어두운 색상`, `자동`, `수동` 등 세 가지 옵션 중 하나를 선택할 수 있습니다.

https://github.com/rhymix/rhymix/issues/1556 와 같이 일부 모듈 스킨은 다크모드를 지원하고, 일부 모듈 스킨은 다크모드를 지원하지 않아서 일어나는 문제를 미연에 방지할 수 있습니다.

|           옵션                           | `color_scheme_light` | `color_scheme_dark` |
|------------------------------|----------------------|----------------------|
|사용 안 함 (기본)                    |             O                 |                 X              |
|어두운 색상 (고정)                  |             X                 |                 O             |
|자동 (접속자의 설정)              |             O               |                   O           |


