### PR TITLE
Add the "trash_srl" attribute to the $obj when invoking the "document.moveDocumentToTrash" (after) trigger.

### DIFF
--- a/modules/document/document.controller.php
+++ b/modules/document/document.controller.php
@@ -1341,7 +1341,9 @@ class DocumentController extends Document
 		// new trash module
 		require_once(RX_BASEDIR.'modules/trash/model/TrashVO.php');
 		$oTrashVO = new TrashVO();
-		$oTrashVO->setTrashSrl(getNextSequence());
+		$trash_srl = getNextSequence();
+		$obj->trash_srl = $trash_srl
+		$oTrashVO->setTrashSrl($trash_srl);
 		$oTrashVO->setTitle($oDocument->variables['title']);
 		$oTrashVO->setOriginModule('document');
 		$oTrashVO->setSerializedObject(serialize($oDocument->variables));


### PR DESCRIPTION
"document.moveDocumentToTrash" (after) 트리거에서 새롭게 휴지통에 삽입된 녀석의 trash_srl 을 가져올수 없어서 $obj->trash_srl 에 포함되도록 수정했습니다.