### PR TITLE
Fix #1579 remove unnecessary $is_admin set

### DIFF
--- a/modules/document/document.view.php
+++ b/modules/document/document.view.php
@@ -96,7 +96,7 @@ class documentView extends document
 
 		if(count($document_srl_list))
 		{
-			$document_list = DocumentModel::getDocuments($document_srl_list, $this->grant->is_admin);
+			$document_list = DocumentModel::getDocuments($document_srl_list);
 			Context::set('document_list', $document_list);
 		}
 		else


### PR DESCRIPTION
불필요하게 $is_admin을 지정한 부분을 삭제합니다.