### PR TITLE
PHP8에서 session.auto_start 체크가 안되는 경우

### DIFF
--- a/modules/install/install.controller.php
+++ b/modules/install/install.controller.php
@@ -320,9 +320,9 @@ class installController extends install
 		$license_agreement_time = intval(trim(FileHandler::readFile($this->flagLicenseAgreement)));
 		if(isset($_SESSION['license_agreement']) && (!$license_agreement_time || ($license_agreement_time == $_SESSION['license_agreement'])))
 		{
-			$sess_autostart = ini_get('session.auto_start');
+			$sess_autostart = intval(ini_get('session.auto_start'));
 			
-			if($sess_autostart === 0 || $sess_autostart === "")
+			if($sess_autostart === 0)
 			{
 				$checklist['session'] = true;
 			}

--- a/modules/install/install.controller.php
+++ b/modules/install/install.controller.php
@@ -320,7 +320,9 @@ class installController extends install
 		$license_agreement_time = intval(trim(FileHandler::readFile($this->flagLicenseAgreement)));
 		if(isset($_SESSION['license_agreement']) && (!$license_agreement_time || ($license_agreement_time == $_SESSION['license_agreement'])))
 		{
-			if(ini_get('session.auto_start') == 0)
+			$sess_autostart = ini_get('session.auto_start');
+			
+			if($sess_autostart === 0 || $sess_autostart === "")
 			{
 				$checklist['session'] = true;
 			}


### PR DESCRIPTION
#1667 이슈 관련하여 PR 드립니다.

`session.auto_start` 가 `Off` 인 경우 `ini_get` 시 string 타입의 `""` 로 eval되는데, PHP8 부터는 `""` 와 `0`  사이의 `==` 연산이 `False`가 되도록 바뀌었습니다. [관련 자료](https://www.php.net/manual/en/migration80.incompatible.php)

따라서 단순히 0과 비교하는 것이 아닌 설정값을 intval을 이용하여 int로 변환한 뒤 0과 strict하게 체크하는 것으로 변경하였으니 확인 부탁드립니다.

감사합니다.