### PR TITLE
CKEditor에 붙여넣거나 드래그&드롭한 이미지 자동 업로드

### DIFF
--- a/common/js/plugins/ckeditor/ckeditor/plugins/rx_upload/plugin.js
+++ b/common/js/plugins/ckeditor/ckeditor/plugins/rx_upload/plugin.js
@@ -8,7 +8,7 @@ CKEDITOR.plugins.add('rx_upload', {
 	init: function(editor) {
 
 		/**
-		 * Prevent the clipboard plugin from interfering with file type support.
+		 * Prevent the clipboard plugin from displaying the "file type not supported" error.
 		 */
 		editor.plugins.clipboard._supportedFileMatchers.unshift(function() { return true; });
 
@@ -41,7 +41,7 @@ CKEDITOR.plugins.add('rx_upload', {
 
 			// Get the editor sequence.
 			const editor_container = $(editor.container.$).parents('.rx_ckeditor');
-			const upload_container = editor_container.next('.xefu-container');
+			const upload_container = editor_container.nextAll('.xefu-container').first();
 			const editor_sequence = editor_container.data('editorSequence');
 
 			// Generate the form data.

--- a/common/js/plugins/ckeditor/ckeditor/plugins/rx_upload/plugin.js
+++ b/common/js/plugins/ckeditor/ckeditor/plugins/rx_upload/plugin.js
@@ -1,7 +1,10 @@
+'use strict';
+
 /**
  * Upload plugin for Rhymix
  */
 CKEDITOR.plugins.add('rx_upload', {
+
 	init: function(editor) {
 
 		/**
@@ -53,11 +56,15 @@ CKEDITOR.plugins.add('rx_upload', {
 				data: form,
 				dataType: 'json',
 				success: function(data) {
-					insertFile(upload_container, data);
-					reloadFileList(upload_container, data);
+					if (data.error == 0) {
+						insertFile(upload_container, data);
+						reloadFileList(upload_container, data);
+					} else {
+						displayError(8, data.message);
+					}
 				},
 				error: function(jqXHR) {
-					alert('Upload error: ' + jqXHR.responseText);
+					displayError(9, jqXHR.responseText);
 				}
 			});
 		};
@@ -66,10 +73,6 @@ CKEDITOR.plugins.add('rx_upload', {
 		 * Insert file into editor.
 		 */
 		const insertFile = function(container, data) {
-			if (data.error != 0) {
-				alert(data.message);
-				return;
-			}
 
 			let temp_code = '';
 			if(/\.(gif|jpe?g|png|webp)$/i.test(data.source_filename)) {
@@ -112,5 +115,13 @@ CKEDITOR.plugins.add('rx_upload', {
 			container.data('instance').loadFilelist(container, true);
 		};
 
+		/**
+		 * Display an error message.
+		 */
+		const displayError = function(type, message) {
+			alert(window.xe.msg_file_upload_error + ' (Type ' + type + ")\n" + message);
+		};
+
 	}
+
 });

--- a/common/js/plugins/ckeditor/ckeditor/plugins/rx_upload/plugin.js
+++ b/common/js/plugins/ckeditor/ckeditor/plugins/rx_upload/plugin.js
@@ -8,6 +8,11 @@ CKEDITOR.plugins.add('rx_upload', {
 	init: function(editor) {
 
 		/**
+		 * Prevent the clipboard plugin from interfering with file type support.
+		 */
+		editor.plugins.clipboard._supportedFileMatchers.unshift(function() { return true; });
+
+		/**
 		 * The main event handler for paste and drop.
 		 */
 		editor.on('paste', function(event) {

--- a/common/js/plugins/ckeditor/ckeditor/plugins/rx_upload/plugin.js
+++ b/common/js/plugins/ckeditor/ckeditor/plugins/rx_upload/plugin.js
@@ -43,7 +43,7 @@ CKEDITOR.plugins.add('rx_upload', {
 		const uploadFile = function(file) {
 
 			// Get the editor sequence.
-			const editor_container = $(editor.container.$).parents('.rx_ckeditor');
+			const editor_container = $(editor.container.$).closest('.rx_ckeditor');
 			const upload_container = editor_container.nextAll('.xefu-container').first();
 			const editor_sequence = editor_container.data('editorSequence');
 

--- a/common/js/plugins/ckeditor/ckeditor/plugins/rx_upload/plugin.js
+++ b/common/js/plugins/ckeditor/ckeditor/plugins/rx_upload/plugin.js
@@ -1,0 +1,116 @@
+/**
+ * Upload plugin for Rhymix
+ */
+CKEDITOR.plugins.add('rx_upload', {
+	init: function(editor) {
+
+		/**
+		 * The main event handler for paste and drop.
+		 */
+		editor.on('paste', function(event) {
+
+			// Check if the pasted data contains any files.
+			const method = event.data.method;
+			const dataTransfer = event.data.dataTransfer;
+			const files_count = dataTransfer.getFilesCount();
+			if (!files_count) {
+				return;
+			}
+
+			// Prevent the default plugin from touching these files.
+			event.stop();
+
+			// Read and upload each file.
+			for (let i = 0; i < files_count; i++) {
+				uploadFile(dataTransfer.getFile(i));
+			}
+		});
+
+		/**
+		 * Upload function.
+		 */
+		const uploadFile = function(file) {
+
+			// Get the editor sequence.
+			const editor_container = $(editor.container.$).parents('.rx_ckeditor');
+			const upload_container = editor_container.next('.xefu-container');
+			const editor_sequence = editor_container.data('editorSequence');
+
+			// Generate the form data.
+			const form = new FormData();
+			form.append('mid', window.editor_mid ? window.editor_mid : window.current_mid);
+			form.append('act', 'procFileUpload');
+			form.append('editor_sequence', editor_sequence);
+			form.append('Filedata', file);
+
+			// Upload!
+			$.ajax({
+				url: window.request_uri,
+				type: 'POST',
+				contentType: false,
+				processData: false,
+				cache: false,
+				data: form,
+				dataType: 'json',
+				success: function(data) {
+					insertFile(upload_container, data);
+					reloadFileList(upload_container, data);
+				},
+				error: function(jqXHR) {
+					alert('Upload error: ' + jqXHR.responseText);
+				}
+			});
+		};
+
+		/**
+		 * Insert file into editor.
+		 */
+		const insertFile = function(container, data) {
+			if (data.error != 0) {
+				alert(data.message);
+				return;
+			}
+
+			let temp_code = '';
+			if(/\.(gif|jpe?g|png|webp)$/i.test(data.source_filename)) {
+				temp_code += '<img src="' + data.download_url + '" alt="' + data.source_filename + '" editor_component="image_link" data-file-srl="' + data.file_srl + '" />';
+			}
+			else if(/\.(mp3|wav|ogg|flac|aac)$/i.test(data.source_filename)) {
+				temp_code += '<audio src="' + data.download_url + '" controls data-file-srl="' + data.file_srl + '" />';
+			}
+			else if(/\.(mp4|webm|ogv)$/i.test(data.source_filename)) {
+				if(data.original_type === 'image/gif') {
+					temp_code += '<video src="' + data.download_url + '" autoplay loop muted playsinline data-file-srl="' + data.file_srl + '" />';
+				} else if (data.download_url.match(/\b(?:procFileDownload\b|files\/download\/)/)) {
+					if (!data.download_url.match(/^\//)) {
+						data.download_url = XE.URI(default_url).pathname() + data.download_url;
+					}
+					temp_code += '<video src="' + data.download_url + '" controls preload="none" data-file-srl="' + data.file_srl + '" />';
+				} else {
+					temp_code += '<video src="' + data.download_url + '" controls data-file-srl="' + data.file_srl + '" />';
+				}
+				if(data.thumbnail_filename) {
+					temp_code = temp_code.replace('controls', 'poster="' + data.thumbnail_filename.replace(/^.\//, XE.URI(default_url).pathname()) + '" controls');
+				}
+			}
+			else {
+				temp_code += '<a href="' + data.download_url + '" data-file-srl="' + data.file_srl + '">' + data.source_filename + "</a>\n";
+			}
+
+			if(temp_code !== '') {
+				temp_code = "<p>" + temp_code + "</p>\n";
+			}
+
+			editor.insertHtml(temp_code, 'unfiltered_html');
+		};
+
+		/**
+		 * Reload the file list.
+		 */
+		const reloadFileList = function(container, data) {
+			container.data('editorStatus', data);
+			container.data('instance').loadFilelist(container, true);
+		};
+
+	}
+});

--- a/common/js/plugins/ckeditor/ckeditor/plugins/rx_upload/plugin.js
+++ b/common/js/plugins/ckeditor/ckeditor/plugins/rx_upload/plugin.js
@@ -8,9 +8,12 @@ CKEDITOR.plugins.add('rx_upload', {
 	init: function(editor) {
 
 		/**
-		 * Prevent the clipboard plugin from displaying the "file type not supported" error.
+		 * Prevent the clipboard plugin from interfering with us.
 		 */
 		editor.plugins.clipboard._supportedFileMatchers.unshift(function() { return true; });
+		if (editor.config.clipboard_handleImages) {
+			editor.config.clipboard_handleImages = false;
+		}
 
 		/**
 		 * The main event handler for paste and drop.

--- a/common/js/plugins/ckeditor/ckeditor/plugins/rx_upload/plugin.js
+++ b/common/js/plugins/ckeditor/ckeditor/plugins/rx_upload/plugin.js
@@ -73,38 +73,8 @@ CKEDITOR.plugins.add('rx_upload', {
 		 * Insert file into editor.
 		 */
 		const insertFile = function(container, data) {
-
-			let temp_code = '';
-			if(/\.(gif|jpe?g|png|webp)$/i.test(data.source_filename)) {
-				temp_code += '<img src="' + data.download_url + '" alt="' + data.source_filename + '" editor_component="image_link" data-file-srl="' + data.file_srl + '" />';
-			}
-			else if(/\.(mp3|wav|ogg|flac|aac)$/i.test(data.source_filename)) {
-				temp_code += '<audio src="' + data.download_url + '" controls data-file-srl="' + data.file_srl + '" />';
-			}
-			else if(/\.(mp4|webm|ogv)$/i.test(data.source_filename)) {
-				if(data.original_type === 'image/gif') {
-					temp_code += '<video src="' + data.download_url + '" autoplay loop muted playsinline data-file-srl="' + data.file_srl + '" />';
-				} else if (data.download_url.match(/\b(?:procFileDownload\b|files\/download\/)/)) {
-					if (!data.download_url.match(/^\//)) {
-						data.download_url = XE.URI(default_url).pathname() + data.download_url;
-					}
-					temp_code += '<video src="' + data.download_url + '" controls preload="none" data-file-srl="' + data.file_srl + '" />';
-				} else {
-					temp_code += '<video src="' + data.download_url + '" controls data-file-srl="' + data.file_srl + '" />';
-				}
-				if(data.thumbnail_filename) {
-					temp_code = temp_code.replace('controls', 'poster="' + data.thumbnail_filename.replace(/^.\//, XE.URI(default_url).pathname()) + '" controls');
-				}
-			}
-			else {
-				temp_code += '<a href="' + data.download_url + '" data-file-srl="' + data.file_srl + '">' + data.source_filename + "</a>\n";
-			}
-
-			if(temp_code !== '') {
-				temp_code = "<p>" + temp_code + "</p>\n";
-			}
-
-			editor.insertHtml(temp_code, 'unfiltered_html');
+			const html = container.data('instance').generateHtml(container, data);
+			editor.insertHtml(html, 'unfiltered_html');
 		};
 
 		/**

--- a/modules/editor/skins/ckeditor/editor.html
+++ b/modules/editor/skins/ckeditor/editor.html
@@ -128,7 +128,6 @@
 	            fontSize_sizes: font_sizes,
 				toolbarCanCollapse: true,
 				allowedContent: true,
-				clipboard_handleImages: false,
 				startupFocus: {json_encode($editor_focus)},
 				language: "{str_replace('jp','ja',$lang_type)}",
 				iframe_attributes: {},
@@ -177,6 +176,7 @@
 		settings.ckeconfig.toolbarStartupExpanded = {$editor_toolbar_hide ? 'false' : 'true'};
 
 		// Add or remove plugins based on Rhymix configuration.
+		{@ $editor_additional_plugins[] = 'rx_upload'}
 		<!--@if($editor_additional_plugins)-->
 			settings.ckeconfig.extraPlugins = {json_encode(implode(',', $editor_additional_plugins))};
 		<!--@endif-->

--- a/modules/editor/skins/ckeditor/editor.html
+++ b/modules/editor/skins/ckeditor/editor.html
@@ -134,8 +134,7 @@
 				versionCheck: false
 			},
 			loadXeComponent: true,
-			enableToolbar: true,
-			content_field: jQuery('[name={$editor_content_key_name}]')
+			enableToolbar: true
 		};
 
 		// Add style-sheet for the WYSIWYG
@@ -219,15 +218,15 @@
 		var ckeApp = $('#ckeditor_instance_{$editor_sequence}').XeCkEditor(settings);
 
 		// Add use_editor and use_html fields to parent form.
-		var parentform = $('#ckeditor_instance_{$editor_sequence}').parents('form');
+		var parentform = $('#ckeditor_instance_{$editor_sequence}').closest('form');
 		var use_editor = parentform.find("input[name='use_editor']");
 		var use_html = parentform.find("input[name='use_html']");
-		if (use_editor.size()) {
+		if (use_editor.length) {
 			use_editor.val("Y");
 		} else {
 			parentform.append('<input type="hidden" name="use_editor" value="Y" />');
 		}
-		if (use_html.size()) {
+		if (use_html.length) {
 			use_html.val("Y");
 		} else {
 			parentform.append('<input type="hidden" name="use_html" value="Y" />');

--- a/modules/editor/skins/ckeditor/file_upload.html
+++ b/modules/editor/skins/ckeditor/file_upload.html
@@ -1,10 +1,17 @@
+<config autoescape="on" />
+<load target="./lang" />
+
 <!--%load_js_plugin("jquery.fileupload")-->
 <!--%load_js_plugin("jquery.finderSelect")-->
 <!--%load_js_plugin("handlebars")-->
-<load target="./lang" />
+
 <div cond="$allow_fileupload" id="xefu-container-{$editor_sequence}" class="xefu-container xe-clearfix"
 	data-editor-sequence="{$editor_sequence}"
-	data-editor-status="{escape(json_encode(FileModel::getInstance()->getFileList($editor_sequence)))}">
+	data-editor-status="{json_encode(FileModel::getInstance()->getFileList($editor_sequence), JSON_UNESCAPED_UNICODE)}"
+	data-max-file-size="{$logged_info->is_admin === 'Y' ? 0 : $file_config->allowed_filesize}"
+	data-max-chunk-size="{$file_config->allowed_chunk_size ?: 0}"
+	data-autoinsert-types="{json_encode($editor_autoinsert_types)}"
+	data-autoinsert-position="{$editor_autoinsert_position ?: 'paragraph'}">
 
 	<!--// dropzone -->
 	<div class="xefu-dropzone">
@@ -29,10 +36,9 @@
 		<div style="float: left;">
 			{$lang->ckeditor_file_count} (<span class="attached_size"></span> / <span class="allowed_attach_size"></span>)
 		</div>
-
 		<div style="float: right">
-			<input type="button" class="xefu-btn xefu-act-link-selected" style=" vertical-align: middle; vertical-align: middle;" value="{$lang->edit->link_file}">
-			<input type="button" class="xefu-btn xefu-act-delete-selected" style=" vertical-align: middle; vertical-align: middle;" value="{$lang->edit->delete_selected}">
+			<input type="button" class="xefu-btn xefu-act-link-selected" style="vertical-align: middle" value="{$lang->edit->link_file}">
+			<input type="button" class="xefu-btn xefu-act-delete-selected" style="vertical-align: middle" value="{$lang->edit->delete_selected}">
 		</div>
 	</div>
 
@@ -41,7 +47,6 @@
 			<ul>
 			</ul>
 		</div>
-
 		<div class="xefu-list-files">
 			<ul>
 			</ul>
@@ -51,24 +56,18 @@
 </div>
 
 <script>
-	function reloadUploader(editor_sequence){
-<!--@if($allow_fileupload)-->
-		$container = jQuery('#xefu-container-' + editor_sequence);
-		$container.data('instance').loadFilelist($container);
-<!--@endif-->
-	}
-<!--@if($allow_fileupload)-->
+
 	jQuery(function($){
-		// uploader
-		var setting = {
-			maxFileSize: {$logged_info->is_admin === 'Y' ? 0 : $file_config->allowed_filesize},
-			maxChunkSize: {$file_config->allowed_chunk_size ?: 0},
-			autoinsertTypes: {json_encode($editor_autoinsert_types)},
-			autoinsertPosition: {json_encode($editor_autoinsert_position ?: 'paragraph')},
-			singleFileUploads: true
-		};
-		$container = $('#xefu-container-{$editor_sequence}');
-		$container.data('instance',$container.xeUploader(setting));
+		var container = $('#xefu-container-{$editor_sequence}');
+		if (container.length) {
+			container.data('instance', container.xeUploader({
+				maxFileSize: parseInt(container.data('maxFileSize'), 10),
+				maxChunkSize: parseInt(container.data('maxChunkSize'), 10),
+				autoinsertTypes: container.data('autoinsertTypes'),
+				autoinsertPosition: container.data('autoinsertPosition'),
+				singleFileUploads: true
+			}));
+		}
 		window.xe.msg_exceeds_limit_size = '{$lang->msg_exceeds_limit_size}';
 		window.xe.msg_checked_file_is_deleted = '{$lang->msg_checked_file_is_deleted}';
 		window.xe.msg_file_cart_is_null = '{$lang->msg_file_cart_is_null}';
@@ -76,5 +75,12 @@
 		window.xe.msg_not_allowed_filetype = '{$lang->msg_not_allowed_filetype}';
 		window.xe.msg_file_upload_error = '{$lang->msg_file_upload_error}';
 	});
-<!--@endif-->
+
+	function reloadUploader(editor_sequence) {
+		var container = $('#xefu-container-' + editor_sequence);
+		if (container.length) {
+			container.data('instance').loadFilelist($container);
+		}
+	}
+
 </script>

--- a/modules/editor/skins/ckeditor/file_upload.html
+++ b/modules/editor/skins/ckeditor/file_upload.html
@@ -79,7 +79,7 @@
 	function reloadUploader(editor_sequence) {
 		var container = $('#xefu-container-' + editor_sequence);
 		if (container.length) {
-			container.data('instance').loadFilelist($container);
+			container.data('instance').loadFilelist(container);
 		}
 	}
 

--- a/modules/editor/skins/simpleeditor/js/simpleeditor.js
+++ b/modules/editor/skins/simpleeditor/js/simpleeditor.js
@@ -70,12 +70,12 @@
 
 			// Load editor info.
 			var editor = $(this);
-			var editor_sequence = editor.data('editor-sequence');
-			var content_key = editor.data('editor-content-key-name');
-			var primary_key = editor.data('editor-primary-key-name');
+			var editor_sequence = editor.data('editorSequence');
+			var content_key = editor.data('editorContentKeyName');
+			var primary_key = editor.data('editorPrimaryKeyName');
 			var insert_form = editor.closest('form');
 			var content_input = insert_form.find('input,textarea').filter('[name=' + content_key + ']');
-			var editor_height = editor.data('editor-height');
+			var editor_height = editor.data('editorHeight');
 			if (editor_height) {
 				editor.css('height', editor_height + 'px');
 			}

--- a/modules/editor/skins/textarea/js/textarea.js
+++ b/modules/editor/skins/textarea/js/textarea.js
@@ -1,27 +1,27 @@
 function editorTextarea(editor_sequence) {
 	var textarea = jQuery("#textarea_instance_" + editor_sequence);
-	var content_key = textarea.data("editor-content-key-name");
-	var primary_key = textarea.data("editor-primary-key-name");
+	var content_key = textarea.data("editorContentKeyName");
+	var primary_key = textarea.data("editorPrimaryKeyName");
 	var insert_form = textarea.closest("form");
 	var content_input = insert_form.find("input[name='" + content_key + "']");
 	var content = "";
-	
+
 	// Set editor keys
     editorRelKeys[editor_sequence] = {};
     editorRelKeys[editor_sequence].primary = insert_form.find("input[name='" + primary_key + "']");
 	editorRelKeys[editor_sequence].content = content_input;
     editorRelKeys[editor_sequence].func = editorGetContent;
-	
+
 	// Set editor_sequence
 	insert_form[0].setAttribute('editor_sequence', editor_sequence);
-	
+
 	// Load existing content
 	if (content_input.size()) {
 		content = String(content_input.val()).stripTags();
 		content_input.val(content);
 		textarea.val(content.unescape());
 	}
-	
+
 	// Save edited content
 	textarea.on("change", function() {
 		content_input.val(String(jQuery(this).val()).escape());


### PR DESCRIPTION
지난해 CKEditor 업데이트 후, 에디터에 스크린샷을 붙여넣거나 파일을 드래그&드롭하면 이미지 내용 전체가 `data:` URL로 변환되어 [본문의 용량이 크게 늘어나는 문제](https://xetown.com/questions/1821298)를 해결합니다.

붙여넣은 이미지를 정식으로 업로드하여 첨부파일로 처리하고, 이미지, 동영상, 오디오 등 파일 형식에 따라 적절한 형태로 본문에 삽입합니다. 파일 첨부와 관련된 제한이 있다면 그것도 모두 일관성있게 적용됩니다.

개별적으로 붙여넣거나 드래그&드롭한 파일만 해당되며, 다른 사이트에서 긁어온 HTML에 포함되어 있는 `<img>` 태그까지 첨부파일로 변환해 주지는 않습니다.

@cydemo 님의 허락을 받아, [바로 업로드 애드온](https://xetown.com/download/1664903)을 참고하였습니다.

크롬, 엣지, 파이어폭스에서 테스트중이며 아직 버그가 있을 수 있습니다.