### PR TITLE
멤버 모듈 index 접속 시 리다이렉트 문제 수정

### DIFF
--- a/modules/member/member.view.php
+++ b/modules/member/member.view.php
@@ -121,11 +121,11 @@ class MemberView extends Member
 	{
 		if ($this->user->isMember())
 		{
-			$this->setRedirectUrl(getUrl(['mid' => $this->mid, 'act' => 'dispMemberInfo']));
+			$this->setRedirectUrl(getNotEncodedUrl(['mid' => $this->mid, 'act' => 'dispMemberInfo']));
 		}
 		else
 		{
-			$this->setRedirectUrl(getUrl(['mid' => $this->mid, 'act' => 'dispMemberLoginForm']));
+			$this->setRedirectUrl(getNotEncodedUrl(['mid' => $this->mid, 'act' => 'dispMemberLoginForm']));
 		}
 	}
 


### PR DESCRIPTION
멤버모듈에 기본으로 생성된 /member로 접속 시
주소가 `/index.php?mid=member&amp;act=dispMemberInfo`로 생성되어 무한 리다이렉트에 빠지는 문제를 수정하였습니다. 