### PR TITLE
dispDocumentAdminList의 member_nick_neme 변수명 오타 수정

### DIFF
--- a/modules/document/document.admin.view.php
+++ b/modules/document/document.admin.view.php
@@ -40,7 +40,7 @@ class documentAdminView extends document
 		$args->page = Context::get('page'); // /< Page
 		$args->list_count = 30; // /< the number of posts to display on a single page
 		$args->page_count = 5; // /< the number of pages that appear in the page navigation
-
+		
 		$args->search_target = Context::get('search_target'); // /< search (title, contents ...)
 		$args->search_keyword = Context::get('search_keyword'); // /< keyword to search
 		if ($args->search_target === 'member_srl')
@@ -56,7 +56,7 @@ class documentAdminView extends document
 		$args->sort_index = 'list_order'; // /< sorting value
 		$args->module_srl = Context::get('module_srl');
 		$args->statusList = array($this->getConfigStatus('public'), $this->getConfigStatus('secret'), $this->getConfigStatus('temp'));
-
+		
 		// get a list
 		$oDocumentModel = getModel('document');
 		$columnList = array('document_srl', 'module_srl', 'category_srl', 'member_srl', 'title', 'nick_name', 'comment_count', 'trackback_count', 'readed_count', 'voted_count', 'blamed_count', 'regdate', 'ipaddress', 'status');
@@ -104,7 +104,7 @@ class documentAdminView extends document
 			}
 		}
 		Context::set('module_list', $module_list);
-
+		
 		// Get anonymous nicknames
 		$anonymous_member_srls = array();
 		foreach($output->data as $oDocument)
@@ -176,7 +176,7 @@ class documentAdminView extends document
 		$args->list_count = 20; // /< the number of posts to display on a single page
 		$args->page_count = 10; // /< the number of pages that appear in the page navigation
 		$args->order_type = strtolower(Context::get('order_type')) === 'asc' ? 'asc' : 'desc';
-
+		
 		// select sort method
 		$sort_index = Context::get('sort_index');
 		if (!in_array($sort_index, array('declared_latest', 'declared_count', 'regdate')))
@@ -184,7 +184,7 @@ class documentAdminView extends document
 			$sort_index = 'declared_latest';
 		}
 		Context::set('sort_index', $sort_index);
-
+		
 		// get latest declared list
 		if ($sort_index === 'declared_latest')
 		{
@@ -325,7 +325,7 @@ class documentAdminView extends document
 		}
 		else
 		{
-			$aliases = $output->data;
+			$aliases = $output->data; 
 		}
 
 		Context::set('aliases', $aliases);

--- a/modules/document/document.admin.view.php
+++ b/modules/document/document.admin.view.php
@@ -40,7 +40,7 @@ class documentAdminView extends document
 		$args->page = Context::get('page'); // /< Page
 		$args->list_count = 30; // /< the number of posts to display on a single page
 		$args->page_count = 5; // /< the number of pages that appear in the page navigation
-		
+
 		$args->search_target = Context::get('search_target'); // /< search (title, contents ...)
 		$args->search_keyword = Context::get('search_keyword'); // /< keyword to search
 		if ($args->search_target === 'member_srl')
@@ -56,7 +56,7 @@ class documentAdminView extends document
 		$args->sort_index = 'list_order'; // /< sorting value
 		$args->module_srl = Context::get('module_srl');
 		$args->statusList = array($this->getConfigStatus('public'), $this->getConfigStatus('secret'), $this->getConfigStatus('temp'));
-		
+
 		// get a list
 		$oDocumentModel = getModel('document');
 		$columnList = array('document_srl', 'module_srl', 'category_srl', 'member_srl', 'title', 'nick_name', 'comment_count', 'trackback_count', 'readed_count', 'voted_count', 'blamed_count', 'regdate', 'ipaddress', 'status');
@@ -104,7 +104,7 @@ class documentAdminView extends document
 			}
 		}
 		Context::set('module_list', $module_list);
-		
+
 		// Get anonymous nicknames
 		$anonymous_member_srls = array();
 		foreach($output->data as $oDocument)
@@ -121,14 +121,14 @@ class documentAdminView extends document
 			$member_output = executeQueryArray('member.getMembers', $member_args);
 			if($member_output)
 			{
-				$member_nick_neme = array();
+				$member_nick_name = array();
 				foreach($member_output->data as $member)
 				{
-					$member_nick_neme[$member->member_srl] = $member->nick_name;
+					$member_nick_name[$member->member_srl] = $member->nick_name;
 				}
 			}
 		}
-		Context::set('member_nick_name', $member_nick_neme);
+		Context::set('member_nick_name', $member_nick_name);
 
 		$security = new Security();
 		$security->encodeHTML('search_target', 'search_keyword');
@@ -176,7 +176,7 @@ class documentAdminView extends document
 		$args->list_count = 20; // /< the number of posts to display on a single page
 		$args->page_count = 10; // /< the number of pages that appear in the page navigation
 		$args->order_type = strtolower(Context::get('order_type')) === 'asc' ? 'asc' : 'desc';
-		
+
 		// select sort method
 		$sort_index = Context::get('sort_index');
 		if (!in_array($sort_index, array('declared_latest', 'declared_count', 'regdate')))
@@ -184,7 +184,7 @@ class documentAdminView extends document
 			$sort_index = 'declared_latest';
 		}
 		Context::set('sort_index', $sort_index);
-		
+
 		// get latest declared list
 		if ($sort_index === 'declared_latest')
 		{
@@ -325,7 +325,7 @@ class documentAdminView extends document
 		}
 		else
 		{
-			$aliases = $output->data; 
+			$aliases = $output->data;
 		}
 
 		Context::set('aliases', $aliases);


### PR DESCRIPTION
- document 모듈의 dispDocumentAdminList의 변수명 오타 `member_nick_neme`을 `member_nick_name`으로 수정합니다.
- 오타가 있는 상태로도 정상 동작하지만, 오타 수정을 통해 향후 유지보수성을 개선할 수 있다고 생각되어 PR을 작성합니다.