### PR TITLE
Fix #1958 Do not install point module trigger by default

### DIFF
--- a/modules/point/point.class.php
+++ b/modules/point/point.class.php
@@ -159,9 +159,6 @@ class point extends ModuleObject
 		
 		// Create a directory to store points information.
 		FileHandler::makeDir('./files/member_extra_info/point');
-		
-		// Register triggers.
-		$this->registerTriggers();
 	}
 
 	/**


### PR DESCRIPTION
초기 설치시 포인트 모듈의 트리거를 등록하면 포인트 모듈이 정상 동작하나 실제 설정은 OFF인 이상한 상태가 됩니다.
따라서 실제 설정과 동작을 일치시키기 위해 트리거 등록 코드를 삭제합니다. 포인트 모듈 활성화시 같은 함수를 실행하므로 동작상 오류는 없습니다.

기존 사이트는 영향을 받지 않으며 트리거만 등록되고 실제 설정은 OFF인 경우 포인트 모듈을 활성화후 비활성화해야 트리거를 삭제할 수 있습니다.