### PR TITLE
통합검색 모듈의 이미지 및 동영상 썸네일 처리 개선 #2230

### DIFF
--- a/common/js/common.js
+++ b/common/js/common.js
@@ -706,13 +706,17 @@ function _displayMultimedia(src, width, height, options) {
 	var clsid = "";
 	var codebase = "";
 	var html = "";
+	var background = "black";
 	width = parseInt(width, 10);
 	height = parseInt(height, 10);
 
-	if(/\.(gif|jpg|jpeg|bmp|png)$/i.test(src)){
+	if (/\.(gif|jpe?g|bmp|png|webp)$/i.test(src)){
 		html = '<img src="'+src+'" width="'+width+'" height="'+height+'" class="thumb" />';
 	} else {
-		html = '<span style="position:relative;background:black;width:' + width + 'px;height:' + height + 'px" class="thumb">';
+		if (options.thumbnail) {
+			background += " url('" + options.thumbnail + "');background-size:cover;background-position:center center";
+		}
+		html = '<span style="position:relative;background:' + background + ';width:' + width + 'px;height:' + height + 'px" class="thumb">';
 		html += '<img style="width:24px;height:24px;position:absolute;left:50%;top:50%;border:0;margin:-12px 0 0 -12px;padding:0" src="' + request_uri + 'common/img/play.png" alt="" />';
 		html += '</span>';
 	}

--- a/modules/integration_search/models/FileSearchResult.php
+++ b/modules/integration_search/models/FileSearchResult.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Rhymix\Modules\Integration_Search\Models;
+
+use Context;
+use FileHandler;
+
+#[\AllowDynamicProperties]
+class FileSearchResult
+{
+	/**
+	 * Properties of the file.
+	 */
+	public $file_srl;
+	public $file_size;
+	public $filename;
+	public $uploaded_filename;
+	public $download_count;
+	public $download_url;
+	public $video_thumbnail_url;
+	public $target_srl;
+	public $type;
+
+	/**
+	 * Properties of the upload target.
+	 */
+	public $url;
+	public $regdate;
+	public $nick_name;
+
+	/**
+	 * Get a thumbnail.
+	 *
+	 * @param int $width
+	 * @param int $height
+	 * @param string $type
+	 * @return string
+	 */
+	public function getThumbnail(int $width = 120, int $height = 0, string $type = 'crop'): string
+	{
+		if ($this->type !== 'image')
+		{
+			return '';
+		}
+
+		$thumbnail_path = sprintf('files/thumbnails/%s', getNumberingPath($this->file_srl, 3));
+		if(!is_dir($thumbnail_path))
+		{
+			FileHandler::makeDir($thumbnail_path);
+		}
+		$thumbnail_file = sprintf('%s%dx%d.%s.jpg', $thumbnail_path, $width, $height ?: $width, $type);
+		$thumbnail_url = \RX_BASEURL . $thumbnail_file;
+		if (!file_exists($thumbnail_file))
+		{
+			FileHandler::createImageFile($this->uploaded_filename, $thumbnail_file, $width, $height ?: $width, 'jpg', $type, 50);
+		}
+		return $thumbnail_url;
+	}
+
+	/**
+	 * Display video.
+	 *
+	 * @param int $width
+	 * @param int $height
+	 * @return string
+	 */
+	public function displayVideo(int $width = 120, int $height = 0): string
+	{
+		if ($this->type !== 'multimedia')
+		{
+			return '';
+		}
+
+		$options = new \stdClass;
+		if ($this->video_thumbnail_url)
+		{
+			$options->thumbnail = $this->video_thumbnail_url;
+		}
+
+		return vsprintf('<script>displayMultimedia(%s, %d, %d, %s);</script>', [
+			json_encode(\RX_BASEURL . preg_replace('!^\.\/!', '', $this->uploaded_filename)),
+			$width,
+			$height ?: $width,
+			json_encode($options),
+		]);
+	}
+
+	/**
+	 * Magic method to generate the 'src' attribute for backward compatibility.
+	 *
+	 * For images, it returns a 120x120 thumbnail.
+	 * For videos, it returns a 80x80 preview.
+	 * For other types of files, this method returns an empty string.
+	 */
+	public function __get(string $key)
+	{
+		if ($key === 'src')
+		{
+			if ($this->type === 'image')
+			{
+				return vsprintf('<img src="%s" alt="%s" width="120" height="120" class="thumb" />', [
+					$this->getThumbnail(120, 120),
+					escape($this->filename, false),
+				]);
+			}
+			elseif ($this->type === 'multimedia')
+			{
+				return $this->displayVideo(80, 80);
+			}
+			else
+			{
+				return '';
+			}
+		}
+		else
+		{
+			return null;
+		}
+	}
+}


### PR DESCRIPTION
#2230 에서 @eondcom 님이 지적해 주셨듯이, 스킨에서 썸네일 크기를 지정할 수 있는 문서나 댓글과 달리 이미지와 동영상의 썸네일 크기는 각각 120px과 80px로 고정되어 있는 불편을 해결합니다.

단, 모듈 공통 설정보다는 각 스킨의 디자인 기조에 따라 달라져야 하는 부분으로 보이고, 문서와 댓글의 썸네일 크기도 스킨에서 지정하고 있는 점을 고려하여 "모듈 설정 신설"보다는 "스킨에서 지정할 수 있도록 지원"하는 방향을 택했습니다.

### 이미지

스킨에서 이미지 검색 결과의 썸네일을 임의의 크기로 생성하려면, 문서나 댓글과 마찬가지로 아래와 같은 코드를 사용하시면 됩니다. 세로를 지정하지 않으면 정사각형이 됩니다.

```
<img src="{$image->getThumbnail(가로, 세로)}" ... />
```

기존과 같이 `src` 속성을 사용할 경우, 가로세로 120px 크기의 썸네일을 출력하는 `<img>` 태그가 출력됩니다.

```
{$image->src}
```

※ `$image` 변수명은 스킨에 따라 다를 수 있습니다.

※ `src` 속성은 미리 넣어 놓은 것이 아니고 magic method를 사용하여 동적으로 생성되므로, 이 속성을 사용하지 않더라도 불필요한 120px짜리 썸네일이 중복으로 생성되지는 않습니다.

※ 사용자가 설정을 바꿀 때마다 불필요한 썸네일이 많이 생성되지 않도록, 테마 패키지를 제작하시는 분들은 적당한 크기의 썸네일 한두 가지만 생성하여 css로 크기를 조절해서 사용하실 것을 추천합니다. 게시물이 많은 사이트를 오랫동안 운영하다 보면 수천만 개의 썸네일이 생성되어 서버 관리나 백업에 애로사항이 꽃피곤 합니다.

### 동영상

아래의 코드를 사용하여 썸네일을 표시하는 부분의 코드를 커스터마이징할 수 있습니다. 세로를 지정하지 않으면 정사각형이 됩니다. 동영상이 아닌 경우 아무 것도 출력되지 않습니다.

```
{$image->displayVideo(가로, 세로)}
```

기존과 같이 `src` 속성을 사용할 경우, 가로세로 80px 크기로 고정됩니다.

```
{$image->src}
```

물론 통합검색 결과의 동영상 영역은 실제로 동영상이 재생되는 것이 아니라 재생 버튼을 포함하는 사각형을 표시하는 것뿐이므로, 새로 추가된 메소드와 속성을 모두 무시하고 원본 파일의 속성을 사용하여 다른 방식으로 구현해도 무방합니다.

추가로, ffmpeg을 사용하여 동영상 썸네일을 추출해 놓은 경우에는 재생 버튼 배경에 검은 상자 대신 그 썸네일을 표시하도록 개선하였습니다. 좀더 직관적인 검색 결과가 될 것으로 기대합니다.
