### PR TITLE
짧은 다운로드 주소 지원

### DIFF
--- a/common/framework/router.php
+++ b/common/framework/router.php
@@ -46,8 +46,14 @@ class Router
 			'vars' => ['mid' => 'any', 'act' => 'word'],
 			'priority' => 20,
 		),
-		'files/download/$file_srl/$file_key/$filename' => array(
-			'regexp' => '#^files/download/(?<file_srl>[0-9]+)/(?<file_key>[a-zA-Z0-9_-]+)/(?<filename>[^/]+)$#',
+		'files/download/0/$file_srl/$sid/$filename' => array(
+			'regexp' => '#^files/download/0/(?<file_srl>[0-9]+)/(?<sid>[a-zA-Z0-9_-]+)/(?<filename>[^/]+)$#',
+			'vars' => ['file_srl' => 'int', 'sid' => 'any', 'filename' => 'any'],
+			'extra_vars' => ['act' => 'procFileDownload'],
+			'priority' => 0,
+		),
+		'files/download/1/$file_srl/$file_key/$filename' => array(
+			'regexp' => '#^files/download/1/(?<file_srl>[0-9]+)/(?<file_key>[a-zA-Z0-9_-]+)/(?<filename>[^/]+)$#',
 			'vars' => ['file_srl' => 'int', 'file_key' => 'any', 'filename' => 'any'],
 			'extra_vars' => ['act' => 'procFileOutput'],
 			'priority' => 0,

--- a/common/js/plugins/jquery.fileupload/js/main.js
+++ b/common/js/plugins/jquery.fileupload/js/main.js
@@ -183,8 +183,8 @@
 						else if(/\.(mp4|webm|ogv)$/i.test(result.source_filename) && opt.autoinsertTypes.video) {
 							if(result.original_type === 'image/gif') {
 								temp_code += '<video src="' + result.download_url + '" autoplay loop muted playsinline data-file-srl="' + result.file_srl + '" />';
-							} else if (result.download_url.match(/\bprocFileDownload\b/)) {
-								if (result.download_url.match(/^\?/)) {
+							} else if (result.download_url.match(/(?:\bprocFileDownload\b|files\/download\/)/)) {
+								if (!result.download_url.match(/^\//)) {
 									result.download_url = XE.URI(default_url).pathname() + result.download_url;
 								}
 								temp_code += '<video src="' + result.download_url + '" controls preload="none" data-file-srl="' + result.file_srl + '" />';
@@ -364,8 +364,8 @@
 				else if(/\.(mp4|webm|ogv)$/i.test(result.source_filename)) {
 					if(result.original_type === 'image/gif') {
 						temp_code += '<video src="' + result.download_url + '" autoplay loop muted playsinline data-file-srl="' + result.file_srl + '" />';
-					} else if (result.download_url.match(/\bprocFileDownload\b/)) {
-						if (result.download_url.match(/^\?/)) {
+					} else if (result.download_url.match(/(?:\bprocFileDownload\b|files\/download\/)/)) {
+						if (!result.download_url.match(/^\//)) {
 							result.download_url = XE.URI(default_url).pathname() + result.download_url;
 						}
 						temp_code += '<video src="' + result.download_url + '" controls preload="none" data-file-srl="' + result.file_srl + '" />';

--- a/modules/file/file.controller.php
+++ b/modules/file/file.controller.php
@@ -387,7 +387,7 @@ class fileController extends file
 		// Use short URL or long URL
 		if ($file_module_config->download_short_url === 'Y' && config('use_rewrite'))
 		{
-			$url = RX_BASEURL . sprintf('files/download/%d/%s/%s', $file_srl, $file_key, rawurlencode(preg_replace('/\.\.+/', '.', $filename)));
+			$url = RX_BASEURL . sprintf('files/download/1/%d/%s/%s', $file_srl, $file_key, rawurlencode(preg_replace('/\.\.+/', '.', $filename)));
 		}
 		else
 		{


### PR DESCRIPTION
현재 다운로드 주소(`procFileDownload`)는 주소에 파일이름과 확장자가 없어 파일 다운로드 주소로 인식되기 어려운 주소입니다. 때문에 SEO나 구글 애널리틱스에서 파일 다운로드로 집계되지 않는 문제가 발생합니다.

"다운로드시 짧은주소 사용" 옵션을 활성화하면 `procFileOutput`와 같이 `procFileDownload`에도 파일명이 포함된 짧은 주소가 적용되도록 하였습니다.
- `procFileDownload`: `files/download/0/$file_srl/$sid/$filename`
- `procFileOutput`: `files/download/1/$file_srl/$file_key/$filename`
