### PR TITLE
회원가입 약관 다국어 기능 추가

### DIFF
--- a/modules/member/member.admin.controller.php
+++ b/modules/member/member.admin.controller.php
@@ -328,6 +328,10 @@ class memberAdminController extends member
 		$config = new stdClass;
 		$config->agreements = array();
 		$config->agreement = null;
+
+		$config_agreements = memberModel::getMemberConfig()->agreements;
+		$lang_type = Context::get('lang_type');
+		$default_lang = config('locale.default_lang') ?: 'ko';
 		
 		$args = Context::getRequestVars();
 		for ($i = 1; $i < 20; $i++)
@@ -335,8 +339,15 @@ class memberAdminController extends member
 			if (isset($args->{'agreement_' . $i . '_type'}))
 			{
 				$agreement = new stdClass;
-				$agreement->title = escape(utf8_trim($args->{'agreement_' . $i . '_title'}));
-				$agreement->content = $args->{'agreement_' . $i . '_content'};
+				$agreement->title = escape(utf8_trim($args->{'agreement_' . $i . '_title'}), true, true);
+				$agreement_content = $args->{'agreement_' . $i . '_content'};
+				if ($agreement_content)
+				{
+					$agreement->multilingual = $config_agreements[$i]->multilingual ?? array();
+					$agreement->multilingual[$lang_type] = new stdClass;
+					$agreement->multilingual[$lang_type]->content = $agreement_content;
+				}
+				$agreement->content = $agreement->multilingual[$default_lang]->content ?: $agreement_content;
 				$agreement->use_editor = $args->use_editor;
 				getModel('editor')->converter($agreement, 'document');
 				$agreement->type = $args->{'agreement_' . $i . '_type'};

--- a/modules/member/member.model.php
+++ b/modules/member/member.model.php
@@ -69,6 +69,13 @@ class memberModel extends member
 			$config->agreements[1]->type = !empty($config->agreements[1]->content) ? 'required' : 'disabled';
 		}
 		unset($config->agreement);
+		foreach($config->agreements as $key => $val)
+		{
+			if (isset($val->multilingual[Context::get('lang_type')]->content))
+			{
+				$config->agreements[$key]->content = $val->multilingual[Context::get('lang_type')]->content;
+			}
+		}
 		
 		// Set signup config
 		$config->limit_day = $config->limit_day ?? 0;

--- a/modules/member/tpl/agreements_config.html
+++ b/modules/member/tpl/agreements_config.html
@@ -12,7 +12,7 @@
 		<div class="x_control-group">
 			<div class="x_control-label" for="agreement_{$i}_title">{$lang->cmd_agreement_title}</div>
 			<div class="x_controls">
-				<input type="text" name="agreement_{$i}_title" id="agreement_{$i}_title" value="{$config->agreements[$i]->title}" />
+				<input type="text" name="agreement_{$i}_title" id="agreement_{$i}_title" value="{escape($config->agreements[$i]->title)}" class="lang_code" />
 			</div>
 		</div>
 		<div class="x_control-group">


### PR DESCRIPTION
- 약관 제목, 약관 내용에 다국어 기능을 추가합니다.
- 약관 내용은 언어 변경 후 작성하면 해당 언어로 작성됩니다.
- 기존 xe 약관은 파일 형식으로 저장되었으나 다국어 지원이 되었습니다.
- 문서 모듈과 연동으로 다국어 지원이 가능하나 불필요한 문서가 생성되어 config 내부 저장 방식으로 하였습니다.