### PR TITLE
삭제한 댓글을 다시 삭제하지 않도록 기록

### DIFF
--- a/modules/comment/comment.admin.controller.php
+++ b/modules/comment/comment.admin.controller.php
@@ -223,13 +223,10 @@ class commentAdminController extends comment
 			}
 
 			$output = $oCommentController->deleteComment($comment_srl, TRUE, toBool($isTrash));
-			if($output->error !== -2)
+			if(!$output->toBool() && $output->error !== -2)
 			{
-				if(!$output->toBool())
-				{
-					$oDB->rollback();
-					return $output;
-				}
+				$oDB->rollback();
+				return $output;
 			}
 			$deleted_count++;
 		}

--- a/modules/comment/comment.admin.controller.php
+++ b/modules/comment/comment.admin.controller.php
@@ -223,12 +223,14 @@ class commentAdminController extends comment
 			}
 
 			$output = $oCommentController->deleteComment($comment_srl, TRUE, toBool($isTrash));
-			if(!$output->toBool())
+			if($output->error !== -2)
 			{
-				$oDB->rollback();
-				return $output;
+				if(!$output->toBool())
+				{
+					$oDB->rollback();
+					return $output;
+				}
 			}
-
 			$deleted_count++;
 		}
 

--- a/modules/comment/comment.controller.php
+++ b/modules/comment/comment.controller.php
@@ -11,7 +11,8 @@
  */
 class commentController extends comment
 {
-
+	private $deleteCommentSrls = array();
+	
 	/**
 	 * Initialization
 	 * @return void
@@ -1048,6 +1049,13 @@ class commentController extends comment
 	{
 		// check if comment already exists
 		$comment = CommentModel::getComment($comment_srl);
+		
+		// 이미 삭제한 댓글을 다시 삭제를 실행할 의무는 없으므로 넘겨버림.
+		if($this->deleteCommentSrls[$comment_srl])
+		{
+			return new BaseObject();
+		}
+		
 		if(!$comment->isExists())
 		{
 			return new BaseObject(-1, 'msg_not_founded');
@@ -1181,6 +1189,8 @@ class commentController extends comment
 		// Remove the thumbnail file
 		Rhymix\Framework\Storage::deleteDirectory(RX_BASEDIR . sprintf('files/thumbnails/%s', getNumberingPath($comment_srl, 3)));
 
+		$this->deleteCommentSrls[$comment_srl] = true;
+		
 		// commit
 		$oDB->commit();
 

--- a/modules/comment/comment.controller.php
+++ b/modules/comment/comment.controller.php
@@ -11,8 +11,6 @@
  */
 class commentController extends comment
 {
-	private $deleteCommentSrls = array();
-	
 	/**
 	 * Initialization
 	 * @return void
@@ -1050,15 +1048,9 @@ class commentController extends comment
 		// check if comment already exists
 		$comment = CommentModel::getComment($comment_srl);
 		
-		// 이미 삭제한 댓글을 다시 삭제를 실행할 의무는 없으므로 넘겨버림.
-		if($this->deleteCommentSrls[$comment_srl])
-		{
-			return new BaseObject();
-		}
-		
 		if(!$comment->isExists())
 		{
-			return new BaseObject(-1, 'msg_not_founded');
+			return new BaseObject(-2, 'msg_not_founded');
 		}
 		if(!$is_admin && !$comment->isGranted())
 		{
@@ -1189,8 +1181,6 @@ class commentController extends comment
 		// Remove the thumbnail file
 		Rhymix\Framework\Storage::deleteDirectory(RX_BASEDIR . sprintf('files/thumbnails/%s', getNumberingPath($comment_srl, 3)));
 
-		$this->deleteCommentSrls[$comment_srl] = true;
-		
 		// commit
 		$oDB->commit();
 


### PR DESCRIPTION
https://xetown.com/questions/1669397

하나의 댓글에 그 대댓글을 먼저 삭제 하게 되면서 다시 deleteComment 함수를 admin.controller.php에서 요청할때댓글을 찾을 수 없다고 뜨는 문제입니다.

이 경우 이미 삭제를 진행했던 리스트들을 따로 담아두어 해당 댓글을 삭제한 이력이 있다면 빈 BaseObject를 리턴시켜 위의 질문과 같은 상태를 방지합니다.

여러개의 댓글을 삭제하는 경우 사용합니다.

좀 더 나은 방법이 있으면 의견주세요 :) 