### PR TITLE
autoinstall 모듈에서 count(null) 에러 수정

### DIFF
--- a/modules/autoinstall/autoinstall.admin.view.php
+++ b/modules/autoinstall/autoinstall.admin.view.php
@@ -342,10 +342,10 @@ class autoinstallAdminView extends autoinstall
 		$buff = FileHandler::getRemoteResource($config->download_server, $body, 3, "POST", "application/xml", array(), array(), array(), $request_config);
 		$xml_lUpdate = new XeXmlParser();
 		$xmlDoc = $xml_lUpdate->parse($buff);
+		$res = array();
 		if($xmlDoc && $xmlDoc->response->packagelist->item)
 		{
 			$item_list = $this->rearranges($xmlDoc->response->packagelist->item, $package_list);
-			$res = array();
 			foreach($package_list as $package_srl => $package)
 			{
 				if($item_list[$package_srl])


### PR DESCRIPTION
dispAutoinstallAdminInstalledPackages() 에서 $buff가 비어있을 경우, $xmlDoc이 null이 되어 if문 안에있는 $res가 선언되지 않는 문제가 있습니다.

이때 if문 밖에 있는 count 함수 인자에 null이 들어가 PHP 8.1에서 에러가 발생하여. $res를 if문과 상관없이 선언하도록 패치하였습니다.