### PR TITLE
스크립트 자동 압축 사용 시 CSS @import 위치 문제 수정

### DIFF
--- a/common/framework/Formatter.php
+++ b/common/framework/Formatter.php
@@ -387,7 +387,7 @@ class Formatter
 			// Convert all paths in LESS and SCSS imports, too.
 			$dirname = dirname($filename);
 			$import_type = ends_with('.scss', $filename) ? 'scss' : 'normal';
-			$content = preg_replace_callback('/@import\s+([^\r\n]+);[\r\n]*/', function($matches) use($dirname, $filename, $target_filename, $import_type, &$imported_list, &$imported_urls) {
+			$content = preg_replace_callback('/@import\s+([^\r\n]+)?;/', function($matches) use($dirname, $filename, $target_filename, $import_type, &$imported_list, &$imported_urls) {
 				if (preg_match('!^url\([\'"]?((?:https?:)?//[^()\'"]+)!i', $matches[1], $urlmatches))
 				{
 					$imported_urls[] = $urlmatches[1];

--- a/common/framework/Formatter.php
+++ b/common/framework/Formatter.php
@@ -387,7 +387,7 @@ class Formatter
 			// Convert all paths in LESS and SCSS imports, too.
 			$dirname = dirname($filename);
 			$import_type = ends_with('.scss', $filename) ? 'scss' : 'normal';
-			$content = preg_replace_callback('/@import\s+([^\r\n]+);(?=[\r\n$])/', function($matches) use($dirname, $filename, $target_filename, $import_type, &$imported_list, &$imported_urls) {
+			$content = preg_replace_callback('/@import\s+([^\r\n]+);[\r\n]*/', function($matches) use($dirname, $filename, $target_filename, $import_type, &$imported_list, &$imported_urls) {
 				if (preg_match('!^url\([\'"]?((?:https?:)?//[^()\'"]+)!i', $matches[1], $urlmatches))
 				{
 					$imported_urls[] = $urlmatches[1];


### PR DESCRIPTION
`concatCSS` 함수에서 `@import`를 추출하여 항상 제일 위로 재배치 해주고 있으나,
`스크립트 자동 압축 사용`과  `스크립트 합치기`를 동시에 사용하여
이미 압축된 경우 `@import` 구문을 인식하지 못하는 문제를 수정하였습니다.