### PR TITLE
Update advanced_mailer.admin.controller.php

### DIFF
--- a/modules/advanced_mailer/advanced_mailer.admin.controller.php
+++ b/modules/advanced_mailer/advanced_mailer.admin.controller.php
@@ -252,8 +252,8 @@ class Advanced_MailerAdminController extends Advanced_Mailer
 		{
 			$oMail = new Rhymix\Framework\Mail();
 			$oMail->setTitle('Advanced Mailer Test : ' . strtoupper($sending_method));
-			$oMail->setContent('<p>This is a <b>test email</b> from Advanced Mailer.</p><p>Thank you for trying Advanced Mailer.</p>' .
-				'<p>고급 메일 발송 모듈 <b>테스트</b> 메일입니다.</p><p>메일이 정상적으로 발송되고 있습니다.</p>');
+			$oMail->setContent('<!DOCTYPE html><html lang="ko"><head><title>Advanced Mailer Test : '.strtoupper($sending_method).'</title></head><body><p>This is a <b>test email</b> from Advanced Mailer.</p><p>Thank you for trying Advanced Mailer.</p>' .
+				'<p>고급 메일 발송 모듈 <b>테스트</b> 메일입니다.</p><p>메일이 정상적으로 발송되고 있습니다.</p></body></html>');
 			$oMail->addTo($recipient_email, $recipient_name);
 			$result = $oMail->send();
 


### PR DESCRIPTION
메일테스트시 전송되는 내용의 html 이메일 콘텐츠의 태그 형식을 맞춰서 이메일 스코어를 높일 수 있습니다.

<img width="994" alt="스크린샷 2023-12-25 오후 11 21 32" src="https://github.com/rhymix/rhymix/assets/5946105/f2ab4d8e-cfe7-44a7-aeef-fc7352907a55">
