### PR TITLE
에디터 컴포넌트 등에서 extravars 항목 중 type이 설정되지 않은 경우에 대한 수정

### DIFF
--- a/common/framework/parsers/baseparser.php
+++ b/common/framework/parsers/baseparser.php
@@ -82,7 +82,7 @@ abstract class BaseParser
 			$item = new \stdClass;
 			$item->group = $group_name;
 			$item->name = trim($var['name']);
-			$item->type = trim($var['type']);
+			$item->type = trim($var['type']) ?: 'text';
 			$item->title = self::_getChildrenByLang($var, 'title', $lang);
 			$item->description = str_replace('\\n', "\n", self::_getChildrenByLang($var, 'description', $lang));
 			$item->default = trim($var['default']) ?: null;


### PR DESCRIPTION
에디터 컴포넌트 등의 설정 xml 에서 type이 설정되지 않은 경우 `text` 가 기본 값으로 합니다.
이슈: https://github.com/rhymix/rhymix/issues/1871
@Lastorder-DC 님 감사합니다.