### PR TITLE
Fix #1954 로그인 무한 리다이렉트 문제 수정

### DIFF
--- a/modules/member/member.view.php
+++ b/modules/member/member.view.php
@@ -609,7 +609,7 @@ class memberView extends member
 	{
 		// Get referer URL
 		$referer_url = Context::get('referer_url') ?: ($_SERVER['HTTP_REFERER'] ?? '');
-		if (!$referer_url || !Rhymix\Framework\URL::isInternalURL($referer_url) || contains('procMember', $referer_url))
+		if (!$referer_url || !Rhymix\Framework\URL::isInternalURL($referer_url) || contains('procMember', $referer_url) || contains('dispMemberLoginForm', $referer_url))
 		{
 			$referer_url = getNotEncodedUrl('act', '');
 		}


### PR DESCRIPTION
이 현상이 2.0.18부터 발생하고 있으며,
간혹 발생하여 확인이 어려웠는데,
증상 확인방법은 비밀번호를 틀리거나, 로그인 링크 버튼을 2번연속 눌러서 리퍼러에 dispMemberLoginForm가 지정되면 발생합니다.

참고 https://github.com/rhymix/rhymix/commit/6e0b4ab688f8fcd36c9cf2849bb63aa354085d66