### PR TITLE
e361d2e 커밋에서 exec_xml() 함수의 대체가 잘못 수정된 문제

### DIFF
--- a/common/js/common.js
+++ b/common/js/common.js
@@ -779,7 +779,7 @@ function doCallModuleAction(module, action, target_srl) {
 		cur_mid    : current_mid,
 		mid        : current_mid
 	};
-	exec_xml(module + '.' + action, params, completeCallModuleAction);
+	exec_json(module + '.' + action, params, completeCallModuleAction);
 }
 
 function completeCallModuleAction(ret_obj, response_tags) {


### PR DESCRIPTION
e361d2e 커밋에서 변경해야 할 코드 일부가 실수로 누락된 것 같습니다.

exec_xml -> exec_json

게시물 추천/비추천 동작에서 문제가 발생합니다.

```
AJAX communication error while requesting document.procDocumentVoteUp.[object Object]

500 Internal Server Error (error)

{"error":-1,"message":"TypeError #0 &quot;Cannot access offset of type array in isset or empty&quot; in modules\/ncenterlite\/ncenterlite.controller.php on line 1057"}
```

```
PHP Exception: TypeError #0 "Cannot access offset of type array in isset or empty" in modules/ncenterlite/ncenterlite.controller.php on line 1057
#0 /Users/kkigomi/Dev/rhymix/classes/module/ModuleHandler.class.php(1351): NcenterliteController->triggerBeforeDisplay()
#1 /Users/kkigomi/Dev/rhymix/classes/display/DisplayHandler.class.php(70): ModuleHandler::triggerCall()
#2 /Users/kkigomi/Dev/rhymix/classes/module/ModuleHandler.class.php(1222): DisplayHandler->printContent()
#3 /Users/kkigomi/Dev/rhymix/index.php(60): ModuleHandler->displayContent()
```

```
요청 데이터
MIME 유형: application/x-www-form-urlencoded; charset=UTF-8
module: document.procDocumentVoteUp
act[target_srl]: 4124
act[cur_mid]: board
act[mid]: board
```