### PR TITLE
File 모듈의 procFileDownload 메소드에 대한 단축 주소를 정의합니다.

### DIFF
--- a/modules/file/conf/module.xml
+++ b/modules/file/conf/module.xml
@@ -10,7 +10,7 @@
 		<action name="procFileDelete" type="controller" />
 		<action name="procFileSetCoverImage" type="controller" />
 		<action name="procFileDownload" type="controller" method="GET|POST">
-			<route route="download/$file_srl:int/$sid:word@$module_srl:int" priority="50" />
+			<route route="procFileDownload/$file_srl:int/$sid:word/$module_srl:int" priority="50" />
 		</action>
 		<action name="procFileOutput" type="controller" method="GET|POST" />
 		<action name="procFileGetList" type="controller" permission="root" />

--- a/modules/file/conf/module.xml
+++ b/modules/file/conf/module.xml
@@ -10,7 +10,7 @@
 		<action name="procFileDelete" type="controller" />
 		<action name="procFileSetCoverImage" type="controller" />
 		<action name="procFileDownload" type="controller" method="GET|POST">
-			<route route="procFileDownload/$file_srl:int/$sid:word/$module_srl:int" priority="50" />
+			<route route="download/$file_srl:int/$sid:word" priority="50" />
 		</action>
 		<action name="procFileOutput" type="controller" method="GET|POST" />
 		<action name="procFileGetList" type="controller" permission="root" />

--- a/modules/file/conf/module.xml
+++ b/modules/file/conf/module.xml
@@ -9,7 +9,9 @@
 		<action name="procFileImageResize" type="controller" ruleset="imageResize" />
 		<action name="procFileDelete" type="controller" />
 		<action name="procFileSetCoverImage" type="controller" />
-		<action name="procFileDownload" type="controller" method="GET|POST" />
+		<action name="procFileDownload" type="controller" method="GET|POST">
+			<route route="download/$file_srl:int/$sid:word@$module_srl:int" priority="50" />
+		</action>
 		<action name="procFileOutput" type="controller" method="GET|POST" />
 		<action name="procFileGetList" type="controller" permission="root" />
 		

--- a/modules/file/file.model.php
+++ b/modules/file/file.model.php
@@ -253,9 +253,10 @@ class fileModel extends file
 	 */
 	public static function getDownloadUrl($file_srl, $sid, $module_srl = 0)
 	{
-		if (Rhymix\Framework\Router::getRewriteLevel() === 2)
+		$mid = ModuleModel::getMidByModuleSrl($module_srl);
+		if (Rhymix\Framework\Router::getRewriteLevel() === 2 && !is_null($mid))
 		{
-			return sprintf('file/procFileDownload/%d/%s/%d', $file_srl, $sid, $module_srl);
+			return sprintf('%s/download/%d/%s', $mid, $file_srl, $sid);
 		}
 		else
 		{

--- a/modules/file/file.model.php
+++ b/modules/file/file.model.php
@@ -253,7 +253,7 @@ class fileModel extends file
 	 */
 	public static function getDownloadUrl($file_srl, $sid, $module_srl = 0)
 	{
-		return getUrl('', 'module', 'file', 'act', 'procFileDownload', 'file_srl', intval($file_srl), 'sid', strval($sid), 'module_srl', intval($module_srl));
+		return '.'.getUrl('', 'module', 'file', 'act', 'procFileDownload', 'file_srl', intval($file_srl), 'sid', strval($sid), 'module_srl', intval($module_srl));
 	}
 	
 	/**

--- a/modules/file/file.model.php
+++ b/modules/file/file.model.php
@@ -253,7 +253,7 @@ class fileModel extends file
 	 */
 	public static function getDownloadUrl($file_srl, $sid, $module_srl = 0)
 	{
-		return getUrl('', 'module', 'file', 'act', 'procFileDownload', 'file_srl', intval($file_srl), 'sid', $sid, 'module_srl', intval($module_srl));
+		return getUrl('', 'module', 'file', 'act', 'procFileDownload', 'file_srl', intval($file_srl), 'sid', strval($sid), 'module_srl', intval($module_srl));
 	}
 	
 	/**

--- a/modules/file/file.model.php
+++ b/modules/file/file.model.php
@@ -255,7 +255,7 @@ class fileModel extends file
 	{
 		if (Rhymix\Framework\Router::getRewriteLevel() === 2)
 		{
-			return sprintf('file/download/%d/%s@%d', $file_srl, $sid, $module_srl);
+			return sprintf('file/procFileDownload/%d/%s/%d', $file_srl, $sid, $module_srl);
 		}
 		else
 		{

--- a/modules/file/file.model.php
+++ b/modules/file/file.model.php
@@ -253,7 +253,14 @@ class fileModel extends file
 	 */
 	public static function getDownloadUrl($file_srl, $sid, $module_srl = 0)
 	{
-		return '.'.getUrl('', 'module', 'file', 'act', 'procFileDownload', 'file_srl', intval($file_srl), 'sid', strval($sid), 'module_srl', intval($module_srl));
+		if (Rhymix\Framework\Router::getRewriteLevel() === 2)
+		{
+			return '.'.getUrl('', 'module', 'file', 'act', 'procFileDownload', 'file_srl', intval($file_srl), 'sid', strval($sid), 'module_srl', intval($module_srl));
+		}
+		else
+		{
+			return sprintf('?module=%s&amp;act=%s&amp;file_srl=%s&amp;sid=%s&amp;module_srl=%d', 'file', 'procFileDownload', $file_srl, $sid, $module_srl);
+		}
 	}
 	
 	/**

--- a/modules/file/file.model.php
+++ b/modules/file/file.model.php
@@ -253,7 +253,7 @@ class fileModel extends file
 	 */
 	public static function getDownloadUrl($file_srl, $sid, $module_srl = 0)
 	{
-		return sprintf('?module=%s&amp;act=%s&amp;file_srl=%s&amp;sid=%s&amp;module_srl=%d', 'file', 'procFileDownload', $file_srl, $sid, $module_srl);
+		return getUrl('', 'module', 'file', 'act', 'procFileDownload', 'file_srl', intval($file_srl), 'sid', $sid, 'module_srl', intval($module_srl));
 	}
 	
 	/**

--- a/modules/file/file.model.php
+++ b/modules/file/file.model.php
@@ -255,7 +255,7 @@ class fileModel extends file
 	{
 		if (Rhymix\Framework\Router::getRewriteLevel() === 2)
 		{
-			return '.'.getUrl('', 'module', 'file', 'act', 'procFileDownload', 'file_srl', intval($file_srl), 'sid', strval($sid), 'module_srl', intval($module_srl));
+			return sprintf('file/download/%d/%s@%d', $file_srl, $sid, $module_srl);
 		}
 		else
 		{


### PR DESCRIPTION
File 모듈의 procFileDownload 메소드에 대한 단축 주소를 정의합니다.
파일 다운로드는 많이 사용되는 메소드 이지만, `procFileDownload`에 대한 단축 주소는 정의되어 있지 않습니다.
게시글에 대한 링크 주소 처럼 많이 사용되는 형태를 피하기 위해서 다음과 같이 단축 주소를 고안해보았습니다.
```xml
<action name="procFileDownload" type="controller" method="GET|POST">
	<route route="download/$file_srl:int/$sid:word@$module_srl:int" priority="50" />
</action>
```

1. 기존에 XE나 라이믹스에서 많이 사용되던 `/` 이외에도 `@`과 같은 구분자를 사용하는 예시를 만들면 어떨까 하는 마음
2. 기존에 많이 사용되던 형식에 충돌하지 않고 싶은 마음

두 가지 생각에서 제안해봅니다.

[@kijin ](https://github.com/rhymix/rhymix/pull/1322#issuecomment-1031373666) 님 의견에 따라, 무의미한 `global route` 사용은 삭제했습니다.