### PR TITLE
닉네임 변경 금지 설정시 관리자가 회원 등록을 하지 못하는 문제 수정

### DIFF
--- a/modules/member/member.admin.view.php
+++ b/modules/member/member.admin.view.php
@@ -659,7 +659,7 @@ class MemberAdminView extends Member
 					}
 					else
 					{
-						if($formInfo->name === 'nick_name' && ($member_config->allow_nickname_change ?? 'Y') === 'N' && !$isSignup)
+						if($formInfo->name === 'nick_name' && ($member_config->allow_nickname_change ?? 'Y') === 'N' && !$isAdmin && !$isSignup)
 						{
 							$readonly = 'readonly="readonly" ';
 						}


### PR DESCRIPTION
`관리자 - 회원 설정 -> 기본 설정 -> 닉네임 변경 허용`이 `아니오`일 때
관리자가 회원 신규 등록이 불가능 문제를 수정하였습니다.
이 변경으로 닉네임 변경 금지일 때도 관리자는 닉네임 수정이 가능해집니다.