### PR TITLE
Fix #1766 상위 메뉴를 자기 자신으로 설정할수 없도록 수정

### DIFF
--- a/modules/menu/menu.admin.controller.php
+++ b/modules/menu/menu.admin.controller.php
@@ -1460,6 +1460,7 @@ class menuAdminController extends menu
 
 		$target_item = $oMenuAdminModel->getMenuItemInfo($target_srl);
 		if($target_item->menu_item_srl != $target_srl) throw new Rhymix\Framework\Exceptions\InvalidRequest;
+		if($target_srl == $parent_srl) throw new Rhymix\Framework\Exceptions\InvalidRequest;
 		// Move the menu location(change the order menu appears)
 		if($mode == 'move')
 		{


### PR DESCRIPTION
상위 메뉴를 자기 자신으로 설정하면 어떠한 메뉴에도 해당 메뉴가 표시되지 않으므로 메뉴를 관리하기 힘들어집니다.
이를 수정합니다.

다만 현재 위 오류로 인해 깨진 메뉴는 복원되지 않습니다. 이건 필요하다면 별도로 PR 보내겠습니다.