### PR TITLE
Add devcontainer config files for codespace

### DIFF
--- a/.devcontainer/apache/devcontainer.json
+++ b/.devcontainer/apache/devcontainer.json
@@ -1,0 +1,14 @@
+{
+	"name": "Rhymix with Apache",
+	"image": "mcr.microsoft.com/devcontainers/base:focal",
+	"features": {
+		"ghcr.io/rocker-org/devcontainer-features/apt-packages:1": {
+			"packages": "apache2, mariadb-client, mariadb-server, php7.4, php7.4-curl, php7.4-gd, php7.4-mbstring, php7.4-json, php7.4-mysql, php7.4-xml, php7.4-opcache, php7.4-apcu, php7.4-intl, php7.4-zip",
+			"upgradePackages": false
+		}
+	},
+	"forwardPorts": [80],
+	"postCreateCommand": "sudo bash $PWD/.devcontainer/init.sh && sudo bash $PWD/.devcontainer/apache/init.sh",
+	"postStartCommand": "sudo bash $PWD/.devcontainer/apache/start.sh",
+	"waitFor": "postStartCommand"
+}

--- a/.devcontainer/apache/init.sh
+++ b/.devcontainer/apache/init.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# stop apache to update config
+service apache2 stop
+
+# link repo to /var/www/ to access from web
+ln -s /workspaces /var/www/
+
+# set apache2 config
+cp -f $PWD/.devcontainer/apache/web.conf /etc/apache2/sites-enabled/000-default.conf
+sed -i "s/REPO_NAME/$RepositoryName/g" /etc/apache2/sites-enabled/000-default.conf
+
+# enable rewrite
+a2enmod rewrite

--- a/.devcontainer/apache/start.sh
+++ b/.devcontainer/apache/start.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+service mysql start
+service apache2 start

--- a/.devcontainer/apache/web.conf
+++ b/.devcontainer/apache/web.conf
@@ -1,0 +1,13 @@
+<VirtualHost *:80>
+	ServerAdmin webmaster@localhost
+	DocumentRoot /var/www/workspaces/REPO_NAME
+	DirectoryIndex index.php
+
+	ErrorLog ${APACHE_LOG_DIR}/error.log
+	CustomLog ${APACHE_LOG_DIR}/access.log combined
+
+	<Directory /var/www/workspaces/REPO_NAME>
+		AllowOverride All
+		Require all granted
+	</Directory>
+</VirtualHost>

--- a/.devcontainer/config.php
+++ b/.devcontainer/config.php
@@ -1,0 +1,2 @@
+<?php
+$_SERVER['HTTP_HOST'] = isset($_SERVER['HTTP_X_FORWARDED_HOST']) ? $_SERVER['HTTP_X_FORWARDED_HOST'] : "localhost";

--- a/.devcontainer/init.sh
+++ b/.devcontainer/init.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# remove previous files folder
+rm -rf $PWD/files
+
+# set config
+cp -f $PWD/.devcontainer/config.php $PWD/config/config.user.inc.php
+cp -f $PWD/.devcontainer/install.php $PWD/config/install.config.php
+
+# set domain to proxy one
+cp -f $PWD/.devcontainer/config.php $PWD/config/config.user.inc.php
+
+# create db (only first time)
+service mysql start
+mysql -uroot -proot -e "CREATE DATABASE rhymix CHARSET utf8mb4 COLLATE utf8mb4_unicode_ci"
+mysql -uroot -proot -e "CREATE USER 'rhymix'@localhost IDENTIFIED BY 'rhymix'"
+mysql -uroot -proot -e "GRANT ALL ON rhymix.* to rhymix@localhost; FLUSH PRIVILEGES"

--- a/.devcontainer/install.php
+++ b/.devcontainer/install.php
@@ -1,0 +1,18 @@
+<?php $install_config = array (
+  'db_type' => 'mysql',
+  'db_port' => '3306',
+  'db_hostname' => 'localhost',
+  'db_userid' => 'rhymix',
+  'db_password' => 'rhymix',
+  'db_database' => 'rhymix',
+  'db_table_prefix' => 'rx_auto',
+  'db_charset' => 'utf8',
+  'use_rewrite' => 'Y',
+  'time_zone' => '0900',
+  'email_address' => 'admin@admin.net',
+  'password' => 'admin',
+  'password2' => 'admin',
+  'nick_name' => 'admin',
+  'user_id' => 'admin',
+  'lang_type' => 'ko',
+);

--- a/.devcontainer/nginx/devcontainer.json
+++ b/.devcontainer/nginx/devcontainer.json
@@ -1,0 +1,14 @@
+{
+	"name": "Rhymix with Nginx",
+	"image": "mcr.microsoft.com/devcontainers/base:focal",
+	"features": {
+		"ghcr.io/rocker-org/devcontainer-features/apt-packages:1": {
+			"packages": "nginx, mariadb-client, mariadb-server, php7.4-fpm, php7.4-curl, php7.4-gd, php7.4-mbstring, php7.4-json, php7.4-mysql, php7.4-xml, php7.4-opcache, php7.4-apcu, php7.4-intl, php7.4-zip",
+			"upgradePackages": false
+		}
+	},
+	"forwardPorts": [80],
+	"postCreateCommand": "sudo bash $PWD/.devcontainer/init.sh && sudo bash $PWD/.devcontainer/nginx/init.sh",
+	"postStartCommand": "sudo bash $PWD/.devcontainer/nginx/start.sh",
+	"waitFor": "postStartCommand"
+}

--- a/.devcontainer/nginx/init.sh
+++ b/.devcontainer/nginx/init.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# stop apache to update config
+service nginx stop
+
+# link repo to /var/www/ to access from web
+ln -s /workspaces /var/www/
+
+# set nginx config
+cp -f $PWD/.devcontainer/nginx/web.conf /etc/nginx/sites-enabled/default
+cp -f $PWD/common/manual/server_config/rhymix-nginx.conf /etc/nginx/snippets/rhymix.conf
+sed -i "s/REPO_NAME/$RepositoryName/g" /etc/nginx/sites-enabled/default

--- a/.devcontainer/nginx/start.sh
+++ b/.devcontainer/nginx/start.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+service mysql start
+service nginx start
+service php7.4-fpm start

--- a/.devcontainer/nginx/web.conf
+++ b/.devcontainer/nginx/web.conf
@@ -1,0 +1,19 @@
+server {
+	listen 80 default_server;
+	listen [::]:80 default_server;
+
+	root /var/www/workspaces/REPO_NAME;
+	index index.php;
+	server_name _;
+
+	include snippets/rhymix.conf;
+
+	location ~ \.php$ {
+		include snippets/fastcgi-php.conf;
+		fastcgi_pass unix:/run/php/php7.4-fpm.sock;
+	}
+
+	location ~ /\.ht {
+		deny all;
+	}
+}

--- a/server.php
+++ b/server.php
@@ -1,0 +1,2 @@
+<?php
+print_r($_SERVER);

--- a/server.php
+++ b/server.php
@@ -1,2 +1,0 @@
-<?php
-print_r($_SERVER);


### PR DESCRIPTION
Github Codespace에서 라이믹스를 바로 실행해 볼 수 있도록 구성 파일을 추가합니다.

~~현재 라이믹스에서 프록시가 설정하는 도메인 host를 무시하고 있으므로(80포트 오픈시 내부적으로 프록시를 거칩니다) 수동 설정이 필요한데, `postCreateCommand` 단계에서 도메인 설정시 빈 값이 입력되는 문제점이 있어 codespace 설정후 `.devcontainer/set-domain.sh` 파일을 한번 실행할 필요성이 있습니다.~~ 일단 프록시에서 넘겨주는 값을 설정하는것으로 변경했습니다. 일단 정상적인 프록시 구성의 경우 Host값을 변조해 주므로 코어에 이 헤더를 읽는 부분을 추가할 필요는 없다고 판단했습니다.