### PR TITLE
회원가입 설정 다국어 표시 문제 수정

### DIFF
--- a/modules/member/member.model.php
+++ b/modules/member/member.model.php
@@ -134,7 +134,8 @@ class memberModel extends member
 		{
 			if($value->isDefaultForm && empty($value->isCustomTitle))
 			{
-				$config->signupForm[$key]->title = lang($value->name);
+				$title = in_array($value->name, ['signature', 'profile_image', 'image_name', 'image_mark']) ? 'member.' . $value->name : $value->name;
+				$config->signupForm[$key]->title = lang($title);
 			}
 			$config->signupForm[$key]->isPublic = $config->signupForm[$key]->isPublic ?? 'Y';
 		}

--- a/modules/member/tpl/signup_config.html
+++ b/modules/member/tpl/signup_config.html
@@ -21,7 +21,7 @@
 		<label class="x_control-label" for="limit_day">{$lang->limit_day}</label>
 		<div class="x_controls">
 			<input type="number" min="0" id="limit_day" name="limit_day" value="{$config->limit_day}" /> {$lang->unit_day}
-			<input type="text" name="limit_day_description" value="{$config->limit_day_description}" placeholder="{$lang->limit_day_description}" style="width:90%" class="lang_code" />
+			<input type="text" name="limit_day_description" value="{escape($config->limit_day_description)}" placeholder="{$lang->limit_day_description}" style="width:90%" class="lang_code" />
 			<p class="x_help-block">{$lang->about_limit_day}</p>
 		</div>
 	</div>
@@ -122,7 +122,7 @@
 							<div class="wrap">
 								<button type="button" class="dragBtn">Move to</button>
 								<!--@if(in_array($item->name, ['birthday', 'signature', 'profile_image', 'image_name', 'image_mark']))-->
-									<input class="_title_edit lang_code" type="text" name="{$item->name}_title_edit" value="{$item->title}" placeholder="{lang($item->name)}" />
+									<input class="_title_edit lang_code" type="text" name="{$item->name}_title_edit" value="{escape($item->title)}" placeholder="{lang($item->name)}" />
 								<!--@else-->
 									<span class="_title" style="display:inline-block;white-space:pre-line;overflow:inherit;width:120px;text-overflow:ellipsis" title="{$item->title}">{$item->title}</span>
 								<!--@endif-->


### PR DESCRIPTION
- signature, profile_image, image_name, image_mark 기본 가입 폼 언어 적용 오류
![image](https://user-images.githubusercontent.com/60457472/203288724-19287c14-85f6-4ff1-a4c8-9ac5f9824a2f.png)
- static이라 member lang이 로드 되지 않아 생기는 문제입니다.

- 가입 폼 다국어 설정 표시 안 되는 오류
- 임시 제한 일자 설명 다국어 설정 표시 안 되는 오류