### PR TITLE
Fix #1964 통합게시판 사용시 댓글 포인트 지급 오류 고침

### DIFF
--- a/modules/board/board.controller.php
+++ b/modules/board/board.controller.php
@@ -401,8 +401,7 @@ class boardController extends board
 
 		// get the relevant data for inserting comment
 		$obj = Context::getRequestVars();
-		$obj->module_srl = $this->module_srl;
-		
+
 		// Remove disallowed Unicode symbols.
 		if ($this->module_info->filter_specialchars !== 'N')
 		{
@@ -448,19 +447,7 @@ class boardController extends board
 			throw new Rhymix\Framework\Exceptions\TargetNotFound;
 		}
 
-		if(isset($module_info->include_modules))
-		{
-			if(intval($oDocument->get('module_srl')) !== intval($obj->module_srl))
-			{
-				$module_info = moduleModel::getModuleInfoByModuleSrl($obj->module_srl);
-				$include_modules = explode(',', $module_info->include_modules);
-				
-				if(in_array($obj->module_srl, $include_modules))
-				{
-					$obj->module_srl = $oDocument->get('module_srl');
-				}
-			}
-		}
+		$obj->module_srl = $oDocument->get('module_srl');
 		
 		// For anonymous use, remove writer's information and notifying information
 		if($this->module_info->use_anonymous == 'Y' && (!$this->grant->manager || ($this->module_info->anonymous_except_admin ?? 'N') !== 'Y'))

--- a/modules/board/board.controller.php
+++ b/modules/board/board.controller.php
@@ -448,6 +448,20 @@ class boardController extends board
 			throw new Rhymix\Framework\Exceptions\TargetNotFound;
 		}
 
+		if(isset($module_info->include_modules))
+		{
+			if(intval($oDocument->get('module_srl')) !== intval($obj->module_srl))
+			{
+				$module_info = moduleModel::getModuleInfoByModuleSrl($obj->module_srl);
+				$include_modules = explode(',', $module_info->include_modules);
+				
+				if(in_array($obj->module_srl, $include_modules))
+				{
+					$obj->module_srl = $oDocument->get('module_srl');
+				}
+			}
+		}
+		
 		// For anonymous use, remove writer's information and notifying information
 		if($this->module_info->use_anonymous == 'Y' && (!$this->grant->manager || ($this->module_info->anonymous_except_admin ?? 'N') !== 'Y'))
 		{


### PR DESCRIPTION
#1964 통합게시판 사용시 댓글 포인트에 오류가 있는 문제를 고쳤습니다.

이와 더불어서 include_modules 설정이 세팅되어 있는 경우 정확하게 해당 모듈이 포함되어 있는지 확인 후 module_srl 을 수정하도록 채크하였습니다.

일부 타임라인 모듈과 충돌이 나지 않도록 그 외 불필요한 리턴 동작은 해당 동작에서 제외하였습니다.
