### PR TITLE
SessionHelper 클래스에서 dynamic 프로퍼티 문제 수정

### DIFF
--- a/common/framework/helpers/SessionHelper.php
+++ b/common/framework/helpers/SessionHelper.php
@@ -4,39 +4,78 @@ namespace Rhymix\Framework\Helpers;
 
 /**
  * Session helper class.
+ *
+ * @property int $member_srl
+ * @property ?string $user_id
+ * @property ?string $password
+ * @property ?string $email_address
+ * @property ?string $email_id
+ * @property ?string $email_host
+ * @property ?string $phone_number
+ * @property ?string $phone_country
+ * @property ?string $phone_type
+ * @property ?string $user_name
+ * @property ?string $nick_name
+ * @property ?string $find_account_question
+ * @property ?string $find_account_answer
+ * @property ?string $homepage
+ * @property ?string $blog
+ * @property ?string $birthday
+ * @property 'Y'|'N'|null $allow_mailing
+ * @property 'Y'|'N'|null $allow_message
+ * @property 'Y'|'N' $is_admin
+ * @property 'Y'|'N'|null $denied
+ * @property ?string $status
+ * @property ?string $regdate
+ * @property ?string $ipaddress
+ * @property ?string $last_login
+ * @property ?string $last_login_ipaddress
+ * @property ?string $change_password_date
+ * @property ?string $limit_date
+ * @property ?string $description
+ * @property ?int $list_order
+ * @property ?object{
+ *     'width': int,
+ *     'height': int,
+ *     'src': string,
+ *     'file': string,
+ * } $profile_image
+ * @property ?string $image_name
+ * @property ?string $image_mark
+ * @property ?string $signature
+ * @property ?array<string, string> $group_list
+ * @property ?array<string> $menu_list
+ * @property ?bool $is_site_admin
+ * @property ?string $refused_reason
+ * @property ?string $limited_reason
+ * @property ?array<string> $phone
  */
-#[\AllowDynamicProperties]
 class SessionHelper
 {
 	/**
-	 * Instance properties.
+	 * @var array<string, mixed>
 	 */
-	public $member_srl = 0;
-	public $is_admin = 'N';
-	public $group_list = array();
-	public $menu_list = array();
+	protected $member_info = array(
+		'member_srl' => 0,
+		'is_admin' => 'N',
+	);
 
 	/**
 	 * Constructor.
 	 *
 	 * @param int $member_srl (optional)
-	 * @return void
 	 */
-	public function __construct($member_srl = 0)
+	public function __construct(int $member_srl = 0)
 	{
 		// Load member information.
 		$member_srl = intval($member_srl);
 		if ($member_srl)
 		{
 			$member_info = \MemberModel::getMemberInfo($member_srl);
-			if (isset($member_info->member_srl) && intval($member_info->member_srl) === $member_srl)
+			if (($member_info->member_srl ?? null) === $member_srl)
 			{
-				foreach (get_object_vars($member_info) as $key => $value)
-				{
-					$this->{$key} = $value;
-				}
-				$this->member_srl = $member_srl;
-				$this->group_list = \MemberModel::getMemberGroups($member_srl);
+				$this->member_info = get_object_vars($member_info);
+				$this->member_info['menu_list'] = $this->member_info['menu_list'] ?? array();
 			}
 		}
 	}
@@ -79,14 +118,51 @@ class SessionHelper
 	 */
 	public function isValid(): bool
 	{
-		if ($this->denied === 'N' && (!$this->limit_date || substr($this->limit_date, 0, 8) < date('Ymd')))
-		{
-			return true;
-		}
-		else
+		if ($this->denied === 'N')
 		{
 			return false;
 		}
+
+		if (!!$this->limit_date && str_starts_with($this->limit_date, date('Ymd')))
+		{
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Check if profile image exist
+	 */
+	public function profileImageExists(): bool
+	{
+		return !!($this->member_info['profile_image']->src ?? null);
+	}
+
+	/**
+	 * Profile image URL
+	 */
+	public function profileImageUrl(): ?string
+	{
+		if (!($this->member_info['profile_image']->src ?? null))
+		{
+			return null;
+		}
+
+		return $this->member_info['profile_image']->src;
+	}
+
+	/**
+	 * Profile image path
+	 */
+	public function profileImagePath(): ?string
+	{
+		if (!($this->member_info['profile_image']->file ?? null))
+		{
+			return null;
+		}
+
+		return \FileHandler::getRealPath($this->member_info['profile_image']->file);
 	}
 
 	/**
@@ -96,6 +172,29 @@ class SessionHelper
 	 */
 	public function getGroups(): array
 	{
-		return $this->group_list;
+		return $this->member_info['group_list'] ?? [];
+	}
+
+	/**
+	 * @return mixed
+	 */
+	public function &__get(string $name)
+	{
+		if (isset($this->member_info[$name])) {
+			return $this->member_info[$name];
+		}
+
+		// Trigger the `Undefined property` warning
+		trigger_error('Undefined property: ' . __CLASS__ . '::$' . $name, E_USER_WARNING);
+
+		return $this->member_info[$name];
+	}
+
+	/**
+	 * @param mixed $value
+	 */
+	public function __set(string $name, $value): void
+	{
+		$this->member_info[$name] = $value;
 	}
 }

--- a/tests/unit/framework/SessionTest.php
+++ b/tests/unit/framework/SessionTest.php
@@ -266,6 +266,24 @@ class SessionTest extends \Codeception\Test\Unit
 		Rhymix\Framework\Session::close();
 	}
 
+	public function testProfileImage()
+	{
+		$member_info = new Rhymix\Framework\Helpers\SessionHelper();
+
+		$this->assertFalse($member_info->profileImageExists());
+		$this->assertNull($member_info->profileImageUrl());
+		$this->assertNull($member_info->profileImagePath());
+
+		$member_info->profile_image = (object) array(
+			'src' => '/tests/_data/images/rhymix.png?t=12345678',
+			'file' => './tests/_data/images/rhymix.png'
+		);
+
+		$this->assertTrue($member_info->profileImageExists());
+		$this->assertEquals('/tests/_data/images/rhymix.png?t=12345678', $member_info->profileImageUrl());
+		$this->assertEquals(\RX_BASEDIR . 'tests/_data/images/rhymix.png', $member_info->profileImagePath());
+	}
+
 	public function testGetSetLanguage()
 	{
 		@Rhymix\Framework\Session::start();


### PR DESCRIPTION
`#[\AllowDynamicProperties]` attribute 를 제거하여 미래의 PHP 변경에 대비합니다.

대신 `__get()`, `__set()` 매직 메소드를 이용해 프로퍼티 문제를 해결합니다.

주석에 이 클래스에서 사용할 수 있는 프로퍼티 목록과 타입을 정의합니다.

프로필 이미지를 확인하고 가져오는 메소드를 추가했습니다.