### PR TITLE
알림센터 index hint로 인한 쿼리 성능 저하 문제

### DIFF
--- a/modules/ncenterlite/ncenterlite.class.php
+++ b/modules/ncenterlite/ncenterlite.class.php
@@ -70,7 +70,7 @@ class ncenterlite extends ModuleObject
 				return true;
 			}
 		}
-		foreach(['idx_srl', 'idx_member_srl', 'idx_regdate', 'idx_readed', 'idx_target_srl', 'idx_target_p_srl', 'idx_target_member_srl', 'idx_member_srl_and_readed'] as $index_name)
+		foreach(['idx_srl', 'idx_member_srl', 'idx_regdate', 'idx_readed', 'idx_target_srl', 'idx_target_p_srl', 'idx_target_member_srl'] as $index_name)
 		{
 			if(!$oDB->isIndexExists('ncenterlite_notify', $index_name))
 			{
@@ -187,12 +187,6 @@ class ncenterlite extends ModuleObject
 				}
 			}
 			$prev_type = $type;
-		}
-		
-		// Composite index to speed up getNotifyList
-		if(!$oDB->isIndexExists('ncenterlite_notify', 'idx_member_srl_and_readed'))
-		{
-			$oDB->addIndex('ncenterlite_notify', 'idx_member_srl_and_readed', array('member_srl', 'readed'));
 		}
 
 		// PK duplicate

--- a/modules/ncenterlite/queries/getNotifyList.xml
+++ b/modules/ncenterlite/queries/getNotifyList.xml
@@ -2,9 +2,6 @@
 	<tables>
 		<table name="ncenterlite_notify" />
 	</tables>
-	<index_hint for="ALL">
-		<index table="ncenterlite_notify" name="idx_member_srl_and_readed" type="USE" />
-	</index_hint>
 	<columns>
 		<column name="*" />
 	</columns>

--- a/modules/ncenterlite/queries/getNotifyNewCount.xml
+++ b/modules/ncenterlite/queries/getNotifyNewCount.xml
@@ -2,9 +2,6 @@
 	<tables>
 		<table name="ncenterlite_notify" />
 	</tables>
-	<index_hint for="ALL">
-		<index table="ncenterlite_notify" name="idx_member_srl_and_readed" type="USE" />
-	</index_hint>
 	<columns>
 		<column name="count(*)" alias="cnt" />
 	</columns>


### PR DESCRIPTION
## 현상

현재 운영중인 사이트에서 12월 중순부터 갑자기 이용자들이 크게 체감할 수 있을 정도로, 사이트 전체에 걸쳐 상당한 성능 저하가 발생하였습니다. DB 병목 및 부하로 인한 문제였고, 여러가지 최적화를 시도하였으나 완전히 해결되지 않았습니다.

그러다가 최근 성능 저하가 발생한 시점들을 전후로 slow query를 확인해본 결과 결정적인 원인을 찾았는데, 바로 **알림센터 Lite** 모듈 때문에 발생하는 문제였습니다.

일부 회원들이 "알림 개수 모으기"를 하면서 몇개월간 알림 개수를 쌓은 것이 문제를 일으켰습니다. 알림을 고의적으로 몇개월간 확인하지 않으면서 확인하지 않은 알림이 수만개 이상 쌓였고 (특히 어떤 회원은 **혼자 3만개 이상 모은 경우**도 있었습니다) 알림을 가져오는 쿼리가 오래 걸리면서 발생한 이슈였습니다.

특히 알림센터는 모든 페이지에서 알림 갯수를 표시하기 때문에 전체적으로 성능 저하를 유발했습니다.


## 원인 분석

```SQL
SELECT *  FROM `xe_ncenterlite_notify` AS `ncenterlite_notify` USE INDEX (`idx_member_srl_and_readed`)    WHERE `member_srl` = 3684341 AND `readed` = 'N'   ORDER BY `regdate` DESC  LIMIT 0, 5;
```

이 쿼리가 8초 가까이 걸리는 경우도 있었습니다. `idx_member_srl_and_readed`의 경우 `member_srl`와 `readed`의 조합이기 때문에 특정 회원의 읽지 않은 알림 수가 크게 늘어나게 되면 좋은 성능을 발휘하기 어렵습니다.

`USE INDEX` 로 특정 인덱스 사용을 강제하면, 경우에 따라 좋은 쿼리 성능을 보여줄 수 있지만 자칫하면 오히려 문제를 일으킬 수 있습니다. 특히 dynamic하게 `WHERE` 절 조건이 바뀌는 상황에서 사용하면 굉장히 불안정한 요소가 될 수 있으며, 다양한 (특이한) 상황에 대응하기 어렵게 됩니다.


## 해결책

`USE INDEX`를 제거하고 MySQL 옵티마이저에게 인덱스 선택을 위임하여 해결하였습니다. 현재 저희 사이트에서는 `USE INDEX` 옵션을 제거하고 운영 중입니다.

이를 통해 아래와 같이 알림 수가 수만 개에 달하는 경우에도 쿼리 타임이 5.38초에서 0.01초 미만으로 극적으로 개선되었음을 확인할 수 있습니다. (여러 번의 측정을 통해 평균을 낸 것은 아니므로 성능 개선폭은 차이가 있을 수 있습니다.)

![인덱스 힌트 제거 전후 성능 비교](https://user-images.githubusercontent.com/19200664/104193448-78327400-5463-11eb-9d38-4664d9963c46.png)

https://github.com/rhymix/rhymix/commit/d6428bb71d93729c589cb822beb7dd38b1659b64 커밋에서 인덱스 힌트를 추가하신 이유가 있을 테니 단순히 이를 제거하는 PR을 작성하기는 조심스럽습니다만, 저희는 이 방법을 통해 성능 이슈를 해결했습니다. 인덱스 힌트에 대한 재검토 또는 다른 방법으로 개선이 필요해 보입니다.