### PR TITLE
댓글 신고 불가 시 세션 값 변경 필요

### DIFF
--- a/modules/comment/comment.controller.php
+++ b/modules/comment/comment.controller.php
@@ -1530,7 +1530,7 @@ class commentController extends comment
 	function declaredComment($comment_srl, $declare_message)
 	{
 		// Fail if session information already has a reported document
-		if($_SESSION['declared_comment'][$comment_srl])
+		if(isset($_SESSION['declared_comment'][$comment_srl]))
 		{
 			return new BaseObject(-1, 'failed_declared');
 		}


### PR DESCRIPTION
document.controller.php 에서는 문제가 없으나, comment.controller.php 에서만 잘못 지정되어 있는것 같아서 보고드립니다!

문맥 의미 상, 신고 실패시에는 세션값에는 TRUE가 아닌 FALSE가 저장되는게 맞는것으로 보여집니다.