### PR TITLE
소셜 로그인에서 생성하는 임의 비밀번호 개선

### DIFF
--- a/modules/sociallogin/sociallogin.controller.php
+++ b/modules/sociallogin/sociallogin.controller.php
@@ -468,7 +468,7 @@ class SocialloginController extends Sociallogin
 		// 회원 가입 진행
 		if (!$member_srl)
 		{
-			$password = cut_str(md5(date('YmdHis')), 13, '');
+			$password = Rhymix\Framework\Password::getRandomPassword(13);
 			$nick_name = preg_replace('/[\pZ\pC]+/u', '', $serviceAccessData->profile['user_name']);
 
 			if ($oMemberModel->getMemberSrlByNickName($nick_name))
@@ -896,7 +896,7 @@ class SocialloginController extends Sociallogin
 
 		unset($args->user_id);
 
-		$args->password = $args->password2 = cut_str(md5(date('YmdHis')), 13, '');
+		$args->password = $args->password2 = Rhymix\Framework\Password::getRandomPassword(13);
 		
 		return $args;
 	}


### PR DESCRIPTION
기존 방식인 md5 + 13자리 자르기의 경우 비밀번호 수준 높음 기준(특문 포함)을 통과하지 못하는데 이를 라이믹스 내장 임의 비밀번호 생성기를 사용함으로 개선합니다.