### PR TITLE
소셜로그인에 필요한 코드들을 추가

### DIFF
--- a/layouts/xedition/layout.html
+++ b/layouts/xedition/layout.html
@@ -153,6 +153,7 @@
 <load target="./css/webfont.css" />
 <load target="./css/xeicon.css" cond="$mid === 'xeicon'" />
 <load target="../../common/xeicon/xeicon.min.css" />
+<load target="../../modules/sociallogin/skins/default/css/default.css" />
 <!--// JS -->
 <load cond="$_enable_slide" target="./js/idangerous.swiper.min.js" />
 <load target="./js/layout.js" />
@@ -494,6 +495,11 @@
 				</fieldset>
 			</form>
 		</div>
+		<!--@if(class_exists('SocialloginModel'))-->
+		<!--@if(!$is_logged && SocialloginModel::isEnabled())-->
+		{SocialloginModel::getSocialloginButtons()}
+		<!--@end-->
+		<!--@end-->
 		<div class="login-footer">
 			<a href="{getUrl('act', 'dispMemberFindAccount')}">{$lang->cmd_find_member_account}</a>
 			<span class="f_bar">|</span>

--- a/modules/member/member.controller.php
+++ b/modules/member/member.controller.php
@@ -652,9 +652,10 @@ class memberController extends member
 		// Extract the necessary information in advance
 		$getVars = array();
 		$use_phone = false;
+		$oSocialData = SocialloginModel::getSocialSignUpUserData();
 		if($config->signupForm)
 		{
-			foreach($config->signupForm as $formInfo)
+			foreach($config->signupForm as $key => $formInfo)
 			{
 				if($formInfo->name === 'phone_number' && $formInfo->isUse)
 				{
@@ -663,6 +664,14 @@ class memberController extends member
 				if($formInfo->isUse || $formInfo->required || $formInfo->mustRequired)
 				{
 					$getVars[] = $formInfo->name;
+				}
+				
+				if($oSocialData)
+				{
+					if($formInfo->name == 'user_id')
+					{
+						unset($config->signupForm[$key]);
+					}
 				}
 			}
 		}
@@ -702,6 +711,14 @@ class memberController extends member
 		$args->allow_mailing = Context::get('allow_mailing');
 		$args->allow_message = Context::get('allow_message');
 		if($args->password1) $args->password = $args->password1;
+		
+		/** @var SocialloginController $oSocialLoginController */
+		$oSocialLoginController = SocialloginController::getInstance();
+		if($oSocialData)
+		{
+			$args = $oSocialLoginController->replaceSignUpFormBySocial($args);
+			Context::set('password2', $args->password);
+		}
 		
 		// Check all required fields
 		$output = $this->_checkSignUpFields($config, $args, 'insert');
@@ -1100,22 +1117,46 @@ class memberController extends member
 		// Extract the necessary information in advance
 		$current_password = trim(Context::get('current_password'));
 		$password = trim(Context::get('password1'));
+		$password2 = trim(Context::get('password2'));
+		
+		if($password === '' || $password2 === '')
+		{
+			throw new \Rhymix\Framework\Exception('msg_need_input_password');
+		}
+		
+		if($password !== $password2)
+		{
+			throw new \Rhymix\Framework\Exception('msg_not_equal_password');
+		}
 		// Get information of logged-in user
-		$logged_info = Context::get('logged_info');
-		$member_srl = $logged_info->member_srl;
+		$member_srl = Context::get('logged_info')->member_srl;
 		$member_info = MemberModel::getMemberInfoByMemberSrl($member_srl);
 		// Verify the cuttent password
 		if(!MemberModel::isValidPassword($member_info->password, $current_password, $member_srl)) throw new Rhymix\Framework\Exception('invalid_password');
 
+		if($_SESSION['rechecked_password_modify'] != 'VALIDATE_PASSWORD')
+		{
+			if($current_password === '')
+			{
+				throw new \Rhymix\Framework\Exception('msg_need_current_password');
+			}
+			
+			if(!MemberModel::isValidPassword($member_info->password, $current_password, $member_srl))
+			{
+				throw new Rhymix\Framework\Exception('invalid_password');
+			}
+		}
 		// Check if a new password is as same as the previous password
-		if($current_password == $password) throw new Rhymix\Framework\Exception('invalid_new_password');
-
+		if($current_password === $password) throw new Rhymix\Framework\Exception('invalid_new_password');
+		
 		// Execute insert or update depending on the value of member_srl
 		$args = new stdClass;
 		$args->member_srl = $member_srl;
 		$args->password = $password;
 		$output = $this->updateMemberPassword($args);
 		if(!$output->toBool()) return $output;
+		
+		unset($_SESSION['rechecked_password_modify']);
 		
 		// Log out all other sessions.
 		$member_config = ModuleModel::getModuleConfig('member');

--- a/modules/member/member.view.php
+++ b/modules/member/member.view.php
@@ -215,9 +215,40 @@ class memberView extends member
 		if($member_config->enable_join != 'Y') throw new Rhymix\Framework\Exceptions\FeatureDisabled('msg_signup_disabled');
 		
 		$formTags = getAdminView('member')->_getMemberInputTag();
-		Context::set('formTags', $formTags);
-		Context::set('email_confirmation_required', $member_config->enable_confirm);
-		
+
+		if($_SESSION['tmp_sociallogin_input_add_info'])
+		{
+			foreach ($formTags as $key => $formtag)
+			{
+				if($_SESSION['tmp_sociallogin_input_add_info']['nick_name'])
+				{
+					if($formtag->name == 'user_id')
+					{
+						unset($formTags[$key]);
+					}
+					
+					if($formtag->name == 'user_name')
+					{
+						unset($formTags[$key]);
+					}
+
+					if($formtag->name == 'nick_name')
+					{
+						unset($formTags[$key]);
+					}
+				}
+			}
+		}
+
+		$identifierForm = new stdClass;
+		$identifierForm->title = lang($member_config->identifier);
+		$identifierForm->name = $member_config->identifier;
+		$identifierForm->show = true;
+		if(isset($_SESSION['tmp_sociallogin_input_add_info']['email_address']))
+		{
+			$identifierForm->show = false;
+		}
+
 		// Editor of the module set for signing by calling getEditor
 		foreach($formTags as $formTag)
 		{
@@ -246,12 +277,11 @@ class memberView extends member
 				Context::set('editor', getModel('editor')->getEditor(0, $option));
 			}
 		}
-		
-		$identifierForm = new stdClass;
-		$identifierForm->title = lang($member_config->identifier);
-		$identifierForm->name = $member_config->identifier;
+
+		Context::set('formTags', $formTags);
+		Context::set('email_confirmation_required', $member_config->enable_confirm);
 		Context::set('identifierForm', $identifierForm);
-		
+
 		$this->addExtraFormValidatorMessage();
 		
 		// Set a copy of the agreement for compatibility with old skins
@@ -271,6 +301,11 @@ class memberView extends member
 
 		$_SESSION['rechecked_password_step'] = 'INPUT_PASSWORD';
 
+		if(class_exists('SocialloginModel'))
+		{
+			Context::set('member_sns_list', SocialloginModel::getMemberSnsList(\Rhymix\Framework\Session::getMemberSrl(), 'recheck'));	
+		}
+		
 		$templateFile = $this->getTemplatePath().'rechecked_password.html';
 		if(!is_readable($templateFile))
 		{
@@ -659,6 +694,11 @@ class memberView extends member
 		$member_info = MemberModel::getMemberInfoByMemberSrl($member_srl, 0, $columnList);
 		Context::set('member_info',$member_info);
 
+		if(class_exists('SocialloginModel'))
+		{
+			Context::set('member_sns_list', SocialloginModel::getMemberSnsList(Rhymix\Framework\Session::getMemberSrl(), 'modify_password'));	
+		}
+		
 		if($memberConfig->identifier == 'user_id')
 		{
 			Context::set('identifier', 'user_id');

--- a/modules/member/skins/default/modify_password.html
+++ b/modules/member/skins/default/modify_password.html
@@ -3,7 +3,7 @@
 <div cond="$XE_VALIDATOR_MESSAGE" class="message {$XE_VALIDATOR_MESSAGE_TYPE}">
 	<p>{$XE_VALIDATOR_MESSAGE}</p>
 </div>
-<form ruleset="modifyPassword" id="fo_insert_member" action="./" method="post">
+<form id="fo_insert_member" action="./" method="post">
 	<input type="hidden" name="module" value="member" />
 	<input type="hidden" name="act" value="procMemberModifyPassword" />
     <input type="hidden" name="mid" value="{$mid}" />
@@ -14,15 +14,31 @@
 	<div>
 		<input type="email" disabled="disabled" value="{$formValue}" id="uid" placeholder="{lang($identifier)}" title="{lang($identifier)}" />
 	</div>
+	<!--@if($_SESSION['rechecked_password_modify'] != 'VALIDATE_PASSWORD')-->
 	<div>
-		<input type="password" name="current_password" id="cpw" required placeholder="{$lang->current_password}" title="{$lang->current_password}" />
+		<input type="password" name="current_password" id="cpw"  placeholder="{$lang->current_password}" title="{$lang->current_password}" />
+	</div>
+	<!--@end-->
+	<div>
+		<input type="password" name="password1" id="npw1"  placeholder="{$lang->password1}" title="{$lang->password1}" /> <span class="help-inline">{$lang->about_password_strength[$member_config->password_strength]}</span>
 	</div>
 	<div>
-		<input type="password" name="password1" id="npw1" required placeholder="{$lang->password1}" title="{$lang->password1}" /> <span class="help-inline">{$lang->about_password_strength[$member_config->password_strength]}</span>
-	</div>
-	<div>
-		<input type="password" name="password2" id="npw2" required placeholder="{$lang->password2}" title="{$lang->password2}" />
+		<input type="password" name="password2" id="npw2"  placeholder="{$lang->password2}" title="{$lang->password2}" />
 	</div>
 	<input type="submit" value="{$lang->cmd_registration}" class="btn btn-inverse" style="min-width:220px" />
+	<!--@if($is_logged && SocialloginModel::isEnabled() && $_SESSION['rechecked_password_modify'] != 'VALIDATE_PASSWORD')-->
+	<ul class="rechecked_sns_login">
+		<!--@foreach($member_sns_list as $key => $val)-->
+		<li>
+			<div class="sociallogin_{$val->service}">
+				<a class="loginBtn" href="{$val->auth_url}">
+					<span class="icon"></span>
+					<span class="buttonText">{$val->service} Login</span>
+				</a>
+			</div>
+		</li>
+		<!--@end-->
+	</ul>
+	<!--@end-->
 </form>
 <include target="./common_footer.html" />

--- a/modules/member/skins/default/modify_password.html
+++ b/modules/member/skins/default/modify_password.html
@@ -26,6 +26,7 @@
 		<input type="password" name="password2" id="npw2"  placeholder="{$lang->password2}" title="{$lang->password2}" />
 	</div>
 	<input type="submit" value="{$lang->cmd_registration}" class="btn btn-inverse" style="min-width:220px" />
+	<!--@if(class_exists('SocialloginModel'))-->
 	<!--@if($is_logged && SocialloginModel::isEnabled() && $_SESSION['rechecked_password_modify'] != 'VALIDATE_PASSWORD')-->
 	<ul class="rechecked_sns_login">
 		<!--@foreach($member_sns_list as $key => $val)-->
@@ -39,6 +40,7 @@
 		</li>
 		<!--@end-->
 	</ul>
+	<!--@end-->
 	<!--@end-->
 </form>
 <include target="./common_footer.html" />

--- a/modules/member/skins/default/rechecked_password.html
+++ b/modules/member/skins/default/rechecked_password.html
@@ -16,5 +16,19 @@
 		<input type="password" name="password" required placeholder="{$lang->password}" title="{$lang->password}" />
 		<input type="submit" value="{$lang->cmd_confirm}" class="btn btn-inverse" />
 	</span>
+	<!--@if($is_logged && SocialloginModel::isEnabled())-->
+	<ul class="rechecked_sns_login">
+		<!--@foreach($member_sns_list as $key => $val)-->
+		<li>
+			<div class="sociallogin_{$val->service}">
+				<a class="loginBtn" href="{$val->auth_url}">
+					<span class="icon"></span>
+					<span class="buttonText">{$val->service} Login</span>
+				</a>
+			</div>
+		</li>
+		<!--@end-->
+	</ul>
+	<!--@end-->
 </form>
 <include target="./common_footer.html" />

--- a/modules/member/skins/default/rechecked_password.html
+++ b/modules/member/skins/default/rechecked_password.html
@@ -16,6 +16,7 @@
 		<input type="password" name="password" required placeholder="{$lang->password}" title="{$lang->password}" />
 		<input type="submit" value="{$lang->cmd_confirm}" class="btn btn-inverse" />
 	</span>
+	<!--@if(class_exists('SocialloginModel'))-->
 	<!--@if($is_logged && SocialloginModel::isEnabled())-->
 	<ul class="rechecked_sns_login">
 		<!--@foreach($member_sns_list as $key => $val)-->
@@ -29,6 +30,7 @@
 		</li>
 		<!--@end-->
 	</ul>
+	<!--@end-->
 	<!--@end-->
 </form>
 <include target="./common_footer.html" />

--- a/modules/member/skins/default/signup_form.html
+++ b/modules/member/skins/default/signup_form.html
@@ -27,7 +27,7 @@
 				</label>
 			</div>
 		</div>
-		<div class="control-group">
+		<div class="control-group" cond="$identifierForm->show">
 			<label for="{$identifierForm->name}" class="control-label"><em style="color:red">*</em> {$identifierForm->title}</label>
 			<div class="controls">
 				<input type="text"|cond="$identifierForm->name!='email_address'" type="email"|cond="$identifierForm->name=='email_address'" name="{$identifierForm->name}" id="{$identifierForm->name}" value="" required />
@@ -36,14 +36,14 @@
 				</p>
 			</div>
 		</div>
-		<div class="control-group">
+		<div class="control-group" cond="$identifierForm->show">
 			<label for="password" class="control-label"><em style="color:red">*</em> {$lang->password}</label>
 			<div class="controls">
 				<input type="password" name="password" id="password" value="" required />
 				<p class="help-inline">{$lang->about_password_strength[$member_config->password_strength]}</p>
 			</div>
 		</div>
-		<div class="control-group">
+		<div class="control-group" cond="$identifierForm->show">
 			<label for="password2" class="control-label"><em style="color:red">*</em> {$lang->password3}</label>
 			<div class="controls">
 				<input type="password" name="password2" id="password2" value="" required />


### PR DESCRIPTION
소셜로그인 프로젝트가 분리됨에 따라 관련된 소셜로그인에 필요한 부분을 next브랜치에서 우선 따다가 진행하고 있습니다.

아직 테스트는 완벽하지 않으므로 해당 코드를 이용하여 소셜로그인을 이용하지 않을것을 권장합니다.

현재 PHP8.1 환경에서 테스트하고 잇으며 실사용 서비스에서도 php8.1에서 테스트 예정입니다.

* [ ] 각 서비스 로그인 테스트
* [ ] 클래스 호출 이 안되어서 발생되는 에러 고침
* [x] 스킨상에서  클래스 충돌 문제가 없는지 확인
* [ ] 소셜 로그인 모듈이 설치하지 않더라도, 맴버 모듈의 액션이 실행될때 기존의 라이믹스의 액션이 진행되는지 체크

