### PR TITLE
Fix #1990 게시판 익명 사용 설정 후 기존 글 수정 시 닉네임만 익명이 되는 문제 수정

### DIFF
--- a/modules/board/board.controller.php
+++ b/modules/board/board.controller.php
@@ -99,8 +99,10 @@ class boardController extends board
 		$manual = false;
 		$logged_info = Context::get('logged_info');
 		
-		// Set anonymous information
-		if($this->module_info->use_anonymous == 'Y' && (!$this->grant->manager || ($this->module_info->anonymous_except_admin ?? 'N') !== 'Y'))
+		$oDocument = DocumentModel::getDocument($obj->document_srl);
+
+		// Set anonymous information when insert mode or status is temp
+		if($this->module_info->use_anonymous == 'Y' && (!$this->grant->manager || ($this->module_info->anonymous_except_admin ?? 'N') !== 'Y') && (!$oDocument->isExists() || $oDocument->get('status') == DocumentModel::getConfigStatus('temp')))
 		{
 			if(!$obj->document_srl)
 			{
@@ -118,7 +120,6 @@ class boardController extends board
 		}
 		
 		// Update if the document already exists.
-		$oDocument = DocumentModel::getDocument($obj->document_srl);
 		if($oDocument->isExists())
 		{
 			if(!$oDocument->isGranted())


### PR DESCRIPTION
Fix https://github.com/rhymix/rhymix/issues/1990 글 작성 또는 임시 문서 수정 때만 익명 정보를 생성합니다.