### PR TITLE
특정 환경에서 태그 및 댓글 검색 시 오류 수정

### DIFF
--- a/modules/document/document.model.php
+++ b/modules/document/document.model.php
@@ -1496,10 +1496,6 @@ class DocumentModel extends Document
 					$args->sort_index = 'extra_sort.value';
 				}
 				$query_id = 'document.getDocumentListWithExtraVars';
-				if($args->columnList && !in_array($args->sort_index, $args->columnList))
-				{
-					$args->columnList[] = $args->sort_index;
-				}
 			}
 			else
 			{
@@ -1556,6 +1552,10 @@ class DocumentModel extends Document
 				continue;
 			}
 			$args->columnList[$key] = 'documents.' . $column;
+		}
+		if($args->columnList && !in_array($args->sort_index, $args->columnList))
+		{
+			$args->columnList[] = $args->sort_index;
 		}
 	}
 


### PR DESCRIPTION
DB sql_mode 설정된 특정 환경에서 태그 및 댓글 검색 시 오류

`SQLSTATE[HY000]: General error: 3065 Expression #1 of ORDER BY clause is not in SELECT list, references column '#.documents.list_order' which is not in SELECT list; this is incompatible with DISTINCT`

참고
https://github.com/rhymix/rhymix/issues/1592#issuecomment-770345095
와 동일한 오류입니다.

`getDocumentListWithinComment`
`getDocumentListWithinTag`
`getDocumentListWithExtraVars`
에서 select항목에 order하려는 컬럼이 추가 되면 됩니다만

order한 컬럼이라면 활용할 가능성이 높은 항목으로 전체적으로 select에 추가해두는게 좋지 않을까 합니다.
그래서 PR에서 옮긴 위치에서 최종적으로 order 컬럼을 추가하는 것으로 요청드립니다.