### PR TITLE
Debug 메시지가 `json_encode()` 오류로 인해 잘못된 포맷으로 응답을 생성하는 문제 해결

### DIFF
--- a/classes/display/DisplayHandler.class.php
+++ b/classes/display/DisplayHandler.class.php
@@ -257,7 +257,11 @@ class DisplayHandler extends Handler
 						unset($_SESSION['_rx_debug_previous']);
 						if (preg_match('/^(.+)\}$/', $output, $matches))
 						{
-							$output = $matches[1] . ',"_rx_debug":' . json_encode($data) . '}';
+							$data = json_encode($data);
+							if (json_last_error() === JSON_ERROR_NONE)
+							{
+								$output = $matches[1] . ',"_rx_debug":' . $data . '}';
+							}
 						}
 						break;
 					default:


### PR DESCRIPTION
`_rx_debug` 데이터를 JSON 응답 데이터에 끼워넣기위한 코드에서 JSON 인코딩이 실패할 때 잘못된 응답이 생성되는 문제를 해결합니다.

예로, JSON  인코딩에 실패하면 다음과 같이 잘못된 형식으로 변조됩니다.

```php
{'data': 'value'}

// 다음과 같이 잘못된 응답을 생성함
{'data': 'value','_rx_debug':}
```