### PR TITLE
중복 선언된 insertSelectedModule 함수 제거

### DIFF
--- a/modules/document/tpl/js/document_admin.js
+++ b/modules/document/tpl/js/document_admin.js
@@ -46,12 +46,6 @@ function completeCancelDeclare(ret_obj) {
     location.reload();
 }
 
-function insertSelectedModule(id, module_srl, mid, browser_title) {
-    jQuery('#_'+id).val(browser_title+' ('+mid+')');
-    jQuery('#'+id).val(module_srl);
-    doGetCategoryFromModule(module_srl);
-}
-
 function completeInsertExtraVar(ret_obj) {
     // alert(ret_obj['message']);
     location.href = current_url.setQuery('type','').setQuery('selected_var_idx','');


### PR DESCRIPTION
`modules/document/tpl/js/document_admin.js`에 중복 선언된 `insertSelectedModule` 함수를 정리합니다.
2번 중복 선언되어 앞의 선언은 무시되고 있었으므로 유지보수성 개선을 위해 뒤의 선언만 남기고 삭제하였습니다.