### PR TITLE
Resolve #1595 - 게시물 관리 사용 시 게시판이 기본 선택되도록 개선

### DIFF
--- a/modules/board/skins/default/list.html
+++ b/modules/board/skins/default/list.html
@@ -132,7 +132,7 @@
 	</div>
 	<div class="btnArea">
 		<a href="{getUrl('act','dispBoardWrite','document_srl','')}" class="btn">{$lang->cmd_write}</a>
-		<a cond="$grant->manager" href="{getUrl('','module','document','act','dispDocumentManageDocument','module_srl',$mi->module_srl)}" class="btn" onclick="popopen(this.href,'manageDocument'); return false;">{$lang->cmd_manage_document}</a>
+		<a cond="$grant->manager" href="{getUrl('','module','document','act','dispDocumentManageDocument','target_mid',$mid)}" class="btn" onclick="popopen(this.href,'manageDocument'); return false;">{$lang->cmd_manage_document}</a>
 	</div>
 	<button type="button" class="bsToggle" title="{$lang->cmd_search}">{$lang->cmd_search}</button>
 	<form cond="$grant->view" action="{getUrl()}" method="get" onsubmit="return procFilter(this, search)" id="board_search" class="board_search" no-error-return-url="true">

--- a/modules/board/skins/default/list.html
+++ b/modules/board/skins/default/list.html
@@ -132,7 +132,7 @@
 	</div>
 	<div class="btnArea">
 		<a href="{getUrl('act','dispBoardWrite','document_srl','')}" class="btn">{$lang->cmd_write}</a>
-		<a cond="$grant->manager" href="{getUrl('','module','document','act','dispDocumentManageDocument','target_mid',$mid)}" class="btn" onclick="popopen(this.href,'manageDocument'); return false;">{$lang->cmd_manage_document}</a>
+		<a cond="$grant->manager" href="{getUrl('','mid',$mid,'act','dispDocumentManageDocument')}" class="btn" onclick="popopen(this.href,'manageDocument'); return false;">{$lang->cmd_manage_document}</a>
 	</div>
 	<button type="button" class="bsToggle" title="{$lang->cmd_search}">{$lang->cmd_search}</button>
 	<form cond="$grant->view" action="{getUrl()}" method="get" onsubmit="return procFilter(this, search)" id="board_search" class="board_search" no-error-return-url="true">

--- a/modules/board/skins/default/list.html
+++ b/modules/board/skins/default/list.html
@@ -132,7 +132,7 @@
 	</div>
 	<div class="btnArea">
 		<a href="{getUrl('act','dispBoardWrite','document_srl','')}" class="btn">{$lang->cmd_write}</a>
-		<a cond="$grant->manager" href="{getUrl('','module','document','act','dispDocumentManageDocument')}" class="btn" onclick="popopen(this.href,'manageDocument'); return false;">{$lang->cmd_manage_document}</a>
+		<a cond="$grant->manager" href="{getUrl('','module','document','act','dispDocumentManageDocument','module_srl',$mi->module_srl)}" class="btn" onclick="popopen(this.href,'manageDocument'); return false;">{$lang->cmd_manage_document}</a>
 	</div>
 	<button type="button" class="bsToggle" title="{$lang->cmd_search}">{$lang->cmd_search}</button>
 	<form cond="$grant->view" action="{getUrl()}" method="get" onsubmit="return procFilter(this, search)" id="board_search" class="board_search" no-error-return-url="true">

--- a/modules/board/skins/xedition/list.html
+++ b/modules/board/skins/xedition/list.html
@@ -136,7 +136,7 @@
 		<a href="{getUrl('act','dispBoardWrite','document_srl','')}" class="btn"><i class="xi-pen"></i> {$lang->cmd_write}</a>
 		<a href="{getUrl('act','dispBoardTagList')}" class="btn" title="{$lang->tag}"><i class="xi-tag"></i> {$lang->tag}</a>
 		<a cond="$grant->manager" class="btn" href="{getUrl('act','dispBoardAdminBoardInfo')}" title="{$lang->cmd_setup}"><i class="xi-cog"></i> {$lang->cmd_setup}</a>			
-		<a cond="$grant->manager" href="{getUrl('','module','document','act','dispDocumentManageDocument','module_srl',$mi->module_srl)}" class="btn" onclick="popopen(this.href,'manageDocument'); return false;">{$lang->cmd_manage_document}</a>
+		<a cond="$grant->manager" href="{getUrl('','module','document','act','dispDocumentManageDocument','target_mid',$mid)}" class="btn" onclick="popopen(this.href,'manageDocument'); return false;">{$lang->cmd_manage_document}</a>
 	</div>
 
 	<form cond="$grant->view" action="{getUrl()}" method="get" onsubmit="return procFilter(this, search)" id="board_search" class="board_search" no-error-return-url="true">

--- a/modules/board/skins/xedition/list.html
+++ b/modules/board/skins/xedition/list.html
@@ -136,7 +136,7 @@
 		<a href="{getUrl('act','dispBoardWrite','document_srl','')}" class="btn"><i class="xi-pen"></i> {$lang->cmd_write}</a>
 		<a href="{getUrl('act','dispBoardTagList')}" class="btn" title="{$lang->tag}"><i class="xi-tag"></i> {$lang->tag}</a>
 		<a cond="$grant->manager" class="btn" href="{getUrl('act','dispBoardAdminBoardInfo')}" title="{$lang->cmd_setup}"><i class="xi-cog"></i> {$lang->cmd_setup}</a>			
-		<a cond="$grant->manager" href="{getUrl('','module','document','act','dispDocumentManageDocument','target_mid',$mid)}" class="btn" onclick="popopen(this.href,'manageDocument'); return false;">{$lang->cmd_manage_document}</a>
+		<a cond="$grant->manager" href="{getUrl('','mid',$mid,'act','dispDocumentManageDocument')}" class="btn" onclick="popopen(this.href,'manageDocument'); return false;">{$lang->cmd_manage_document}</a>
 	</div>
 
 	<form cond="$grant->view" action="{getUrl()}" method="get" onsubmit="return procFilter(this, search)" id="board_search" class="board_search" no-error-return-url="true">

--- a/modules/board/skins/xedition/list.html
+++ b/modules/board/skins/xedition/list.html
@@ -136,7 +136,7 @@
 		<a href="{getUrl('act','dispBoardWrite','document_srl','')}" class="btn"><i class="xi-pen"></i> {$lang->cmd_write}</a>
 		<a href="{getUrl('act','dispBoardTagList')}" class="btn" title="{$lang->tag}"><i class="xi-tag"></i> {$lang->tag}</a>
 		<a cond="$grant->manager" class="btn" href="{getUrl('act','dispBoardAdminBoardInfo')}" title="{$lang->cmd_setup}"><i class="xi-cog"></i> {$lang->cmd_setup}</a>			
-		<a cond="$grant->manager" href="{getUrl('','module','document','act','dispDocumentManageDocument')}" class="btn" onclick="popopen(this.href,'manageDocument'); return false;">{$lang->cmd_manage_document}</a>
+		<a cond="$grant->manager" href="{getUrl('','module','document','act','dispDocumentManageDocument','module_srl',$mi->module_srl)}" class="btn" onclick="popopen(this.href,'manageDocument'); return false;">{$lang->cmd_manage_document}</a>
 	</div>
 
 	<form cond="$grant->view" action="{getUrl()}" method="get" onsubmit="return procFilter(this, search)" id="board_search" class="board_search" no-error-return-url="true">

--- a/modules/document/document.view.php
+++ b/modules/document/document.view.php
@@ -104,9 +104,40 @@ class documentView extends document
 			Context::set('document_list', array());
 		}
 
+		// Set target module info
+		$target_mid = Context::get('target_mid');
 		$module_srl = intval(Context::get('module_srl'));
+
+		if(!is_null($target_mid)) {
+			// if target_mid is provided
+			$module_info = ModuleModel::getModuleInfoByMid($target_mid);
+			if(!is_bool($module_info)) {
+				$module_srl = $module_info->module_srl;
+			}
+		}
+		else if($module_srl > 0) {
+			// if module_srl is provided instead of target_mid (legacy)
+			$module_info = ModuleModel::getModuleInfoByModuleSrl($module_srl);
+		}
+		else
+		{
+			// if no module info is provided
+			$document_module_srl_list = array();
+			foreach($document_list as $key => $val) {
+				$document_module_srl = $val->variables['module_srl'];
+				if(!in_array($document_module_srl, $document_module_srl_list))
+				{
+					array_push($document_module_srl_list, $document_module_srl);
+				}
+			}
+			if(count($document_module_srl_list) == 1)
+			{
+				// set module_srl if all documents has one common module_srl
+				$module_srl = $document_module_srl;
+			}
+			$module_info = ModuleModel::getModuleInfoByModuleSrl($module_srl);
+		}
 		Context::set('module_srl',$module_srl);
-		$module_info = ModuleModel::getModuleInfoByModuleSrl($module_srl);
 		Context::set('mid',$module_info->mid);
 		Context::set('browser_title',$module_info->browser_title);
 

--- a/modules/document/document.view.php
+++ b/modules/document/document.view.php
@@ -111,7 +111,7 @@ class documentView extends document
 		if(!is_null($target_mid)) {
 			// if target_mid is provided
 			$module_info = ModuleModel::getModuleInfoByMid($target_mid);
-			if(!is_bool($module_info)) {
+			if(!is_null($module_info)) {
 				$module_srl = $module_info->module_srl;
 			}
 		}

--- a/modules/document/tpl/checked_list.html
+++ b/modules/document/tpl/checked_list.html
@@ -71,5 +71,8 @@ jQuery(function($){
 			message_content_area.prop("disabled", false);
 		}
 	});
+	<!--@if($module_srl > 0)-->
+	doGetCategoryFromModule({$module_srl});
+	<!--@end-->
 });
 </script>


### PR DESCRIPTION
게시물 관리 팝업 화면인 `document` 모듈의 `dispDocumentMangeDocument`는 `module_srl` 값을 넘겨주는 경우, 대상 모듈을 이 값을 기준으로 표시하도록 이미 구현이 되어 있었습니다. 그러나 스킨단에서 `module_srl` 값을 넘겨주지 않아 #1595 이슈에서와 같이 게시판이 기본 선택되지 않았습니다.

따라서 Rhymix 설치 시 기본적으로 제공되는 XE Default 스킨과 XEDITION 스킨에서 게시물 관리 팝업을 띄울 때 `module_srl` 값을 넘기도록 개선하여 카테고리만 변경하는 경우에는 게시판을 선택할 필요가 없도록 하였습니다.

다만, `module_srl` 값만 넘겨주면 해당 게시판의 카테고리를 표시해주지 못하는 문제가 있어, `module_srl` 값이 0보다 큰 경우 (NULL인 경우 0이며, module_srl 값은 음수일 수 없으므로) JavaScript로 카테고리를 로딩해주도록 하였습니다.