### PR TITLE
회원가입 추가 항목에 tel_intl, tel_intl_v2 추가

### DIFF
--- a/modules/member/member.admin.view.php
+++ b/modules/member/member.admin.view.php
@@ -711,9 +711,9 @@ class MemberAdminView extends Member
 					else if($extendForm->column_type == 'tel')
 					{
 						$extentionReplace = array(
-							'tel_0' => $extendForm->value[0],
-							'tel_1' => $extendForm->value[1],
-							'tel_2' => $extendForm->value[2]
+							'tel_0' => $extendForm->value[0] ?? '',
+							'tel_1' => $extendForm->value[1] ?? '',
+							'tel_2' => $extendForm->value[2] ?? ''
 						);
 						$template = '<input type="tel" class="rx_ev_tel1" name="%column_name%[]" id="%column_name%" value="%tel_0%" size="4" maxlength="4" style="width:30px" title="First Number" /> - <input type="tel" class="rx_ev_tel2" name="%column_name%[]" value="%tel_1%" size="4" maxlength="4" style="width:35px" title="Second Number" /> - <input type="tel" class="rx_ev_tel3" name="%column_name%[]" value="%tel_2%" size="4" maxlength="4" style="width:35px" title="Third Number" />';
 					}
@@ -721,6 +721,40 @@ class MemberAdminView extends Member
 					{
 						$extentionReplace = array('tel_0' => $extendForm->value[0] ?? '');
 						$template = '<input type="tel" class="rx_ev_tel1" name="%column_name%[]" id="%column_name%" value="%tel_0%" size="16" maxlength="16" style="width:100px" />';
+					}
+					else if($extendForm->column_type == 'tel_intl' || $extendForm->column_type == 'tel_intl_v2')
+					{
+						$extentionReplace = array(
+							'tel_0' => $extendForm->value[0] ?? '',
+							'tel_1' => $extendForm->value[1] ?? '',
+							'tel_2' => $extendForm->value[2] ?? '',
+							'tel_3' => $extendForm->value[3] ?? ''
+						);
+						$template = '<select name="%column_name%[]" class="rx_ev_select">';
+						$template .= ' <option value=""></option>';
+						$lang_type = Context::get('lang_type');
+						$country_list = Rhymix\Framework\i18n::listCountries($lang_type === 'ko' ? Rhymix\Framework\i18n::SORT_NAME_KOREAN : Rhymix\Framework\i18n::SORT_NAME_ENGLISH);
+						foreach ($country_list as $country)
+						{
+							if ($country->calling_code)
+							{
+								$template .= '<option value="' . $country->calling_code . '"' . ($country->calling_code === $extendForm->value[0] ? ' selected="selected"' : '') . '>';
+								$template .= escape(Context::get('lang_type') === 'ko' ? $country->name_korean : $country->name_english) . ' (+' . $country->calling_code . ')</option>';
+							}
+						}
+						$template .= '</select>' . "\n";
+						if ($extendForm->column_type == 'tel_intl_v2')
+						{
+							if ($extentionReplace['tel_0'] === '82')
+							{
+								$extentionReplace['tel_1'] = Rhymix\Framework\Korea::formatPhoneNumber($extendForm->value[1]);
+							}
+							$template .= '<input type="tel" class="rx_ev_tel_v2" name="%column_name%[]" id="%column_name%" value="%tel_1%" size="16" maxlength="16" style="width:157px" />';
+						}
+						else
+						{
+							$template .= '<input type="tel" class="rx_ev_tel1" name="%column_name%[]" id="%column_name%" value="%tel_1%" size="4" maxlength="4" style="width:30px" title="First Number" /> - <input type="tel" class="rx_ev_tel2" name="%column_name%[]" value="%tel_2%" size="4" maxlength="4" style="width:35px" title="Second Number" /> - <input type="tel" class="rx_ev_tel3" name="%column_name%[]" value="%tel_3%" size="4" maxlength="4" style="width:35px" title="Third Number" />';
+						}
 					}
 					else if($extendForm->column_type == 'textarea')
 					{

--- a/modules/member/member.view.php
+++ b/modules/member/member.view.php
@@ -255,6 +255,19 @@ class MemberView extends Member
 				{
 					$item->value = implode('-', $orgValue);
 				}
+				elseif($formInfo->type=='tel_intl' && is_array($orgValue))
+				{
+					$country_number = $orgValue[0] ?? '';
+					$array_slice = $orgValue ? array_slice($orgValue, 1) : [];
+					$phone_number = implode('-', $array_slice);
+					$item->value = $orgValue ? "+{$country_number}){$phone_number}": '';
+				}
+				elseif($formInfo->type=='tel_intl_v2' && is_array($orgValue))
+				{
+					$country_number = $orgValue[0] ?? '';
+					$phone_number =  $orgValue[1] ? ($country_number === '82' ? Rhymix\Framework\Korea::formatPhoneNumber($orgValue[1]) : $orgValue[1]) : '';
+					$item->value = $orgValue ? "+{$country_number}){$phone_number}": '';
+				}
 				elseif($formInfo->type=='kr_zip' && is_array($orgValue))
 				{
 					$item->value = implode(' ', $orgValue);


### PR DESCRIPTION
- 국제전화번호 (입력란 4개)
- 국제전화번호 (입력란 2개)
위 2개 항목의 폼을 추가합니다.

다만, 고려가 필요한 점이 있습니다.

이 PR은 게시판 확장변수와 동일하게 `calling code`를 기준으로 국가를 선택하도록 하였습니다.
그러나 기존에 2.0에서 추가된 게시판 확장변수 국제번호 선택이 `calling code`가 중복되는 경우 오작동 하는 문제가 있습니다.
예) `미국 (+1)`, `도미니카 공화국 (+1)`
예) `러시아 (+7)`, `카자흐스탄 (+7)`

장기적으로는 국가 영문 코드 등으로 변경하는 것이 좋지 않을까 합니다.
게시판 확장변수 쪽도 변경 해도 된다면 영문 코드 방식으로 추가 PR넣겠습니다.