### PR TITLE
외부페이지의 load target=... 에 타임스탬프 추가

### DIFF
--- a/classes/frontendfile/FrontEndFileHandler.class.php
+++ b/classes/frontendfile/FrontEndFileHandler.class.php
@@ -183,7 +183,7 @@ class FrontEndFileHandler extends Handler
 		$file = new stdClass();
 		$file->fileName = $pathInfo['basename'];
 		$file->filePath = $this->_getAbsFileUrl($pathInfo['dirname'] ?? '');
-		$file->fileRealPath = FileHandler::getRealPath($pathInfo['dirname'] ?? '');
+		$file->fileRealPath = FileHandler::getRealPath(ltrim($file->filePath, '/'));
 		$file->fileFullPath = $file->fileRealPath . '/' . ($pathInfo['basename'] ?? '');
 		$file->fileExtension = strtolower($pathInfo['extension'] ?? '');
 		if (($pos = strpos($file->fileExtension, '?')) !== false)

--- a/classes/frontendfile/FrontEndFileHandler.class.php
+++ b/classes/frontendfile/FrontEndFileHandler.class.php
@@ -183,7 +183,7 @@ class FrontEndFileHandler extends Handler
 		$file = new stdClass();
 		$file->fileName = $pathInfo['basename'];
 		$file->filePath = $this->_getAbsFileUrl($pathInfo['dirname'] ?? '');
-		$file->fileRealPath = FileHandler::getRealPath(ltrim($file->filePath, '/'));
+		$file->fileRealPath = FileHandler::getRealPath(ltrim($pathInfo['dirname'] ?? '', '/'));
 		$file->fileFullPath = $file->fileRealPath . '/' . ($pathInfo['basename'] ?? '');
 		$file->fileExtension = strtolower($pathInfo['extension'] ?? '');
 		if (($pos = strpos($file->fileExtension, '?')) !== false)

--- a/classes/template/TemplateHandler.class.php
+++ b/classes/template/TemplateHandler.class.php
@@ -854,6 +854,7 @@ class TemplateHandler
 					$replacements = HTMLDisplayHandler::$replacements;
 					$attr['target'] = preg_replace(array_keys($replacements), array_values($replacements), $attr['target']);
 					$pathinfo = pathinfo($attr['target']);
+					$pathinfo['extension'] = preg_replace('/\?.*/', '', $pathinfo['extension']);
 					$doUnload = ($m[3] === 'unload');
 					$isRemote = !!preg_match('@^(https?:)?//@i', $attr['target']);
 

--- a/classes/template/TemplateHandler.class.php
+++ b/classes/template/TemplateHandler.class.php
@@ -854,7 +854,6 @@ class TemplateHandler
 					$replacements = HTMLDisplayHandler::$replacements;
 					$attr['target'] = preg_replace(array_keys($replacements), array_values($replacements), $attr['target']);
 					$pathinfo = pathinfo($attr['target']);
-					$pathinfo['extension'] = preg_replace('/\?.*/', '', $pathinfo['extension']);
 					$doUnload = ($m[3] === 'unload');
 					$isRemote = !!preg_match('@^(https?:)?//@i', $attr['target']);
 
@@ -876,6 +875,7 @@ class TemplateHandler
 						$attr['target'] = $relativeDir . '/' . $pathinfo['basename'];
 					}
 
+					$pathinfo['extension'] = preg_replace('/\?.*/', '', $pathinfo['extension']);
 					switch($pathinfo['extension'])
 					{
 						case 'xml':

--- a/modules/page/page.view.php
+++ b/modules/page/page.view.php
@@ -236,16 +236,13 @@ class pageView extends page
 		// /=absolute path, #=hash in a page, {=Template syntax
 		if(strpos($val, '.') === FALSE || preg_match('@^((?:http|https|ftp|telnet|mms)://|(?:mailto|javascript):|[/#{])@i',$val))
 		{
-				return $matches[0];
-			// In case of  .. , get a path
-		}
-		else if(strncasecmp('..', $val, 2) === 0)
-		{
-			$p = Context::pathToUrl($this->path);
-			return sprintf("%s%s%s%s",$matches[1],$matches[2],$p.$val,$matches[4]);
+			return $matches[0];
 		}
 
-		if(strncasecmp('..', $val, 2) === 0) $val = substr($val,2);
+		if (strncasecmp('./', $val, 2) === 0)
+		{
+			$val = substr($val, 2);
+		}
 		$p = Context::pathToUrl($this->path);
 		$path = sprintf("%s%s%s%s",$matches[1],$matches[2],$p.$val,$matches[4]);
 


### PR DESCRIPTION
`<load target="..."/>` 관련하여 3가지를 수정합니다. 

1. 레이아웃이나 스킨에서 `<load target="test/test.css?1234"/>` 처럼 `?` 가 붙으면 확장자를 인식하지 못하고 skip 하는 것을 fix 합니다.

2. 현재 외부페이지의 경로는 "/" 부터 시작합니다. 예를들면, `external/index.php`에서 `external/test.css`를 로딩하기 위해서 `<load target="test.css"/>`를 호출하면, 다른 레이아웃이나 스킨에서라면 `target="external/test.css"`로 되지만, 외부페이지에서는 `target="/external/test.css"` 처럼 앞에 /가 붙어서 처리됩니다. 

이렇게 해도 정상 동작은 하는데, `loadFile()`에서 `file_exist(/external/test.css)`가 절대 경로로 인식해서 file이 없다고 판단하고, css 통합, cache, minify, timestamp를 하지 못합니다.

애시당초 외부페이지에서 /를 빼주는 것이 좋겠지만, 기존에 이미 오랫동안 써와서 굳어졌기 때문에, 직접 영향을 받는 loadFile 내에서만 수정하는  방법을 써봤습니다. `loadFile()`에서 처리하는 css, js, less, scss 파일들이 홈페이지 root directory보다 위로 거슬러 올라갈수는 없을 것이기 때문에, 즉, 절대경로가 될수는 없으므로, 앞에 /를 제외하고 처리하면 될것 같습니다. 

3. 과거 https://github.com/rhymix/rhymix/commit/5693e340fe87541179474af4c28d2e27726ad05a 커밋때 typo가 있었던 것을 원래대로 수정했습니다 (page.view.php). 결과에는 영향이 없는 것 같습니다.