### PR TITLE
관리자 페이지에서 사이트의 컬러 설정이 안먹는 문제 고침

### DIFF
--- a/classes/module/ModuleHandler.class.php
+++ b/classes/module/ModuleHandler.class.php
@@ -223,7 +223,6 @@ class ModuleHandler extends Handler
 			$this->mid = $module_info->mid;
 			$this->module_info = $module_info;
 			$this->_setModuleSEOInfo($module_info, $site_module_info);
-			$this->_setModuleColorScheme($site_module_info);
 			
 			// Check if the current request is from a mobile device.
 			$this->is_mobile = Mobile::isFromMobilePhone();
@@ -265,6 +264,8 @@ class ModuleHandler extends Handler
 			$this->module_info->mid = $this->mid;
 		}
 
+		$this->_setModuleColorScheme($site_module_info);
+		
 		// Always overwrite site_srl (deprecated)
 		$this->module_info->site_srl = $site_module_info->site_srl;
 


### PR DESCRIPTION
관리자 페이지에서 모듈의 컬러 설정이 처음에 안먹는 문제가 있어서 고쳤습니다.
#1979 에서 발견한 버그를 해결하는 PR입니다.

해당 부분에 그래도 컬러세팅이 필요한 이유는 그래도 도메인별로 작동하는 옵션인데 관리자 페이지에서조차 변경이 안되고 있고, 특히나 관리자 페이지에서는 항상 글들의 내용이나 사진 여부 등등을 화이트배경의 기준으로 확인해며 글을 작성할 수 있도록 해야 실제 페이지에서 출력되는 항목과 동일하게 볼수 있으므로 해당 배경색깔을 사이트 설정에 맞게 설정하는 것이 필요하다고 생각합니다.
