### PR TITLE
위젯 페이지에서 괄호 등 GET/POST 불가 문제 수정

### DIFF
--- a/modules/page/page.view.php
+++ b/modules/page/page.view.php
@@ -67,15 +67,6 @@ class pageView extends page
 		{
 			Context::set('module_srl', $this->module_srl);
 		}
-		
-		// Kick out anyone who tries to exploit RVE-2022-2.
-		foreach (Context::getRequestVars() as $key => $val)
-		{
-			if (preg_match('/[\{\}\(\)<>\$\'"]/', $key) || preg_match('/[\{\}\(\)<>\$\'"]/', $val))
-			{
-				throw new Rhymix\Framework\Exceptions\SecurityViolation();
-			}
-		}
 
 		// Get page content according to page type.
 		$page_type_name = strtolower($this->module_info->page_type);
@@ -165,6 +156,15 @@ class pageView extends page
 		if (!$this->path)
 		{
 			return;
+		}
+		
+		// Kick out anyone who tries to exploit RVE-2022-2.
+		foreach (Context::getRequestVars() as $key => $val)
+		{
+			if (preg_match('/[\{\}\(\)<>\$\'"]/', $key) || preg_match('/[\{\}\(\)<>\$\'"]/', $val))
+			{
+				throw new Rhymix\Framework\Exceptions\SecurityViolation();
+			}
 		}
 		
 		// External URL


### PR DESCRIPTION
RVE-2022-2 보안 패치가 외부페이지 뿐만 아니라 위젯 페이지에도 적용되어
위젯으로 구현된 검색, 입력폼 등에서 일반적인 괄호를 못 쓰는 문제를 수정합니다.