### PR TITLE
포인트 그룹 연동 설정에 연동 불가능한 관리그룹은 노출시키지 않음

### DIFF
--- a/modules/point/tpl/config.html
+++ b/modules/point/tpl/config.html
@@ -162,11 +162,13 @@
 				</select>
 			</div>
 		</div>
-		<div class="x_control-group" loop="$group_list => $key,$val">
+		<div class="x_control-group" loop="$group_list => $key,$val" cond="$val->is_admin != 'Y'">
 			<label class="x_control-label" for="point_group_{$key}">{$val->title}</label>
 			<div class="x_controls">
-				<input cond="$val->is_default != 'Y'" type="number" min="0" max="1000" value="{$config->point_group[$key]}" name="point_group_{$key}" id="point_group_{$key}" style="width:50px" />
+				<!--@if($val->is_default != 'Y')-->
+				<input type="number" min="0" max="1000" value="{$config->point_group[$key]}" name="point_group_{$key}" id="point_group_{$key}" style="width:50px" />
 				&nbsp;{$lang->level}
+				<!--@end-->
 				<span cond="$val->is_default == 'Y'" style="display:inline-block;padding-top:3px">{$lang->default_group}</span>
 			</div>
 		</div>


### PR DESCRIPTION
관리그룹은 설정을 시도해도 실제로 레벨 연동이 불가능합니다. 연동이 가능하다 해도 포인트 레벨을 달성했다고 사이트 전체 관리 권한을 주는 것은 부자연스럽습니다. 따라서 아예 노출이 되지 않도록 조치했습니다.

https://github.com/rhymix/rhymix/blob/c874b318bf38182fd62166f527ca1bb67d488623/modules/point/point.admin.controller.php#L141-L142
어차피 관리그룹은 위 두줄 때문에 값 존재 유무를 체크조차 하지 않고 넘어가므로 폼이 없다고 문제가 생기지는 않을 것입니다.

추가로 기본 그룹 앞에 붙는 "레벨"을 삭제합니다.(의도한 사항이 아닌 것으로 보이며 없는 편이 더 자연스럽습니다)