### PR TITLE
모듈 옵션에 따라 게시글 삭제시 항상 자리 남김 또는 삭제 하도록 개선

### DIFF
--- a/modules/comment/comment.admin.controller.php
+++ b/modules/comment/comment.admin.controller.php
@@ -260,8 +260,6 @@ class commentAdminController extends comment
 
 			$deleted_count++;
 		}
-
-
 		
 		$oDB->commit();
 

--- a/modules/comment/comment.controller.php
+++ b/modules/comment/comment.controller.php
@@ -931,8 +931,7 @@ class commentController extends comment
 		}
 
 		// If the case manager to delete comments, it indicated that the administrator deleted.
-		$logged_info = Context::get('logged_info');
-		if($is_admin === true && $obj->member_srl !== $logged_info->member_srl)
+		if($is_admin === true && $obj->member_srl !== $this->user->member_srl)
 		{
 			$obj->content = lang('msg_admin_deleted_comment');
 			$obj->status = RX_STATUS_DELETED_BY_ADMIN;


### PR DESCRIPTION
#1800 이슈를 해결하는 PR입니다.

아직 완벽하게 코드짠 것은 아닙니다만.. 어느정도 된 코드 부터 테스트를 위해 남겨둡니다.

우선은 게시판 모듈의 설정을 채크하는 기능이 들어가 있긴 합니다. module_info의 데이터를 우선 집중적으로 채크 하고 잇는 상황이긴 합니다만.. 1800이슈에 적어주신 설명처럼 더 나은 팁이 있다면 알려주세요 :) 