### PR TITLE
회원정보 변경시 member 테이블의 phone_number, phone_country, phone_type 컬럼을 빈 값으로 업데이트 하는 오류를 개선.

### DIFF
--- a/modules/member/member.controller.php
+++ b/modules/member/member.controller.php
@@ -3187,9 +3187,9 @@ class MemberController extends Member
 		}
 		else
 		{
-			$args->phone_country = '';
-			$args->phone_number = '';
-			$args->phone_type = '';
+			unset($args->phone_country);
+			unset($args->phone_number);
+			unset($args->phone_type);
 		}
 
 		// Check managed Email Host


### PR DESCRIPTION
insertMember 메소드의 코드를 updateMember 에도 복붙해서 이 오류가 발생한 것 같습니다.