### PR TITLE
PageHandler의 Iterator 구현

### DIFF
--- a/classes/page/PageHandler.class.php
+++ b/classes/page/PageHandler.class.php
@@ -10,16 +10,28 @@
  * @remarks Getting total counts, number of pages, current page number, number of items per page, 
  *          this class implements methods and contains variables for page navigation
  */
-class PageHandler extends Handler
+class PageHandler extends Handler implements Iterator
 {
-
-	var $total_count = 0; ///< number of total items
-	var $total_page = 0; ///< number of total pages
-	var $cur_page = 0; ///< current page number
-	var $page_count = 10; ///< number of page links displayed at one time
-	var $first_page = 1; ///< first page number
-	var $last_page = 1; ///< last page number
-	var $point = 0; ///< increments per getNextPage() 
+	/** @var int Number of total items */
+	public $total_count = 0;
+	
+	/** @var int Number of total pages */
+	public $total_page = 0;
+	
+	/** @var int Current page number */
+	public $cur_page = 0;
+	
+	/** @var int Number of page links displayed at one time. */
+	public $page_count = 10;
+	
+	/** @var int First page number */
+	public $first_page = 1;
+	
+	/** @var int Last page number, same as $total_page */
+	public $last_page = 1;
+	
+	/** @var int Iterator stepper */
+	var $point = 0;
 
 	/**
 	 * constructor
@@ -30,7 +42,7 @@ class PageHandler extends Handler
 	 * @return void
 	 */
 
-	function __construct($total_count, $total_page, $cur_page, $page_count = 10)
+	public function __construct(int $total_count, int $total_page, int $cur_page, int $page_count = 10)
 	{
 		$this->total_count = $total_count;
 		$this->total_page = $total_page;
@@ -49,14 +61,8 @@ class PageHandler extends Handler
 			$first_page -= $first_page + $page_count - 1 - $total_page;
 		}
 
-		$last_page = $total_page;
-		if($last_page > $total_page)
-		{
-			$last_page = $total_page;
-		}
-
 		$this->first_page = $first_page;
-		$this->last_page = $last_page;
+		$this->last_page = $total_page;
 
 		if($total_page < $this->page_count)
 		{
@@ -68,7 +74,7 @@ class PageHandler extends Handler
 	 * request next page
 	 * @return int next page number
 	 */
-	function getNextPage()
+	public function getNextPage(): int
 	{
 		$page = $this->first_page + $this->point++;
 		if($this->point > $this->page_count || $page > $this->last_page)
@@ -83,11 +89,56 @@ class PageHandler extends Handler
 	 * @param int $offset
 	 * @return int
 	 */
-	function getPage($offset)
+	public function getPage(int $offset): int
 	{
 		return max(min($this->cur_page + $offset, $this->total_page), '');
 	}
 
+	/**
+	 * Rewind iterator stepper.
+	 * @return void
+	 */
+	public function rewind ()
+	{
+		$this->point = 0;
+	}
+
+	/**
+	 * Determine if a current iterated item is valid.
+	 * @return bool
+	 */
+	public function valid (): bool
+	{
+		$page = $this->first_page + $this->point;
+		return $this->point <= $this->page_count && $page <= $this->last_page;
+	}
+
+	/**
+	 * Get a current iterated page number.
+	 * @return int
+	 */
+	public function current (): int
+	{
+		return $this->first_page + $this->point;
+	}
+
+	/**
+	 * Get a current iterator stepper.
+	 * @return int
+	 */
+	public function key (): int
+	{
+		return $this->point;
+	}
+
+	/**
+	 * Step up the iterator.
+	 * @return void
+	 */
+	public function next ()
+	{
+		$this->point++;
+	}
 }
 /* End of file PageHandler.class.php */
 /* Location: ./classes/page/PageHandler.class.php */


### PR DESCRIPTION
```php
// Old
while ($page_no = $page_navigation->getNextPage()) {}

// New
foreach ($page_navigation as $page_no) {}
```

이외에도 자잘한 구형 문법을 업데이트하고, 주석을 약간 정리했습니다.
34L의 `var $point`는 혹여나 하위호환성을 깰까봐 private 처리하지는 못했고,
그렇다고 public 을 붙이기엔 public 한 용도로 사용되는 변수가 아니라 혼동을 끼칠까 현행 유지했습니다.

52~59L은 의미없는 조건문이라 축약했습니다.
논리적으론 52L만 빠지는게 맞을 것 같은데, 13년도부터 이어져온 코드라 하위호환성 문제로 현행 유지했습니다.

두 자잘한 수정 모두 기능상 차이도 없고, 유의미한 사이드이펙트를 일으키지도 않으므로 동일 커밋으로 작성했습니다.