### PR TITLE
관리자 메뉴 추가에서 빈 메뉴 항목을 잘못 표시하는 문제 수정

### DIFF
--- a/modules/admin/tpl/js/menu_setup.js
+++ b/modules/admin/tpl/js/menu_setup.js
@@ -26,6 +26,10 @@ jQuery(function($){
 			for(var x in moduleList)
 			{
 				var menuList = moduleList[x];
+				if (!menuList)
+				{
+					continue;
+				}
 				$optgroup = $('<optgroup label="'+x+'" />').appendTo(menuNameList);
 				for(var y in menuList)
 				{


### PR DESCRIPTION
모듈에서 노출하는 메뉴가 없을 때 `undefined` 항목이 다수 잘못 표시되는 문제를 해결합니다.

<img width="475" src="https://github.com/rhymix/rhymix/assets/112419763/afa59c4b-213d-4d46-8a82-de6549aec7d7">
