### PR TITLE
SessionHelper 에서 발생하는 Deprecated 메시지 문제 수정

### DIFF
--- a/common/framework/helpers/SessionHelper.php
+++ b/common/framework/helpers/SessionHelper.php
@@ -5,7 +5,7 @@ namespace Rhymix\Framework\Helpers;
 /**
  * Session helper class.
  */
-#[AllowDynamicProperties]
+#[\AllowDynamicProperties]
 class SessionHelper
 {
 	/**


### PR DESCRIPTION
이 클래스가 네임스페이스 안에 있기 때문에 [`\AllowDynamicProperties`](https://www.php.net/manual/en/class.allowdynamicproperties.php) 클래스를 찾지 못해 Attribute 구문이 무시되는 문제를 수정합니다.