### PR TITLE
모바일 뷰 사용 옵션이 꺼져있을 때 모바일 위젯 페이지가 뜨는 현상 수정

### DIFF
--- a/classes/module/ModuleHandler.class.php
+++ b/classes/module/ModuleHandler.class.php
@@ -407,7 +407,7 @@ class ModuleHandler extends Handler
 				return self::_createErrorMessage(-1, 'msg_module_class_not_found', 404);
 			}
 		}
-		elseif($type == "view" && $this->is_mobile && Context::isInstalled())
+		elseif($type == "view" && Mobile::isFromMobilePhone() && Context::isInstalled())
 		{
 			$orig_type = "view";
 			$type = "mobile";

--- a/classes/module/ModuleHandler.class.php
+++ b/classes/module/ModuleHandler.class.php
@@ -390,6 +390,7 @@ class ModuleHandler extends Handler
 		if($this->module_info->use_mobile !== 'Y')
 		{
 			Mobile::setMobile(FALSE);
+			$this->is_mobile = Mobile::isFromMobilePhone();
 		}
 
 		$logged_info = Context::get('logged_info');
@@ -407,7 +408,7 @@ class ModuleHandler extends Handler
 				return self::_createErrorMessage(-1, 'msg_module_class_not_found', 404);
 			}
 		}
-		elseif($type == "view" && Mobile::isFromMobilePhone() && Context::isInstalled())
+		elseif($type == "view" && $this->is_mobile && Context::isInstalled())
 		{
 			$orig_type = "view";
 			$type = "mobile";
@@ -416,6 +417,7 @@ class ModuleHandler extends Handler
 			{
 				$type = $orig_type;
 				Mobile::setMobile(FALSE);
+				$this->is_mobile = Mobile::isFromMobilePhone();
 				$oModule = self::getModuleInstance($this->module, $type, $kind);
 			}
 		}
@@ -533,6 +535,7 @@ class ModuleHandler extends Handler
 					{
 						$type = $orig_type;
 						Mobile::setMobile(FALSE);
+						$this->is_mobile = Mobile::isFromMobilePhone();
 						$oModule = self::getModuleInstance($forward->module, $type, $kind);
 					}
 				}

--- a/modules/page/page.mobile.php
+++ b/modules/page/page.mobile.php
@@ -15,7 +15,7 @@ class pageMobile extends pageView
 				}
 			case 'OUTSIDE' :
 				{
-					$this->cache_file = sprintf("./files/cache/opage/%d.%s.m.cache.php", $this->module_info->module_srl, Context::getSslStatus());
+					$this->cache_file = sprintf("./files/cache/opage/%d.%s.m.cache.php", $this->module_info->module_srl, Context::getSslStatus()); 
 					$this->interval = (int)($this->module_info->page_caching_interval);
 					$this->path = $this->module_info->mpath ?: $this->module_info->path;
 					break;
@@ -41,7 +41,7 @@ class pageMobile extends pageView
 
 		Context::set('module_info', $this->module_info);
 		Context::set('page_content', $page_content);
-
+		
 		$this->setTemplatePath($this->module_path . 'tpl');
 		$this->setTemplateFile('mobile');
 	}
@@ -49,7 +49,7 @@ class pageMobile extends pageView
 	function _getWidgetContent()
 	{
 		// Arrange a widget ryeolro
-		if($this->module_info->mcontent && $this->module_info->use_mobile === 'Y')
+		if($this->module_info->mcontent)
 		{
 			$cache_file = sprintf("%sfiles/cache/page/%d.%s.m.cache.php", RX_BASEDIR, $this->module_info->module_srl, Context::getLangType());
 			$interval = (int)($this->module_info->page_caching_interval);
@@ -64,19 +64,19 @@ class pageMobile extends pageView
 					$mtime = filemtime($cache_file);
 				}
 
-				if($mtime + $interval*60 > $_SERVER['REQUEST_TIME'])
+				if($mtime + $interval*60 > $_SERVER['REQUEST_TIME']) 
 				{
-					$page_content = FileHandler::readFile($cache_file);
+					$page_content = FileHandler::readFile($cache_file); 
 					$page_content = str_replace('<!--#Meta:', '<!--Meta:', $page_content);
-				}
-				else
+				} 
+				else 
 				{
 					$oWidgetController = getController('widget');
 					$page_content = $oWidgetController->transWidgetCode($this->module_info->mcontent);
 					FileHandler::writeFile($cache_file, $page_content);
 				}
-			}
-			else
+			} 
+			else 
 			{
 				if(file_exists($cache_file))
 				{

--- a/modules/page/page.mobile.php
+++ b/modules/page/page.mobile.php
@@ -15,7 +15,7 @@ class pageMobile extends pageView
 				}
 			case 'OUTSIDE' :
 				{
-					$this->cache_file = sprintf("./files/cache/opage/%d.%s.m.cache.php", $this->module_info->module_srl, Context::getSslStatus()); 
+					$this->cache_file = sprintf("./files/cache/opage/%d.%s.m.cache.php", $this->module_info->module_srl, Context::getSslStatus());
 					$this->interval = (int)($this->module_info->page_caching_interval);
 					$this->path = $this->module_info->mpath ?: $this->module_info->path;
 					break;
@@ -41,7 +41,7 @@ class pageMobile extends pageView
 
 		Context::set('module_info', $this->module_info);
 		Context::set('page_content', $page_content);
-		
+
 		$this->setTemplatePath($this->module_path . 'tpl');
 		$this->setTemplateFile('mobile');
 	}
@@ -49,7 +49,7 @@ class pageMobile extends pageView
 	function _getWidgetContent()
 	{
 		// Arrange a widget ryeolro
-		if($this->module_info->mcontent)
+		if($this->module_info->mcontent && $this->module_info->use_mobile === 'Y')
 		{
 			$cache_file = sprintf("%sfiles/cache/page/%d.%s.m.cache.php", RX_BASEDIR, $this->module_info->module_srl, Context::getLangType());
 			$interval = (int)($this->module_info->page_caching_interval);
@@ -64,19 +64,19 @@ class pageMobile extends pageView
 					$mtime = filemtime($cache_file);
 				}
 
-				if($mtime + $interval*60 > $_SERVER['REQUEST_TIME']) 
+				if($mtime + $interval*60 > $_SERVER['REQUEST_TIME'])
 				{
-					$page_content = FileHandler::readFile($cache_file); 
+					$page_content = FileHandler::readFile($cache_file);
 					$page_content = str_replace('<!--#Meta:', '<!--Meta:', $page_content);
-				} 
-				else 
+				}
+				else
 				{
 					$oWidgetController = getController('widget');
 					$page_content = $oWidgetController->transWidgetCode($this->module_info->mcontent);
 					FileHandler::writeFile($cache_file, $page_content);
 				}
-			} 
-			else 
+			}
+			else
 			{
 				if(file_exists($cache_file))
 				{


### PR DESCRIPTION
어젯밤에 운영 중인 사이트의 관리자 페이지에서 [시스템 설정 > 고급 설정 > 모바일 뷰 사용] 옵션을 켜줬습니다. 그 이후부터 모바일에서는 메인이 빈 화면으로 표시된다는 회원들의 문의가 있어 잠깐 골치가 아팠습니다.

문제가 발생하는 조건은 아래와 같습니다.

1. [관리자 페이지 > 시스템 설정 > 고급 설정 > 모바일 뷰 사용] 옵션이 켜진 상태이고,
2. 위젯 페이지의 설정 화면에서 [모바일 뷰 사용] 옵션이 꺼져 있고,
3. 모바일 위젯 페이지의 내용이 존재하는 경우 (저희의 경우 빈 `<div>`가 들어 있었습니다.)

모바일 뷰 사용 옵션이 꺼진 경우 관리자 권한으로 접근해도 [모바일] 버튼이 표시되지 않아 모바일 위젯 페이지를 수정할 수가 없습니다. 따라서 위젯 페이지를 아무리 수정하고 캐시를 재설정해 봐도, 모바일 위젯 페이지의 내용은 변함이 없어 운영자는 환장하게(?) 됩니다.

따라서 모바일 뷰 사용 옵션이 꺼진 경우 모바일 콘텐츠가 아닌 PC 버전의 콘텐츠를 노출하는 것이 맞다고 생각하여, 해당 옵션이 켜진 경우에만 모바일 콘텐츠를 표시하도록 수정하였습니다.