### PR TITLE
rhymix/next: 네이버 소셜로그인 연동시 닉네임이 없는 경우 예외처리

### DIFF
--- a/common/framework/drivers/social/naver.php
+++ b/common/framework/drivers/social/naver.php
@@ -96,13 +96,17 @@ class Naver extends Base implements \Rhymix\Framework\Drivers\SocialInterface
 		$profileValue['sns_id'] = $profile['id'];
 
 		// 이름 (닉네임이 없다면 이름으로 설정)
-		if ($profile['name'] && preg_match('/\*$/', $profile['nickname']))
+		if (!empty($profile['nickname']))
+		{
+			$profileValue['user_name'] = $profile['nickname'];
+		}
+		else if (!empty($profile['name']))
 		{
 			$profileValue['user_name'] = $profile['name'];
 		}
 		else
 		{
-			$profileValue['user_name'] = $profile['nickname'];
+			$profileValue['user_name'] = "noname";
 		}
 
 		// 프로필 이미지


### PR DESCRIPTION
	네이버 소셜로그인 연동시 닉네임이 없는 경우 user_name에 NULL 이 입력되어
	sociallogin.insertMemberSns Query 실행에 실패하는 문제점 수정

Signed-off-by: kmlee <lovablefish@gmail.com>