### PR TITLE
관리페이지 설정 폼에서 숫자 입력 항목 필드의 type 을 number 로 변경

### DIFF
--- a/modules/admin/tpl/config_advanced.html
+++ b/modules/admin/tpl/config_advanced.html
@@ -179,7 +179,7 @@
 		<div class="x_control-group">
 			<label class="x_control-label" for="cache_default_ttl">{$lang->cache_default_ttl}</label>
 			<div class="x_controls">
-				<input type="text" name="cache_default_ttl" id="cache_default_ttl" value="{$cache_default_ttl}" /> {$lang->unit_sec}
+				<input type="number" min="1" name="cache_default_ttl" id="cache_default_ttl" value="{$cache_default_ttl}" /> {$lang->unit_sec}
 			</div>
 		</div>
 		<div class="x_control-group">

--- a/modules/board/tpl/board_insert.html
+++ b/modules/board/tpl/board_insert.html
@@ -78,21 +78,21 @@
 		<div class="x_control-group">
 			<label class="x_control-label" for="list_count">{$lang->list_count}</label>
 			<div class="x_controls">
-				<input type="text" name="list_count" id="list_count" value="{$module_info->list_count?$module_info->list_count:20}" style="width:30px" />
+				<input type="number" min="1" name="list_count" id="list_count" value="{$module_info->list_count?$module_info->list_count:20}" />
 				<p class="x_help-inline">{$lang->about_list_count}</p>
 			</div>
 		</div>
 		<div class="x_control-group">
 			<label class="x_control-label" for="search_list_count">{$lang->search_list_count}</label>
 			<div class="x_controls">
-				<input type="text" name="search_list_count" id="search_list_count" value="{$module_info->search_list_count?$module_info->search_list_count:20}" style="width:30px" />
+				<input type="number" min="1" name="search_list_count" id="search_list_count" value="{$module_info->search_list_count?$module_info->search_list_count:20}" />
 				<p class="x_help-inline">{$lang->about_search_list_count}</p>
 			</div>
 		</div>
 		<div class="x_control-group">
 			<label class="x_control-label" for="page_count">{$lang->page_count}</label>
 			<div class="x_controls">
-				<input type="text" name="page_count" id="page_count" value="{$module_info->page_count?$module_info->page_count:10}" style="width:30px" />
+				<input type="number" min="1" name="page_count" id="page_count" value="{$module_info->page_count?$module_info->page_count:10}" />
 				<p class="x_help-inline">{$lang->about_page_count}</p>
 			</div>
 		</div>
@@ -143,21 +143,21 @@
 		<div class="x_control-group">
 			<label class="x_control-label" for="mobile_list_count">{$lang->list_count}</label>
 			<div class="x_controls">
-				<input type="text" name="mobile_list_count" id="mobile_list_count" value="{$module_info->mobile_list_count?$module_info->mobile_list_count:20}" style="width:30px" />
+				<input type="number" min="1" name="mobile_list_count" id="mobile_list_count" value="{$module_info->mobile_list_count?$module_info->mobile_list_count:20}" />
 				<p class="x_help-inline">{$lang->about_list_count}</p>
 			</div>
 		</div>
 		<div class="x_control-group">
 			<label class="x_control-label" for="mobile_search_list_count">{$lang->search_list_count}</label>
 			<div class="x_controls">
-				<input type="text" name="mobile_search_list_count" id="mobile_search_list_count" value="{$module_info->mobile_search_list_count?$module_info->mobile_search_list_count:20}" style="width:30px" />
+				<input type="number" min="1" name="mobile_search_list_count" id="mobile_search_list_count" value="{$module_info->mobile_search_list_count?$module_info->mobile_search_list_count:20}" />
 				<p class="x_help-inline">{$lang->about_search_list_count}</p>
 			</div>
 		</div>
 		<div class="x_control-group">
 			<label class="x_control-label" for="mobile_page_count">{$lang->page_count}</label>
 			<div class="x_controls">
-				<input type="text" name="mobile_page_count" id="mobile_page_count" value="{$module_info->mobile_page_count?$module_info->mobile_page_count:5}" style="width:30px" />
+				<input type="number" min="1" name="mobile_page_count" id="mobile_page_count" value="{$module_info->mobile_page_count?$module_info->mobile_page_count:5}" />
 				<p class="x_help-inline">{$lang->about_mobile_page_count}</p>
 			</div>
 		</div>
@@ -243,7 +243,7 @@
 					<input type="checkbox" name="skip_bottom_list_for_olddoc" id="skip_bottom_list_for_olddoc" value="Y" checked="checked"|cond="$module_info->skip_bottom_list_for_olddoc === 'Y'" />
 					{$lang->skip_bottom_list_for_olddoc}
 				</label>
-				<input type="number" name="skip_bottom_list_days" value="{$module_info->skip_bottom_list_days ?: 30}" /> {$lang->unit_day}
+				<input type="number" min="1" name="skip_bottom_list_days" value="{$module_info->skip_bottom_list_days ?: 30}" /> {$lang->unit_day}
 				<br />
 				<label for="skip_bottom_list_for_robot">
 					<input type="checkbox" name="skip_bottom_list_for_robot" id="skip_bottom_list_for_robot" value="Y" checked="checked"|cond="$module_info->skip_bottom_list_for_robot === 'Y'" />
@@ -278,14 +278,14 @@
 		<div class="x_control-group">
 			<label class="x_control-label">{$lang->document_length_limit}</label>
 			<div class="x_controls">
-				<input type="number" name="document_length_limit" id="document_length_limit" value="{$module_info->document_length_limit ?: 1024}" /> KB
+				<input type="number" min="1" name="document_length_limit" id="document_length_limit" value="{$module_info->document_length_limit ?: 1024}" /> KB
 				<p class="x_help-block">{$lang->about_document_length_limit}</p>
 			</div>
 		</div>
 		<div class="x_control-group">
 			<label class="x_control-label">{$lang->comment_length_limit}</label>
 			<div class="x_controls">
-				<input type="number" name="comment_length_limit" id="comment_length_limit" value="{$module_info->comment_length_limit ?: 128}" /> KB
+				<input type="number" min="1" name="comment_length_limit" id="comment_length_limit" value="{$module_info->comment_length_limit ?: 128}" /> KB
 				<p class="x_help-block">{$lang->about_comment_length_limit}</p>
 			</div>
 		</div>
@@ -367,8 +367,8 @@
 		<div class="x_control-group">
 			<label class="x_control-label">{$lang->protect_regdate}</label>
 			<div class="x_controls">
-				{$lang->document} : <input type="number" name="protect_document_regdate" id="protect_document_regdate" value="{$module_info->protect_document_regdate}" />
-				{$lang->comment} : <input type="number" name="protect_comment_regdate" id="protect_comment_regdate" value="{$module_info->protect_comment_regdate}" />
+				{$lang->document} : <input type="number" min="0" name="protect_document_regdate" id="protect_document_regdate" value="{$module_info->protect_document_regdate}" />
+				{$lang->comment} : <input type="number" min="0" name="protect_comment_regdate" id="protect_comment_regdate" value="{$module_info->protect_comment_regdate}" />
 				<p>{$lang->about_protect_regdate}</p>
 			</div>
 		</div>

--- a/modules/board/tpl/board_setup_basic.html
+++ b/modules/board/tpl/board_setup_basic.html
@@ -39,7 +39,7 @@
 	<div class="x_control-group">
 		<label class="x_control-label" for="list_count">{$lang->list_count}</label>
 		<div class="x_controls">
-			<input type="text" name="list_count" id="list_count" value="{$module_info->list_count?$module_info->list_count:20}" style="width:30px" />
+			<input type="number" min="1" name="list_count" id="list_count" value="{$module_info->list_count?$module_info->list_count:20}" />
 			<p class="x_help-inline">{$lang->about_list_count}</p>
 		</div>
 	</div>

--- a/modules/document/tpl/document_config.html
+++ b/modules/document/tpl/document_config.html
@@ -44,7 +44,7 @@
 	<div class="x_control-group">
 		<label class="x_control-label" for="search_division">{$lang->cmd_search_division}</label>
 		<div class="x_controls">
-			<input type="number" name="search_division" value="{$config->search_division ?? 5000}" />
+			<input type="number" min="0" name="search_division" value="{$config->search_division ?? 5000}" />
 			<p class="x_help-block">{$lang->about_search_division}</p>
 		</div>
 	</div>

--- a/modules/page/tpl/page_info.html
+++ b/modules/page/tpl/page_info.html
@@ -96,7 +96,7 @@
 	<div class="x_control-group" cond="$module_info->page_type != 'ARTICLE'">
 		<label class="x_control-label" for="page_caching_interval">{$lang->page_caching_interval}</label>
 		<div class="x_controls">
-			<input type="text" name="page_caching_interval" id="page_caching_interval" value="{(int)$module_info->page_caching_interval}"  /> {$lang->unit_min}
+			<input type="number" min="0" name="page_caching_interval" id="page_caching_interval" value="{(int)$module_info->page_caching_interval}"  /> {$lang->unit_min}
 			<p class="x_help-block" id="aboutCaching">{$lang->about_page_caching_interval}</p>
 		</div>
 	</div>

--- a/modules/spamfilter/tpl/config_block.html
+++ b/modules/spamfilter/tpl/config_block.html
@@ -21,8 +21,8 @@
 					</label>
 				</p>
 				<p>
-					<input type="number" name="limits_interval" id="limits_interval" value="{intval($config->limits_interval) ?: 10}" /> {$lang->unit_sec} &nbsp;
-					<input type="number" name="limits_count" id="limits_count" value="{intval($config->limits_count) ?: 3}" /> {$lang->unit_write_count}
+					<input type="number" min="1" name="limits_interval" id="limits_interval" value="{intval($config->limits_interval) ?: 10}" /> {$lang->unit_sec} &nbsp;
+					<input type="number" min="1" name="limits_count" id="limits_count" value="{intval($config->limits_count) ?: 3}" /> {$lang->unit_write_count}
 				</p>
 				<p class="x_help-block">{$lang->cmd_interval_help}</p>
 			</div>


### PR DESCRIPTION
숫자만 입력받는 항목을 number 타입으로 변경했습니다.

관리페이지 모든 거의 모든 항목을 클릭해서 보긴했는데 감춰진 페이지가 있는지는 모르겠습니다.

`px` 같은 단위와 함께 입력되는 항목은 제외했고, 설정을 저장해보고 음수나 `0`으로 입력 시 무시되는 항목을 체크해서 `min` 속성에 `0` 또는 `1`로 설정했습니다.
"페이지 목록 수"처럼 `0`이 되어서는 안 되는 항목은 `1`로 설정했습니다.

디버그 설정처럼 소수로 입력 받는 항목은 제외했습니다.