### PR TITLE
debug 패널의 가독성 향상과 헤더에 sticky 를 적용하여 사용성 개선

### DIFF
--- a/common/css/rhymix.scss
+++ b/common/css/rhymix.scss
@@ -241,13 +241,16 @@ a img {
 	border-right: 1px solid #ccc;
 	box-shadow: 0 0 4px 0 rgba(0, 0, 0, 0.18), 0 0 8px 0 rgba(0, 0, 0, 0.12);
 	z-index: 1073741824;
+	-webkit-font-smoothing: antialiased;
 	.debug_header {
 		clear: both;
 		width: 100%;
 		height: 36px;
 		background: #444444;
 		background: linear-gradient(to right, #222222 0%, #444444 40%, #eeeeee 100%);
-		position: relative;
+		position: sticky;
+		top: 0;
+		z-index: 1;
 		h2 {
 			font: bold 16px/20px Arial, sans-serif;
 			color: #fcfcfc;
@@ -275,13 +278,15 @@ a img {
 	}
 	.debug_page {
 		clear: both;
-		margin: 12px 10px;
+		margin: 0 10px;
 		font: normal 12px/16px Arial, NanumBarunGothic, NanumGothic, "Malgun Gothic", sans-serif;
 		.debug_page_header {
-			padding-bottom: 8px;
+			padding: 12px 0;
 			border-bottom: 1px solid #ddd;
-			position: relative;
+			position: sticky;
+			top: 36px;
 			cursor: pointer;
+			background-color: #fff;
 			h3 {
 				color: #444;
 				font: inherit;
@@ -294,34 +299,41 @@ a img {
 		.debug_page_collapse {
 			display: block;
 			position: absolute;
-			right: 0; top: 0;
-			color: #999;
+			right: 0;
+			top: 12px;
+			color: #555;
 			font-size: 10px;
 			line-height: 12px;
 			text-decoration: none;
 			padding: 2px 2px;
 		}
 		.debug_page_body {
-			margin: 8px 4px 8px 10px;
+			margin: 0 4px 0 10px;
 			h4 {
 				color: #444;
 				font: inherit;
 				font-size: 13px;
 				font-weight: bold;
-				margin: 0 0 8px 0;
-				padding: 0;
+				margin: 0;
+				padding: 8px;
+				position: sticky;
+				top: 77px;
+				background-color: #fff;
 			}
 		}
 		.debug_entry {
-			font-family: Consolas, "Courier New", monospace;
+			font-family: ui-monospace, Consolas, "Courier New", monospace;
 			color: #444;
 			margin-left: 38px;
 			margin-bottom: 8px;
 			text-indent: -28px;
 			word-wrap: break-word;
 			word-break: break-all;
-			&.pre_wrap {
-				white-space: pre-wrap;
+			&.debug_errors {
+				color: red;
+			}
+			.debug_entry_title {
+				font-weight: 600;
 			}
 			ul.debug_metadata {
 				margin: 0 0 0 -16px; padding: 0;
@@ -335,7 +347,7 @@ a img {
 				li {
 					list-style: disc;
 					margin: 0; padding: 0; text-indent: 0;
-					color: #888;
+					color: #777;
 					ul {
 						padding-left: 20px;
 						li {

--- a/common/js/debug.js
+++ b/common/js/debug.js
@@ -93,9 +93,9 @@ $(function() {
 			cnt = data.entries.reduce(function(a, c) { return a + c.count; }, 0);
 			page_body.append($('<h4></h4>').text('Debug Entries (' + cnt + ')'));
 			for (i in data.entries) {
-				entry = $('<div class="debug_entry pre_wrap"></div>').appendTo(page_body);
+				entry = $('<div class="debug_entry pre_wrap"><strong class="debug_entry_title"></strong></div>').appendTo(page_body);
 				num = parseInt(i) + 1; if (num < 10) num = "0" + num;
-				entry.text(num + ". " + data.entries[i].message);
+				entry.find('strong').text(num + ". " + data.entries[i].message);
 				backtrace = $('<ul class="debug_backtrace"></ul>').appendTo(entry);
 				for (j in data.entries[i].backtrace) {
 					if (data.entries[i].backtrace[j].file) {
@@ -113,9 +113,9 @@ $(function() {
 			cnt = data.errors.reduce(function(a, c) { return a + c.count; }, 0);
 			page_body.append($('<h4></h4>').text('Errors (' + cnt + ')'));
 			for (i in data.errors) {
-				entry = $('<div class="debug_entry"></div>').appendTo(page_body);
+				entry = $('<div class="debug_entry debug_errors"><strong class="debug_entry_title"></strong></div>').appendTo(page_body);
 				num = parseInt(i) + 1; if (num < 10) num = "0" + num;
-				entry.text(num + ". " + data.errors[i].type + ": " + data.errors[i].message);
+				entry.find('strong').text(num + ". " + data.errors[i].type + ": " + data.errors[i].message);
 				backtrace = $('<ul class="debug_backtrace"></ul>').appendTo(entry);
 				for (j in data.errors[i].backtrace) {
 					if (data.errors[i].backtrace[j].file) {
@@ -133,9 +133,9 @@ $(function() {
 			cnt = data.queries.reduce(function(a, c) { return a + c.count; }, 0);
 			page_body.append($('<h4></h4>').text('Queries (' + cnt + ')'));
 			for (i in data.queries) {
-				entry = $('<div class="debug_entry"></div>').appendTo(page_body);
+				entry = $('<div class="debug_entry"><strong class="debug_entry_title"></strong></div>').appendTo(page_body);
 				num = parseInt(i) + 1; if (num < 10) num = "0" + num;
-				entry.text(num + ". " + data.queries[i].query_string);
+				entry.find('strong').text(num + ". " + data.queries[i].query_string);
 				description = $('<ul class="debug_backtrace"></ul>').appendTo(entry);
 				if (data.queries[i].file && data.queries[i].line) {
 					description.append($('<li></li>').text("Caller: " +
@@ -162,9 +162,9 @@ $(function() {
 		if (data.slow_queries && data.slow_queries.length) {
 			page_body.append($('<h4></h4>').text('Slow Queries (' + data.slow_queries.length + ')'));
 			for (i in data.slow_queries) {
-				entry = $('<div class="debug_entry"></div>').appendTo(page_body);
+				entry = $('<div class="debug_entry"><strong class="debug_entry_title"></strong></div>').appendTo(page_body);
 				num = parseInt(i) + 1; if (num < 10) num = "0" + num;
-				entry.text(num + ". " + data.slow_queries[i].query_string);
+				entry.find('strong').text(num + ". " + data.slow_queries[i].query_string);
 				description = $('<ul class="debug_backtrace"></ul>').appendTo(entry);
 				if (data.slow_queries[i].file && data.slow_queries[i].line) {
 					description.append($('<li></li>').text("Caller: " + data.slow_queries[i].file + ":" + data.slow_queries[i].line).append("<br>(" + data.slow_queries[i].method + ")"));
@@ -188,9 +188,9 @@ $(function() {
 		if (data.slow_triggers && data.slow_triggers.length) {
 			page_body.append($('<h4></h4>').text('Slow Triggers (' + data.slow_triggers.length + ')'));
 			for (i in data.slow_triggers) {
-				entry = $('<div class="debug_entry"></div>').appendTo(page_body);
+				entry = $('<div class="debug_entry"><strong class="debug_entry_title"></strong></div>').appendTo(page_body);
 				num = parseInt(i) + 1; if (num < 10) num = "0" + num;
-				entry.text(num + ". " + data.slow_triggers[i].trigger_name);
+				entry.find('strong').text(num + ". " + data.slow_triggers[i].trigger_name);
 				description = $('<ul class="debug_backtrace"></ul>').appendTo(entry);
 				description.append($('<li></li>').text("Target: " + data.slow_triggers[i].trigger_target));
 				description.append($('<li></li>').text("Exec Time: " + (data.slow_triggers[i].trigger_time ? (data.slow_triggers[i].trigger_time.toFixed(4) + " sec") : "")));
@@ -201,9 +201,9 @@ $(function() {
 		if (data.slow_widgets && data.slow_widgets.length) {
 			page_body.append($('<h4></h4>').text('Slow Widgets (' + data.slow_widgets.length + ')'));
 			for (i in data.slow_widgets) {
-				entry = $('<div class="debug_entry"></div>').appendTo(page_body);
+				entry = $('<div class="debug_entry"><strong class="debug_entry_title"></strong></div>').appendTo(page_body);
 				num = parseInt(i) + 1; if (num < 10) num = "0" + num;
-				entry.text(num + ". " + data.slow_widgets[i].widget_name);
+				entry.find('strong').text(num + ". " + data.slow_widgets[i].widget_name);
 				description = $('<ul class="debug_backtrace"></ul>').appendTo(entry);
 				description.append($('<li></li>').text("Exec Time: " + (data.slow_widgets[i].widget_time ? (data.slow_widgets[i].widget_time.toFixed(4) + " sec") : "")));
 			}
@@ -213,9 +213,9 @@ $(function() {
 		if (data.slow_remote_requests && data.slow_remote_requests.length) {
 			page_body.append($('<h4></h4>').text('Slow Remote Requests (' + data.slow_remote_requests.length + ')'));
 			for (i in data.slow_remote_requests) {
-				entry = $('<div class="debug_entry"></div>').appendTo(page_body);
+				entry = $('<div class="debug_entry"><strong class="debug_entry_title"></strong></div>').appendTo(page_body);
 				num = parseInt(i) + 1; if (num < 10) num = "0" + num;
-				entry.text(num + ". " + data.slow_remote_requests[i].url);
+				entry.find('strong').text(num + ". " + data.slow_remote_requests[i].url);
 				description = $('<ul class="debug_backtrace"></ul>').appendTo(entry);
 				if (data.slow_remote_requests[i].file && data.slow_remote_requests[i].line) {
 					description.append($('<li></li>').text("Caller: " + data.slow_remote_requests[i].file + ":" + data.slow_remote_requests[i].line).append("<br>(" + data.slow_remote_requests[i].method + ")"));


### PR DESCRIPTION
디버그 패널의 가독성과 사용성 개선을 위한 패치입니다.

너무 크게 건드리려고는 하지 않았고 가독성 향상을 주 목적으로 했으며, 헤더 섹션에 sticky 를 적용하여 어떤 항목을 표시하고 있는지를 알아보기 쉽도록 스크롤에 따라 헤더를 고정하였습니다.

1. 폰트 가독성 향상
2. 섹션을 구분하기 좋도록 헤더에 sticky 적용하여 스크롤에 따라 상단에 고정
3. 개별 항목을 구분하기 좋도록 굵은 글자로 표시
4. 오류의 개별 항목을 붉은색으로 표시
5. backtrace 항목의 가독성 향상(색상을 약간 더 진하게)

<img width="546" src="https://github.com/rhymix/rhymix/assets/112419763/e8f6191c-5669-45a9-94b3-75cfa5ad8952">
