### PR TITLE
Fix count() error

### DIFF
--- a/common/framework/parsers/dbquery/query.php
+++ b/common/framework/parsers/dbquery/query.php
@@ -150,7 +150,20 @@ class Query extends VariableBase
 					$columns[] = self::quoteName($column->name) . ($column->alias ? (' AS ' . self::quoteName($column->alias)) : '');
 				}
 			}
-			$column_list = implode(', ', $columns);
+			if ($count_only && $has_subquery_columns)
+			{
+				$column_list = implode(', ', array_map(function($str) {
+					if ($str === '*' || preg_match('/\\.\\*/', $str))
+					{
+						return '1';
+					}
+					return $str; 
+				}, $columns));
+			}
+			else
+			{
+				$column_list = implode(', ', $columns);
+			}
 		}
 		
 		// Replace the column list if this is a count-only query.


### PR DESCRIPTION
파라미터 변수를 사용하는 서브쿼리 컬럼이 있는 쿼리를 count() 처리할 때 오류가 있습니다.
컬럼은 count만 존재하지만 _params 에는 서브쿼리내에서 사용된 파라미터 추가되어 있어 쿼리 처리시에 파라미터가 일치하지 않게 됩니다.

이 문제를 수정한 패치입니다.