### PR TITLE
위젯 설정 등의 페이지에서 파일박스에 업로드 후 문제 수정

### DIFF
--- a/common/js/plugins/filebox/filebox.js
+++ b/common/js/plugins/filebox/filebox.js
@@ -136,7 +136,11 @@ jQuery(document).ready(function($){
 			$iframe.attr('src', '#');
 			$iframe.attr('name', 'iframeTarget');
 			$iframe.load(function(){
-				var data = eval('(' + $(window.iframeTarget.document.getElementsByTagName("body")[0]).html() + ')');
+				var content = window.iframeTarget.document.getElementsByTagName('pre');
+				if (!content) {
+					content = window.iframeTarget.document.getElementsByTagName('body');
+				}
+				var data = eval('(' + $(content).html() + ')');
 
 				if (data.error){
 					alert(data.message);


### PR DESCRIPTION
파일박스에서 업로드 후 `iframe` 컨텐츠에 출력된 데이터를 가져오지 못하는 문제를 해결합니다.

원인이 뚜렷하지 않지만 사파리와 크롬(맥 버전)에서 동일하게 `<body>` 태그 안에 `<pre>` 태그가 데이터를 감싸고 있어 데이터를 제대로 처리하지 못하는 문제입니다.

`<pre>` 태그를 먼저 확인하도록하여 문제를 해결하도록 했습니다.

가능하면 좀 더 나은 개선 방법이 있겠지만 현 상황을 유지한채로 처리하였습니다.

이 문제는 위젯의 확장변수에서 `filebox`를 사용할 때 문제를 확인할 수 있습니다.  
(관리페이지의 파일박스에서는 문제 없음)

