### PR TITLE
다음 우편주소 API 도메인 변경

### DIFF
--- a/modules/krzip/tpl/template.daumapi.html
+++ b/modules/krzip/tpl/template.daumapi.html
@@ -1,8 +1,8 @@
 <!--// 다음 우편번호 API -->
 <!--// HEADER -->
 <load target="./css/default.css" />
-<load target="http://dmaps.daum.net/map_js_init/postcode.v2.js" cond="!\RX_SSL" />
-<load target="https://spi.maps.daum.net/imap/map_js_init/postcode.v2.js" cond="\RX_SSL" />
+<load target="http://t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js" cond="!\RX_SSL" />
+<load target="https://t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js" cond="\RX_SSL" />
 <load target="./js/daumapi.js" />
 
 <!--// BODY -->


### PR DESCRIPTION
https://github.com/daumPostcode/QnA/issues/987

> 이외, 기존의 legacy 도메인을 이용하시고 계신 경우엔, 현재 이 서버들의 동작을 완벽히 보장 할 수 없기 때문에
> 최신 JS API URL로 변경 부탁드립니다.
> 이 legacy 도메인들의 경우 21년도 3월달부터 공식 가이드페이지에서는 삭제됬고, 내년 초쯤에 리소스까지 모두 삭제할 계획은 있었습니다만, 주> 말부터 비롯된 장애로 인해 의도치 않게 빠른 교체를 권유하고 있습니다.