### PR TITLE
Fix Warning in getExtraVars()

### DIFF
--- a/modules/document/document.item.php
+++ b/modules/document/document.item.php
@@ -891,7 +891,7 @@ class documentItem extends BaseObject
 		$module_srl = $this->get('module_srl');
 		if(!$module_srl || !$this->document_srl)
 		{
-			return null;
+			return array();
 		}
 
 		return DocumentModel::getExtraVars($module_srl, $this->document_srl);


### PR DESCRIPTION
https://github.com/rhymix/rhymix/blob/b6e21eb61ffda5750073994161622247767d3408/modules/document/document.item.php#L908 Warning: Invalid argument supplied for foreach()