### PR TITLE
댓글 페이지 수 설정 안되는 문제 수정

### DIFF
--- a/modules/comment/comment.model.php
+++ b/modules/comment/comment.model.php
@@ -1123,7 +1123,7 @@ class CommentModel extends Comment
 		{
 			$comment_config->comment_count = 50;
 		}
-		if(!isset($comment_config->comment_page_count) || $comment_config->comment_page_count)
+		if(!isset($comment_config->comment_page_count) || !$comment_config->comment_page_count)
 		{
 			$comment_config->comment_page_count = 10;
 		}


### PR DESCRIPTION
`게시판 추가 설정 -> 댓글 -> 댓글 페이지 수` 설정이 항상 10으로 고정되는 문제를 수정하였습니다.