### PR TITLE
서명, 프로필 사진 등 일부 회원가입 항목들의 이름 변경 지원

### DIFF
--- a/modules/member/member.admin.controller.php
+++ b/modules/member/member.admin.controller.php
@@ -425,7 +425,20 @@ class memberAdminController extends member
 			$signupItem->isIdentifier = ($key == $config->identifier || in_array($key, $config->identifiers ?: []));
 			$signupItem->isDefaultForm = in_array($key, $items);
 			$signupItem->name = $key;
-			$signupItem->title = (!in_array($key, $items)) ? $key : $lang->{$key};
+			if (isset($all_args->{$key . '_title_edit'}) && $all_args->{$key . '_title_edit'} && $all_args->{$key . '_title_edit'} !== $lang->{$key})
+			{
+				$signupItem->isCustomTitle = true;
+				$signupItem->title = $all_args->{$key . '_title_edit'};
+				if (!preg_match('/^\\$user_lang->[a-z0-9_]+$/i', $signupItem->title))
+				{
+					$signupItem->title = escape($signupItem->title);
+				}
+			}
+			else
+			{
+				$signupItem->isCustomTitle = false;
+				$signupItem->title = (!in_array($key, $items)) ? $key : $lang->{$key};
+			}
 			$signupItem->mustRequired = in_array($key, $mustRequireds);
 			$signupItem->imageType = (strpos($key, 'image') !== false);
 			$signupItem->required = ($all_args->{$key} == 'required') || $signupItem->mustRequired;
@@ -465,12 +478,7 @@ class memberAdminController extends member
 			$signupForm[$key] = $signupItem;
 		}
 		$args->signupForm = array_values($signupForm);
-
-		// create Ruleset
-		$this->_createSignupRuleset($signupForm);
-		$this->_createLoginRuleset($args->identifier);
-
-		$output = $oModuleController->updateModuleConfig('member', $args);
+		$oModuleController->updateModuleConfig('member', $args);
 
 		// default setting end
 		$this->setMessage('success_updated');

--- a/modules/member/member.admin.view.php
+++ b/modules/member/member.admin.view.php
@@ -524,7 +524,7 @@ class memberAdminView extends member
 			
 			$formTag = new stdClass();
 			$inputTag = '';
-			$formTag->title = ($formInfo->isDefaultForm) ? $lang->{$formInfo->name} : $formInfo->title;
+			$formTag->title = $formInfo->title;
 			if($isAdmin)
 			{
 				if($formInfo->mustRequired || $formInfo->required) $formTag->title = '<em style="color:red">*</em> '.$formTag->title;

--- a/modules/member/member.model.php
+++ b/modules/member/member.model.php
@@ -45,7 +45,10 @@ class memberModel extends member
 		//for multi language
 		foreach($config->signupForm AS $key=>$value)
 		{
-			$config->signupForm[$key]->title = ($value->isDefaultForm ?? false) ? lang($value->name) : $value->title;
+			if(!isset($value->isCustomTitle) || !$value->isCustomTitle)
+			{
+				$config->signupForm[$key]->title = ($value->isDefaultForm ?? false) ? lang($value->name) : $value->title;
+			}
 			if($config->signupForm[$key]->isPublic != 'N') $config->signupForm[$key]->isPublic = 'Y';
 			if($value->name == 'find_account_question') $config->signupForm[$key]->isPublic = 'N';
 		}

--- a/modules/member/member.view.php
+++ b/modules/member/member.view.php
@@ -123,7 +123,7 @@ class memberView extends member
 
 			if($formInfo->isDefaultForm)
 			{
-				$item->title = lang($formInfo->name);
+				$item->title = $formInfo->title;
 				$item->value = $memberInfo->{$formInfo->name};
 
 				if($formInfo->name == 'profile_image' && $memberInfo->profile_image)

--- a/modules/member/tpl/member_info.html
+++ b/modules/member/tpl/member_info.html
@@ -3,7 +3,7 @@
 </div>
 <table class="x_table x_table-striped x_table-hover">
 	<tr loop="$displayDatas => $item">
-		<th scope="row" ><em style="color:red" cond="$item->required || $item->mustRequired">*</em> {$item->title}</th>
+		<th scope="row" >{$item->title} <em style="color:red" cond="$item->required || $item->mustRequired">*</em></th>
 		<td class="text">{$item->value}</td>
 	</tr>
 	<tr>

--- a/modules/member/tpl/signup_config.html
+++ b/modules/member/tpl/signup_config.html
@@ -113,7 +113,11 @@
 						<th scope="row">
 							<div class="wrap">
 								<button type="button" class="dragBtn">Move to</button>
-								<span class="_title" style="display:inline-block;white-space:pre-line;overflow:inherit;width:120px;text-overflow:ellipsis" title="{$item->title}">{$item->title}</span>
+								<!--@if(in_array($item->name, ['birthday', 'signature', 'profile_image', 'image_name', 'image_mark']))-->
+									<input class="_title_edit lang_code" type="text" name="{$item->name}_title_edit" value="{$item->title}" placeholder="{lang($item->name)}" />
+								<!--@else-->
+									<span class="_title" style="display:inline-block;white-space:pre-line;overflow:inherit;width:120px;text-overflow:ellipsis" title="{$item->title}">{$item->title}</span>
+								<!--@endif-->
 							</div>
 						</th>
 						<td style="text-align:center">


### PR DESCRIPTION
확장변수가 아니어서 이름 변경이 곤란했던 회원가입 기본 항목들 중, 변경이 비교적 수월한 아래 5가지 항목의 이름을 변경할 수 있도록 허용합니다. 다국어도 지원됩니다.

- 서명 (예: "자기소개" 등으로 변경 가능) #1577
- 생일 (예: "생년월일", "구입일", "면허취득일" 등으로 변경 가능)
- 프로필 사진
- 이미지 이름
- 이미지 마크

워낙 오랫동안 기본 항목으로 고정되어 있었기 때문에, 서드파티 스킨이나 회원 관련 기능을 제공하는 서드파티 자료 등에는 적용되지 않을 수도 있습니다.

아이디, 이메일 주소 등 좀더 기본적인 항목들은 회원가입폼 외에도 여기저기에서 같은 단어가 많이 사용되기 때문에 일관성있게 변경하기가 더욱 어려울 것으로 판단하여 그대로 두었습니다.