### PR TITLE
짧은 주소 사용 시 로그인 무한 리다이렉트 문제 수정

### DIFF
--- a/modules/member/member.view.php
+++ b/modules/member/member.view.php
@@ -633,7 +633,7 @@ class MemberView extends Member
 	{
 		// Get referer URL
 		$referer_url = Context::get('referer_url') ?: ($_SERVER['HTTP_REFERER'] ?? '');
-		if (!$referer_url || !Rhymix\Framework\URL::isInternalURL($referer_url) || contains('procMember', $referer_url) || contains('dispMemberLoginForm', $referer_url))
+		if (!$referer_url || !Rhymix\Framework\URL::isInternalURL($referer_url) || contains('procMember', $referer_url) || contains('dispMemberLoginForm', $referer_url) || contains('/login', $referer_url))
 		{
 			$referer_url = getNotEncodedUrl('act', '');
 		}


### PR DESCRIPTION
짧은 주소 모든 주소 형태를 사용 할 때 무한 리다이렉트 오류를 수정합니다.
참고
https://github.com/rhymix/rhymix/pull/1955
https://github.com/rhymix/rhymix/commit/d1b0dbff9caccbebf0b22d044c43402bb8ebfdc2