### PR TITLE
날짜 확장변수에서 자동 완성 기능과 겹치는 문제 수정

### DIFF
--- a/classes/extravar/Extravar.class.php
+++ b/classes/extravar/Extravar.class.php
@@ -560,7 +560,7 @@ class ExtraItem
 				Context::loadJavascriptPlugin('ui.datepicker');
 
 				$buff[] = '<input type="hidden" class="rx_ev_date" name="' . $column_name . '" value="' . $value . '" />'; 
-				$buff[] =	'<input type="text" id="date_' . $column_name . '" value="' . zdate($value, 'Y-m-d') . '" class="date" />';
+				$buff[] =	'<input type="text" id="date_' . $column_name . '" value="' . zdate($value, 'Y-m-d') . '" class="date" autocomplete="off" />';
 				$buff[] =	'<input type="button" value="' . lang('cmd_delete') . '" class="btn" id="dateRemover_' . $column_name . '" />';
 				$buff[] =	'<script type="text/javascript">';
 				$buff[] = '//<![CDATA[';


### PR DESCRIPTION
브라우저 자동 완성 기능 사용 시 datepicker를 가리는 문제가 있어
date input에서 자동 완성 기능을 끕니다.

![image](https://user-images.githubusercontent.com/60457472/163767089-31169866-6f28-4bf8-b335-16451789b41e.png)
