### PR TITLE
디버그 메시지를 출력하는 파일에서 항목을 구분하기 좋게 컬러 적용

### DIFF
--- a/common/framework/Debug.php
+++ b/common/framework/Debug.php
@@ -494,7 +494,7 @@ class Debug
 		// Add the query to the slow query log.
 		if ($query_object->query_time && $query_object->query_time >= (self::$_config['log_slow_queries'] ?? 1))
 		{
-			self::$_slow_queries[] = $query_object;
+			self::$_slow_queries[count(self::$_queries)] = $query_object;
 		}
 	}
 

--- a/common/tpl/debug_comment.html
+++ b/common/tpl/debug_comment.html
@@ -187,17 +187,16 @@ Debug Entries
 ================================================================================
 <?php echo $ansi['off']; ?>
 <?php
-	$query_count = 0;
 	if (!count($data->slow_queries))
 	{
 		echo 'None'. "\n";
 	}
-	foreach ($data->slow_queries as $query)
+	foreach ($data->slow_queries as $index => $query)
 	{
 		$query_caller = sprintf('%s line %d (%s)', $query->file, $query->line, $query->method);
 		$query_result = ($query->message === 'success') ? 'success' : sprintf('error %d %s', $query->error_code, $query->message);
 		echo $ansi['bold'] . $ansi['magenta'];
-		echo sprintf('%02d. %s', ++$query_count, $query->query_string);
+		echo sprintf('%02d. %s', $index, $query->query_string);
 		echo $ansi['off'] . "\n";
 		if (empty($query->backtrace))
 		{


### PR DESCRIPTION
디버그 파일이 길어지니 항목의 구분이 어려운 것같아서 ANSI 컬러 코드를 적용해봤습니다.
추가로 슬로우 쿼리 항목에서 앞에 붙는 숫자를 전체 쿼리 목록과 비교하여 보기 좋게 인덱스 번호를 맞췄습니다.

색상은 환경에 따라 조금씩 달라 보일 수는 있습니다.

아래는 너무 길어서 섹션별 하나씩만 추려서 출력한 예시의 스크린샷입니다.
<img width="890"  src="https://github.com/rhymix/rhymix/assets/112419763/83c2911e-b44a-4a63-b1de-880906574f2b">


이 파일을 에디터 등으로 열었을 때는 보기가 상당히 좋지 않게 되어버렸으나, 이런 상황을 고려해야 할지는 모르겠습니다.

- 시작 줄의 날짜는 cyan
- 섹션 구분 yellow 라인
- 개별 메시지 항목은 굵은 글자
- 오류 항목은 red
- 슬로우 목록은 magenta

의견 주시고 적용 검토해주세요.