### PR TITLE
`debugPrint()` 함수에 파라미터를 다수 사용할 수 있도록 개선

### DIFF
--- a/common/legacy.php
+++ b/common/legacy.php
@@ -789,12 +789,16 @@ function getEncodeEmailAddress($email): string
  */
 function debugPrint(...$entry): void
 {
-	if (count($entry) <= 1)
+	if (count($entry) === 1)
 	{
-		$entry = $entry[0] ?? null;
+		Rhymix\Framework\Debug::addEntry($entry[0]);
+		return;
 	}
 
-	Rhymix\Framework\Debug::addEntry($entry);
+	foreach ($entry as $v)
+	{
+		Rhymix\Framework\Debug::addEntry($v);
+	}
 }
 
 /**

--- a/common/legacy.php
+++ b/common/legacy.php
@@ -789,9 +789,9 @@ function getEncodeEmailAddress($email): string
  */
 function debugPrint(...$entry): void
 {
-	if (func_num_args() === 1)
+	if (count($entry) <= 1)
 	{
-		$entry = $entry[0];
+		$entry = $entry[0] ?? null;
 	}
 
 	Rhymix\Framework\Debug::addEntry($entry);

--- a/common/legacy.php
+++ b/common/legacy.php
@@ -784,18 +784,15 @@ function getEncodeEmailAddress($email): string
 /**
  * Add an entry to the debug log.
  *
- * @param mixed ...$entry Target object to be printed
+ * @param mixed $value The expression to dump.
+ * @param mixed $values Further expressions to dump.
  * @return void
  */
-function debugPrint(...$entry): void
+function debugPrint($value, ...$values): void
 {
-	if (count($entry) === 1)
-	{
-		Rhymix\Framework\Debug::addEntry($entry[0]);
-		return;
-	}
+	Rhymix\Framework\Debug::addEntry($value);
 
-	foreach ($entry as $v)
+	foreach ($values as $v)
 	{
 		Rhymix\Framework\Debug::addEntry($v);
 	}

--- a/common/legacy.php
+++ b/common/legacy.php
@@ -784,11 +784,16 @@ function getEncodeEmailAddress($email): string
 /**
  * Add an entry to the debug log.
  *
- * @param mixed $entry Target object to be printed
+ * @param mixed ...$entry Target object to be printed
  * @return void
  */
-function debugPrint($entry = null): void
+function debugPrint(...$entry): void
 {
+	if (func_num_args() === 1)
+	{
+		$entry = $entry[0];
+	}
+
 	Rhymix\Framework\Debug::addEntry($entry);
 }
 


### PR DESCRIPTION
다수의 변수 등을 확인해야 할 때 약간의 타이핑 편의를 위한 사소한 개선입니다.

현재
```php
debugPrint($arg1);
debugPrint($arg2);
debugPrint('content');

// 또는
debugPrint( array($arg1, $arg2, 'content') );
```

변경된 개선안
```php
debugPrint($arg1, $arg2, 'content');
```

