### PR TITLE
composer optmize 활성화

### DIFF
--- a/common/composer.json
+++ b/common/composer.json
@@ -2,12 +2,15 @@
   "name": "rhymix/rhymix",
   "description": "Rhymix",
   "homepage": "https://www.rhymix.org",
-  "license": "GPL-2.0+",
+  "license": "GPL-2.0-or-later",
   "type": "project",
   "authors": [
     { "name": "Rhymix Developers and Contributors", "email": "devops@rhymix.org" },
     { "name": "NAVER", "email": "developers@xpressengine.com" }
   ],
+  "config": {
+    "optimize-autoloader": true
+  },
   "require": {
     "php": ">=7.2.5",
     "ext-curl": "*",


### PR DESCRIPTION
컴포저로 설치, 업데이트, `dump-autoload` 명령을 실행할 때 autoloader 를 최적화하는 옵션을 기본 실행하도록 변경하여 실수를 방지했습니다.
- https://getcomposer.org/doc/06-config.md#optimize-autoloader
- https://getcomposer.org/doc/articles/autoloader-optimization.md

추가로 license 표기를 권장에 따라 SPDX 식별자로 변경했습니다.
- https://getcomposer.org/doc/04-schema.md#license

`platform_check.php` 파일의 생성은 보통 문제가 없어야 하는데 이력을 보니 특정 패키지의 문제였던 것인지
`composer (install|update|dump) --ignore-platform-req=php` 옵션으로 951e0e16fef66c6b97ea54896b3078e1e5e7087f 커밋에서 제거했던 platform_check.php 파일을 로드하는 코드 생성을 방지할 수 있습니다.
- https://getcomposer.org/doc/06-config.md#platform