### PR TITLE
#2011 을 위한 PR, 다국어 지원을 위한 파일 불러오기인지 먼저 확인합니다.

### DIFF
--- a/classes/template/TemplateHandler.class.php
+++ b/classes/template/TemplateHandler.class.php
@@ -876,6 +876,13 @@ class TemplateHandler
 
 					if(!$isRemote)
 					{
+						if(substr($attr['target'], -5) == '/lang')
+						{
+							$pathinfo['dirname'] .= '/lang';
+							$pathinfo['basename'] = '';
+							$pathinfo['extension'] = 'xml';
+						}
+                        
 						if (preg_match('!^\\^/(.+)!', $attr['target'], $tmatches))
 						{
 							$pathinfo = pathinfo($tmatches[1]);
@@ -890,13 +897,6 @@ class TemplateHandler
 							}
 							$relativeDir = $this->_getRelativeDir($pathinfo['dirname']);
 							$attr['target'] = $relativeDir . '/' . $pathinfo['basename'];
-						}
-						
-						if(substr($attr['target'], -5) == '/lang')
-						{
-							$pathinfo['dirname'] .= '/lang';
-							$pathinfo['basename'] = '';
-							$pathinfo['extension'] = 'xml';
 						}
 					}
 


### PR DESCRIPTION
주요 수정 내용: 코드의 순서를 바꾸었습니다. 템플릿 코드에서 파일을 불러올 때, 디렉토리 경로가 복잡한 경우 정리하게 됩니다. 하지만, 디렉토리를 정리하기 전에 다국어 지원을 위한 파일인지 먼저 확인합니다.

이를 통해 기대되는 내용: https://github.com/rhymix/rhymix/issues/2011 이슈를 해결합니다.