### PR TITLE
Fix getDriverInstance return null after #1946 fix

### DIFF
--- a/common/framework/Cache.php
+++ b/common/framework/Cache.php
@@ -130,7 +130,7 @@ class Cache
 		}
 		else
 		{
-			$class_name = '\\Rhymix\\Framework\\Drivers\\Cache\\' . $name;
+			$class_name = '\\Rhymix\\Framework\\Drivers\\Cache\\' . ucfirst($name);
 			if (class_exists($class_name) && $class_name::isSupported() && $class_name::validateSettings($config))
 			{
 				return $class_name::getInstance($config);


### PR DESCRIPTION
다른 부분에는 전부 ucfirst 처리가 되어 있으나 해당 부분만 누락되어 있어 getDriverInstance시 항상 null이 리턴되고 있습니다.
이를 고칩니다.