### PR TITLE
Fix #1811 크롬 기반 엣지 브라우저 UA 감지 추가

### DIFF
--- a/common/framework/ua.php
+++ b/common/framework/ua.php
@@ -275,7 +275,7 @@ class UA
 				return $result;
 			}
 		}
-		if (preg_match('#Edge/([0-9]+\\.)#', $ua, $matches))
+		if (preg_match('#Edg(?:e|A|iOS)?/([0-9]+\\.)#', $ua, $matches))
 		{
 			$result->browser = 'Edge';
 			$result->version = $matches[1] . '0';

--- a/tests/unit/framework/UATest.php
+++ b/tests/unit/framework/UATest.php
@@ -120,6 +120,27 @@ class UATest extends \Codeception\TestCase\Test
 		$this->assertEquals('4.9', $browser->version);
 		$this->assertEquals('Linux', $browser->os);
 		
+		// Edge 94 on Windows
+		$browser = Rhymix\Framework\UA::getBrowserInfo('Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4606.81 Safari/537.36 Edg/94.0.992.47');
+		$this->assertEquals('Edge', $browser->browser);
+		$this->assertEquals('94.0', $browser->version);
+		$this->assertEquals('Windows', $browser->os);
+		$this->assertFalse($browser->is_mobile);
+		
+		// Edge 93 on Android
+		$browser = Rhymix\Framework\UA::getBrowserInfo('Mozilla/5.0 (Linux; Android 10; SM-G965N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/93.0.4577.82 Mobile Safari/537.36 EdgA/93.0.961.69');
+		$this->assertEquals('Edge', $browser->browser);
+		$this->assertEquals('93.0', $browser->version);
+		$this->assertEquals('Android', $browser->os);
+		$this->assertTrue($browser->is_mobile);
+		
+		// Edge 93 on iOS
+		$browser = Rhymix\Framework\UA::getBrowserInfo('Mozilla/5.0 (iPhone; CPU iPhone OS 15_0_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.0 EdgiOS/93.961.64 Mobile/15E148 Safari/605.1.15');
+		$this->assertEquals('Edge', $browser->browser);
+		$this->assertEquals('93.0', $browser->version);
+		$this->assertEquals('iOS', $browser->os);
+		$this->assertTrue($browser->is_mobile);
+		
 		// Edge 13
 		$browser = Rhymix\Framework\UA::getBrowserInfo('Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2486.0 Safari/537.36 Edge/13.10586');
 		$this->assertEquals('Edge', $browser->browser);


### PR DESCRIPTION
Windows / macOS 상 Edge 브라우저는 `Edg/94.0.992.47` 형태를 사용합니다.
Android 상 Edge 브라우저는 `EdgA/94.0.992.47` 형태를 사용합니다.
iOS상 Edge 브라우저는 `EdgiOS/94.0.992.47` 형태를 사용합니다.

위 3가지 형태를 모두 감지할 수 있게 수정하고 이에 따른 Test case를 추가했습니다.

p.s.) 이번은 이미 Edge 브라우저를 인식하던 것을 못하게 된 것이라 수정했습니다만 앞으로 출시되는 모든 브라우저마다 감지 기능을 추가하는 것은 비효율적이고, 또한 브라우저 UA 기반으로 동작을 달리 하는 것 역시 추천되지 않으므로 이 이상 기능을 추가하기보다는 해당 기능 자체를 데스크톱/모바일 구분 정도로 축소시키는것도 좋을것 같습니다.