### PR TITLE
알림센터 관리자 페이지에서 알림의 언어가 이상하게 나타나는 문제 고침

### DIFF
--- a/modules/ncenterlite/lang/en.php
+++ b/modules/ncenterlite/lang/en.php
@@ -1,5 +1,6 @@
 <?php
 $lang->ncenterlite = 'Notification Center Lite';
+$lang->ncenterlite_notify = 'notification';
 $lang->ncenterlite_install_version = 'Installed version';
 $lang->ncenterlite_advenced_config = 'Advenced Setting';
 $lang->ncenterlite_document = 'post';

--- a/modules/ncenterlite/lang/ko.php
+++ b/modules/ncenterlite/lang/ko.php
@@ -1,5 +1,6 @@
 <?php
 $lang->ncenterlite = '알림센터 Lite';
+$lang->ncenterlite_notify = '알림';
 $lang->ncenterlite_install_version = '설치된 버전';
 $lang->ncenterlite_advenced_config = '고급 설정';
 $lang->ncenterlite_document = '글';

--- a/modules/ncenterlite/tpl/config.html
+++ b/modules/ncenterlite/tpl/config.html
@@ -10,7 +10,13 @@
 	<section class="section">
 		<div class="x_control-group">
 			<!--@foreach($notify_types as $notify_type => $notify_srl)-->
+			<!--@if($notify_srl > 0)-->
+			<label class="x_control-label">
+				{$notify_type} {$lang->ncenterlite_notify}
+			</label>
+			<!--@else-->
 				<label class="x_control-label">{$lang->get('ncenterlite_type_' . $notify_type)}</label>
+			<!--@end-->
 				<div class="x_controls">
 					<label class="x_inline"><input type="checkbox" name="use[{$notify_type}][web]" value="1" checked="checked"|cond="isset($config->use[$notify_type]['web'])" /> {$lang->cmd_web_notify}</label>
 					<label class="x_inline"><input type="checkbox" name="use[{$notify_type}][mail]" value="1" checked="checked"|cond="isset($config->use[$notify_type]['mail'])" /> {$lang->cmd_mail_notify}</label>


### PR DESCRIPTION
https://xetown.com/questions/1669135

참고글 처럼 각각 유저들이 따로 알림을 만들게 되면 어떤 알림이다 라는것은 구분할 수 있지만, 뭔가 프로그래밍 언어적으로 보이는 경우가 많아 우선 변수명을 기준으로 어떤 알림이다라는 것을 언어별로 깔끔하게 구분할 수 있도록 개선 해주는 패치입니다.

![image](https://user-images.githubusercontent.com/4381756/159824499-fe617c17-c6b9-4b5f-86c5-cda1586dc228.png)
위 사진진과 같이 깔끔하게 표현이 가능합니다.