### PR TITLE
procPollInsertItem 후 트랜잭션 커밋이 안되던 문제 수정

### DIFF
--- a/modules/poll/poll.controller.php
+++ b/modules/poll/poll.controller.php
@@ -216,6 +216,7 @@ class pollController extends poll
 			$oDB->rollback();
 			return $output;
 		}
+		$oDB->commit();
 		return $output;
 	}
 


### PR DESCRIPTION
procPollInsertItem (설문항목 추가 기능을 통해 회원들이 자유롭게 설문항목을 추가할 수 있는 기능) 실행 수

트랜잭션이 커밋되지 않아서,
응답으로는 success를 반환하지만 실제로 반영되지는 않고 있었습니다.

사이트 운영중에 버그를 발견하여 제보 및 풀 리퀘스트 드립니다.