### PR TITLE
PageHandler Iterator 사용 시 페이지가 잘못 표시되는 문제 수정

### DIFF
--- a/classes/page/PageHandler.class.php
+++ b/classes/page/PageHandler.class.php
@@ -108,7 +108,7 @@ class PageHandler extends Handler implements Iterator
 	public function valid(): bool
 	{
 		$page = $this->first_page + $this->point;
-		return $this->point <= $this->page_count && $page <= $this->last_page;
+		return $this->point < $this->page_count && $page <= $this->last_page;
 	}
 
 	/**


### PR DESCRIPTION
기본 `$page_count`가 10일 경우 11개가 표시되는 문제를 수정하였습니다.
ex) `$page_count = 5` 6개까지 표시됨