### PR TITLE
오류: Context::addOpenGraphData 메소드의 문제로 Context::setCanonicalURL 메소드 호…

### DIFF
--- a/classes/context/Context.class.php
+++ b/classes/context/Context.class.php
@@ -2874,16 +2874,29 @@ class Context
 	 *
 	 * @param string $name
 	 * @param mixed $content
+	 * @param bool $overwrite
 	 * @return void
 	 */
-	public static function addOpenGraphData($name, $content)
+	public static function addOpenGraphData($name, $content, $overwrite = false) : void
 	{
 		if (is_array($content))
 		{
 			foreach ($content as $key => $val)
 			{
-				self::addOpenGraphData("$name:$key", $val);
+				self::addOpenGraphData("$name:$key", $val, $overwrite);
 			}
+		}
+		else if($overwrite)
+		{
+			foreach(self::$_instance->opengraph_metadata as $key => $val)
+			{
+				if($val[0] == $name)
+				{
+					self::$_instance->opengraph_metadata[$key][1] = $content;
+					return;
+				}
+			}
+			self::$_instance->opengraph_metadata[] = array($name, $content);
 		}
 		else
 		{
@@ -2900,7 +2913,7 @@ class Context
 	public static function setCanonicalURL($url)
 	{
 		self::$_instance->canonical_url = escape($url, false);
-		self::addOpenGraphData('og:url', self::$_instance->canonical_url);
+		self::addOpenGraphData('og:url', self::$_instance->canonical_url, true);
 	}
 
 	/**


### PR DESCRIPTION
…출시 og:url 여러번 선언됨: (예: rhymix.org 소스코드에도 같은 문제가 있음)

해결: 3번째 인자 $overwrite 추가해서 opengraph 선택적으로 덮어쓰기 가능.