### PR TITLE
게시글 읽을 경우를 나타내는 view 트리거 추가.

### DIFF
--- a/modules/board/board.view.php
+++ b/modules/board/board.view.php
@@ -346,6 +346,8 @@ class boardView extends board
 		 * add javascript filters
 		 **/
 		Context::addJsFilter($this->module_path.'tpl/filter', 'insert_comment.xml');
+		
+		ModuleHandler::triggerCall('board.contentView', 'after', $oDocument);
 	}
 
 	/**


### PR DESCRIPTION
게시글을 읽을 경우 나타내는 view트리거를 추가하는게 어떨까 합니다.

document.updateReadedCount 가 읽을때마다 생성이 되지만 이것저것 조건에 의하면 항상 게시글 읽을 때 생성되는 트리거가 아니라고 생각합니다.

조회수 조건필요 없이 스킨에서 특정 코드를 호출하기 위한 `{@ }`을 써가면서 코드를 작성할 필요 없이 해당 트리거에서 함께 Context::set() 으로 넘겨줄 수 있으면 좋지 않을까 생각했습니다.

트리거라서 ModuleHandler 를 직접 조작할 필요 없고 게시글 읽을 경우에만 확실하게 트리거를 활용할 수 있는 방안이 있으면 좋을까 하고 추가 건의 제안드려봅니다.