### PR TITLE
컨텐츠 위젯 및 comment 모듈 버그 수정

### DIFF
--- a/classes/module/ModuleObject.class.php
+++ b/classes/module/ModuleObject.class.php
@@ -720,9 +720,9 @@ class ModuleObject extends BaseObject
 		{
 			$this->setError($triggerOutput->getError());
 			$this->setMessage($triggerOutput->getMessage());
-			if($output->get('rx_error_location'))
+			if($triggerOutput->get('rx_error_location'))
 			{
-				$this->add('rx_error_location', $output->get('rx_error_location'));
+				$this->add('rx_error_location', $triggerOutput->get('rx_error_location'));
 			}
 			return FALSE;
 		}

--- a/modules/comment/comment.controller.php
+++ b/modules/comment/comment.controller.php
@@ -967,7 +967,7 @@ class commentController extends comment
 		}
 
 		// call a trigger (after)
-		ModuleHandler::triggerCall('comment.deleteComment', 'after', $obj);
+		ModuleHandler::triggerCall('comment.deleteComment', 'after', $comment);
 
 		// update the number of comments
 		$comment_count = CommentModel::getCommentCount($obj->document_srl);


### PR DESCRIPTION
1. 컨텐츠 위젯의 경우 https://github.com/rhymix/rhymix/issues/1821 에 대한 패치입니다.
2. comment 모듈의 경우 신규 버그 발견 후 수정하였습니다.

`ModuleHandler::triggerCall('comment.deleteComment', 'after', $obj);` 을 
`ModuleHandler::triggerCall('comment.deleteComment', 'after', $comment);` 로 수정해야합니다.
updateCommentByDelete 함수에서 받아오는 $obj 값을 그대로 사용해서 트리거로 전달하면 안되며, $comment = getModel('comment')->getComment($obj->comment_srl); 을 통해 저장한 $comment 값을 넘겨주어야 합니다.

해당 코드 수정을 통해 **댓글 자리 남김 기능시 댓글 삭제 트리거가 작동하지 않는 문제**가 수정되며
알림센터 알림 회수 문제, 및 https://github.com/rhymix/rhymix/issues/1803 이 해결됩니다.