### PR TITLE
게시물 신고 후 새로고침 되지 않는 문제 수정

### DIFF
--- a/modules/comment/comment.item.php
+++ b/modules/comment/comment.item.php
@@ -406,6 +406,44 @@ class commentItem extends BaseObject
 		return $_SESSION['voted_comment'][$this->comment_srl] = false;
 	}
 
+	function getDeclared()
+	{
+		if (!$this->isExists())
+		{
+			return false;
+		}
+
+		$logged_info = Context::get('logged_info');
+		if (!$logged_info->member_srl)
+		{
+			return false;
+		}
+
+		if (isset($_SESSION['declared_comment'][$this->comment_srl]))
+		{
+			return $_SESSION['declared_comment'][$this->comment_srl];
+		}
+		
+		$args = new stdClass();
+		if ($logged_info->member_srl)
+		{
+			$args->member_srl = $logged_info->member_srl;
+		}
+		else
+		{
+			$args->ipaddress = \RX_CLIENT_IP;
+		}
+		$args->comment_srl = $this->comment_srl;
+		$output = executeQuery('comment.getCommentDeclaredLogInfo', $args);
+		$declared_count = isset($output->data) ? intval($output->data->count) : 0;
+		if ($declared_count > 0)
+		{
+			return $_SESSION['declared_comment'][$this->comment_srl] = $declared_count;
+		}
+		
+		return false;
+	}
+
 	function getContentPlainText($strlen = 0)
 	{
 		if($this->isDeletedByAdmin())

--- a/modules/comment/comment.model.php
+++ b/modules/comment/comment.model.php
@@ -47,21 +47,36 @@ class commentModel extends comment
 			$oComment = self::getComment($comment_srl, FALSE, $columnList);
 			$module_srl = $oComment->get('module_srl');
 			$member_srl = abs($oComment->get('member_srl'));
+			if(!$module_srl) throw new Rhymix\Framework\Exceptions\InvalidRequest;
 
-			$comment_config = ModuleModel::getModulePartConfig('document', $module_srl);
-
+			$comment_config = ModuleModel::getModulePartConfig('comment', $module_srl);
+			$oCommentisVoted = $oComment->getMyVote();
 			if($comment_config->use_vote_up != 'N' && $member_srl != $this->user->member_srl)
 			{
-				// Add a vote-up button for positive feedback
-				$url = sprintf("doCallModuleAction('comment','procCommentVoteUp','%s')", $comment_srl);
-				$oCommentController->addCommentPopupMenu($url, 'cmd_vote', '', 'javascript');
+				if($oCommentisVoted === false || $oCommentisVoted < 0)
+				{
+					$url = sprintf("doCallModuleAction('comment','procCommentVoteUp','%s')", $comment_srl);
+					$oCommentController->addCommentPopupMenu($url, 'cmd_vote', '', 'javascript');
+				}
+				elseif($oCommentisVoted > 0)
+				{
+					$url = sprintf("doCallModuleAction('comment','procCommentVoteUpCancel','%s')", $comment_srl);
+					$oCommentController->addCommentPopupMenu($url, 'cmd_cancel_vote', '', 'javascript');
+				}
 			}
 
 			if($comment_config->use_vote_down != 'N' && $member_srl != $this->user->member_srl)
 			{
-				// Add a vote-down button for negative feedback
-				$url = sprintf("doCallModuleAction('comment','procCommentVoteDown','%s')", $comment_srl);
-				$oCommentController->addCommentPopupMenu($url, 'cmd_vote_down', '', 'javascript');
+				if($oCommentisVoted === false || $oCommentisVoted > 0)
+				{
+					$url = sprintf("doCallModuleAction('comment','procCommentVoteDown','%s')", $comment_srl);
+					$oCommentController->addCommentPopupMenu($url, 'cmd_vote_down', '', 'javascript');
+				}
+				else if($oCommentisVoted < 0)
+				{
+					$url = sprintf("doCallModuleAction('comment','procCommentVoteDownCancel','%s')", $comment_srl);
+					$oCommentController->addCommentPopupMenu($url,'cmd_cancel_vote_down','','javascript');
+				}
 			}
 
 			// Add the report feature against abused posts

--- a/modules/comment/conf/module.xml
+++ b/modules/comment/conf/module.xml
@@ -12,6 +12,7 @@
 		<action name="procCommentVoteDown" type="controller" />
 		<action name="procCommentVoteDownCancel" type="controller" />
 		<action name="procCommentDeclare" type="controller" permission="member" />
+		<action name="procCommentDeclareCancel" type="controller" permission="member" />
 		<action name="procCommentGetList" type="controller" permission="manager" check_type="comment" check_var="comment_srls" />
 		<action name="procCommentInsertModuleConfig" type="controller" permission="manager" check_var="target_module_srl" ruleset="insertCommentModuleConfig" />
 		

--- a/modules/comment/queries/updateDeclaredCommentCancel.xml
+++ b/modules/comment/queries/updateDeclaredCommentCancel.xml
@@ -1,0 +1,11 @@
+<query id="updateDeclaredCommentCancel" action="update">
+	<tables>
+		<table name="comment_declared" />
+	</tables>
+	<columns>
+		<column name="declared_count" default="minus(1)" />
+	</columns>
+	<conditions>
+		<condition operation="equal" column="comment_srl" var="comment_srl" filter="number" notnull="notnull" />
+	</conditions>
+</query>

--- a/modules/comment/tpl/declare_comment.html
+++ b/modules/comment/tpl/declare_comment.html
@@ -2,9 +2,13 @@
 <load target="./css/declare_comment.css" />
 <form action="./" method="post" id="fo_component" ruleset="insertDeclare">
 	<input type="hidden" name="module" value="comment" />
+	<!--@if($type == 'cancel')-->
+	<input type="hidden" name="act" value="procCommentDeclareCancel" />
+	<!--@else-->
 	<input type="hidden" name="act" value="procCommentDeclare" />
+	<!--@end-->
 	<input type="hidden" name="target_srl" value="{$target_srl}" />
-	<input type="hidden" name="success_return_url" value="{getUrl('', 'act', $act, 'target_srl', $target_srl)}" />
+	<input type="hidden" name="success_return_url" value="{getUrl('', 'mid', $mid, 'act', $act, 'target_srl', $target_srl)}" />
 	<input type="hidden" name="xe_validator_id" value="modules/comment/tpl/1" />
 	<div class="x_modal-header">
 		<h1>{$lang->improper_comment_declare} <!--@if($type == 'cancel')-->{$lang->cmd_cancel}<!--@end--></h1>
@@ -16,6 +20,7 @@
 				<p>{$target_comment->getSummary(200)}</p>
 			</section>
 		</blockquote>
+		<!--@if($type !== 'cancel')-->
 		<div class="x_control-group">
 			<label class="x_control-label" for="message_option">{$lang->improper_comment_declare_reason}</label>
 			<div class="x_controls">
@@ -26,16 +31,20 @@
 				<p>{$lang->about_improper_comment_declare}<p>
 			</div>
 		</div>
+		<!--@end-->
 		<div class="x_modal-footer">
 			<span class="x_btn-group x_pull-right">
-				<button type="submit" class="x_btn x_btn-primary">{$lang->cmd_submit}</button>
+				<button type="submit" class="x_btn x_btn-primary"><!--@if($type == 'cancel')-->{$lang->cmd_cancel_declare}<!--@else-->{$lang->cmd_submit}<!--@end--></button>
 			</span>
 		</div>
 	</div>
 </form>
 <script cond="$XE_VALIDATOR_MESSAGE && $XE_VALIDATOR_ID == 'modules/comment/tpl/1'">
 	alert("{$XE_VALIDATOR_MESSAGE}");
-	window.close();
+	if (opener) {
+		opener.location.reload();
+		window.close();
+	}
 </script>
 <script>
 	(function($){

--- a/modules/document/tpl/declare_document.html
+++ b/modules/document/tpl/declare_document.html
@@ -42,7 +42,7 @@
 <script cond="$XE_VALIDATOR_MESSAGE && $XE_VALIDATOR_ID == 'modules/document/tpl/1'">
 	alert("{$XE_VALIDATOR_MESSAGE}");
 	if (opener) {
-		opener.location.href = opener.location.href;
+		opener.location.reload();
 		window.close();
 	}
 </script>

--- a/modules/document/tpl/declare_document.html
+++ b/modules/document/tpl/declare_document.html
@@ -41,7 +41,10 @@
 </form>
 <script cond="$XE_VALIDATOR_MESSAGE && $XE_VALIDATOR_ID == 'modules/document/tpl/1'">
 	alert("{$XE_VALIDATOR_MESSAGE}");
-	window.close();
+	if (opener) {
+		opener.location.href = opener.location.href;
+		window.close();
+	}
 </script>
 <script>
 	(function($){


### PR DESCRIPTION
- 기존 페이지가 갱신 되어야 더보기에서 신고 취소가 즉시 가능합니다.
- 댓글 신고의 경우 페이지가 갱신되고 있습니다.