### PR TITLE
Add ReturnTypeWillChange attribute to DBHelper methods

### DIFF
--- a/common/framework/helpers/DBHelper.php
+++ b/common/framework/helpers/DBHelper.php
@@ -7,18 +7,19 @@ use Rhymix\Framework\Debug;
 use Rhymix\Framework\Exceptions\DBError;
 
 /**
- * DB helper class.
- * 
- * We use instances of this class instead of raw PDO in order to provide
- * better logging and error handling while keeping backward compatibility.
+ * DB Statement helper class.
+ *
+ * We use instances of this class instead of raw PDOStatement in order to log
+ * individual execute() calls of prepared statements. This is controlled by
+ * the PDO::ATTR_STATEMENT_CLASS attribute set in the DB class.
  */
-class DBHelper extends \PDO
+class DBStmtHelper extends \PDOStatement
 {
 	/**
 	 * Store the database type (e.g. master) here.
 	 */
 	protected $_type = 'master';
-	
+
 	/**
 	 * Set the database type.
 	 */
@@ -26,121 +27,31 @@ class DBHelper extends \PDO
 	{
 		$this->_type = $type;
 	}
-	
+
 	/**
-	 * Create a prepared statement.
-	 * 
-	 * @param string $statement
-	 * @param array $driver_options
-	 * @return PDOStatement|DBStmtHelper
-	 */
-	public function prepare($statement, $driver_options = null)
-	{
-		$start_time = microtime(true);
-		$db_class = DB::getInstance($this->_type);
-		
-		try
-		{
-			/**
-			 * $stmt will be an instance of DBStmtHelper.
-			 * This allows it to track the parent database's type
-			 * and send query logs to the appropriate place.
-			 */
-			$stmt = $driver_options ? parent::prepare($statement, $driver_options) : parent::prepare($statement);
-			$stmt->setFetchMode(\PDO::FETCH_OBJ);
-			$stmt->setType($this->_type);
-			$db_class->clearError();
-		}
-		catch (\PDOException $e)
-		{
-			/**
-			 * We only measure the time when the prepared statement fails.
-			 * If the statement is successfully prepared, time will be measured
-			 * when the statement is executed in DBStmtHelper.
-			 */
-			$elapsed_time = microtime(true) - $start_time;
-			$db_class->addElapsedTime($elapsed_time);
-			$db_class->setError(-1, $e->getMessage());
-			if (Debug::isEnabledForCurrentUser())
-			{
-				Debug::addQuery($db_class->getQueryLog($statement, $elapsed_time));
-			}
-			
-			/**
-			 * This is a new feature in Rhymix 2.0 so we don't have to mess
-			 * with status objects. We just throw an exception. Catch it!
-			 */
-			throw new DBError($e->getMessage(), 0, $e);
-		}
-		
-		return $stmt;
-	}
-	
-	/**
-	 * Execute a query.
-	 * 
-	 * This method accepts additional parameters, but they are not for creating
-	 * prepared statements. They exist because PDO's own query() method accepts
-	 * various kinds of additional parameters, and we don't want to touch them.
-	 * 
-	 * @param string $statement
-	 * @return PDOStatement|DBStmtHelper
-	 */
-	public function query($statement, $fetch_mode = \PDO::FETCH_OBJ, ...$fetch_mode_args)
-	{
-		$start_time = microtime(true);
-		$db_class = DB::getInstance($this->_type);
-		$args = func_get_args();
-		array_shift($args);
-		
-		try
-		{
-			/**
-			 * $stmt will be an instance of DBStmtHelper.
-			 * This allows it to track the parent database's type
-			 * and send query logs to the appropriate place.
-			 */
-			$stmt = parent::query($statement, ...$args);
-			$stmt->setFetchMode($fetch_mode);
-			$stmt->setType($this->_type);
-			$db_class->clearError();
-		}
-		catch (\PDOException $e)
-		{
-			$db_class->setError(-1, $e->getMessage());
-		}
-		finally
-		{
-			$elapsed_time = microtime(true) - $start_time;
-			$db_class->addElapsedTime($elapsed_time);
-			if (Debug::isEnabledForCurrentUser())
-			{
-				Debug::addQuery($db_class->getQueryLog($statement, $elapsed_time));
-			}
-		}
-		
-		return $stmt;
-	}
-	
-	/**
-	 * Execute a query and return the number of affected rows.
-	 * 
-	 * @param string $statement
+	 * Execute a prepared statement.
+	 *
+	 * We don't set a type for $input_parameters because the original
+	 * PDOStatement class accepts both arrays and null. Actually, the null
+	 * value must be omitted altogether or it will throw an error.
+	 *
+	 * @param array $input_parameters
 	 * @return bool
 	 */
-	public function exec($query)
+	public function execute($input_parameters = null): bool
 	{
 		$start_time = microtime(true);
 		$db_class = DB::getInstance($this->_type);
-		
+
 		try
 		{
-			$result = parent::exec($query);
+			$result = parent::execute($input_parameters);
 			$db_class->clearError();
 		}
 		catch (\PDOException $e)
 		{
 			$db_class->setError(-1, $e->getMessage());
+			throw new DBError($e->getMessage(), 0, $e);
 		}
 		finally
 		{
@@ -148,10 +59,10 @@ class DBHelper extends \PDO
 			$db_class->addElapsedTime($elapsed_time);
 			if (Debug::isEnabledForCurrentUser())
 			{
-				Debug::addQuery($db_class->getQueryLog($query, $elapsed_time));
+				Debug::addQuery($db_class->getQueryLog($this->queryString, $elapsed_time));
 			}
 		}
-		
+
 		return $result;
 	}
 }


### PR DESCRIPTION
PHP8.1에 추가된 ReturnTypeWillChange를 적용하고,
겸사겸사 PHPDoc 도 갱신하고, 겸사겸사 PDO 기존 파라미터 이름도 맞추고, 겸사겸사 리턴타입도 정리했습니다.

리턴타입을 DBStmtHelper 하나로 지정한건, 어차피 R\F\DB 에서 그렇게 돌려받기로 합의본 상태기도 하고,
DBHelper 에서도 false 등을 돌려받을 경우에 대해서는 고려되지 않은것으로 보여서요.

라이믹스 코드 대부분에 throws 태그가 빠져있어서, 추가해야하나 말아야하나 고민했습니다.
일단 있어서 나쁠건 없다 판단해 추가해 두기는 했습니다.