### PR TITLE
XML Query 파일 내부에 기재된 ID를 XML 파일 이름과 일치하도록 변경

### DIFF
--- a/modules/admin/queries/deleteFavorites.xml
+++ b/modules/admin/queries/deleteFavorites.xml
@@ -1,4 +1,4 @@
-<query id="deleteFavorite" action="delete">
+<query id="deleteFavorites" action="delete">
 	<tables>
 		<table name="admin_favorite" />
 	</tables>

--- a/modules/autoinstall/queries/getPackageSrlByPath.xml
+++ b/modules/autoinstall/queries/getPackageSrlByPath.xml
@@ -1,4 +1,4 @@
-<query id="getPackageSqlByPath" action="select">
+<query id="getPackageSrlByPath" action="select">
     <tables>
         <table name="autoinstall_packages" />
     </tables>

--- a/modules/comment/queries/deleteModuleComments.xml
+++ b/modules/comment/queries/deleteModuleComments.xml
@@ -1,4 +1,4 @@
-<query id="deleteComments" action="delete">
+<query id="deleteModuleComments" action="delete">
     <tables>
         <table name="comments" />
     </tables>

--- a/modules/comment/queries/getCommentVotedLogMulti.xml
+++ b/modules/comment/queries/getCommentVotedLogMulti.xml
@@ -1,4 +1,4 @@
-<query id="getCommentVotedLog" action="select">
+<query id="getCommentVotedLogMulti" action="select">
 	<tables>
 		<table name="comment_voted_log" />
 	</tables>

--- a/modules/comment/queries/getTotalCommentCountByGroupStatus.xml
+++ b/modules/comment/queries/getTotalCommentCountByGroupStatus.xml
@@ -1,4 +1,4 @@
-<query id="getTotalCommentList" action="select">
+<query id="getTotalCommentCountByGroupStatus" action="select">
     <tables>
         <table name="comments" alias="comments" />
     </tables>

--- a/modules/comment/queries/getTotalCommentCountWithinMemberByGroupStatus.xml
+++ b/modules/comment/queries/getTotalCommentCountWithinMemberByGroupStatus.xml
@@ -1,4 +1,4 @@
-<query id="getTotalCommentListWithinMember" action="select">
+<query id="getTotalCommentCountWithinMemberByGroupStatus" action="select">
     <tables>
         <table name="comments" alias="comments" />
         <table name="member" alias="member" />

--- a/modules/communication/queries/getReadedMessages.xml
+++ b/modules/communication/queries/getReadedMessages.xml
@@ -1,4 +1,4 @@
-<query id="getReceivedMessages" action="select">
+<query id="getReadedMessages" action="select">
 	<tables>
 		<table name="member_message" alias="message" />
 		<table name="member" type="left join">

--- a/modules/counter/queries/getCounterStatusDays.xml
+++ b/modules/counter/queries/getCounterStatusDays.xml
@@ -1,4 +1,4 @@
-<query id="getSiteCounterStatus" action="select">
+<query id="getCounterStatusDays" action="select">
     <tables>
         <table name="counter_status" />
     </tables>

--- a/modules/document/queries/deleteDeclaredDocumentLog.xml
+++ b/modules/document/queries/deleteDeclaredDocumentLog.xml
@@ -1,4 +1,4 @@
-<query id="deleteDocumentDeclaredLog" action="delete">
+<query id="deleteDeclaredDocumentLog" action="delete">
 	<tables>
 		<table name="document_declared_log" />
 	</tables>

--- a/modules/document/queries/deleteModuleCategory.xml
+++ b/modules/document/queries/deleteModuleCategory.xml
@@ -1,4 +1,4 @@
-<query id="deleteCategory" action="delete">
+<query id="deleteModuleCategory" action="delete">
     <tables>
         <table name="document_categories" />
     </tables>

--- a/modules/document/queries/getDailyArchivedList.xml
+++ b/modules/document/queries/getDailyArchivedList.xml
@@ -1,4 +1,4 @@
-<query id="getMonthlyArchivedList" action="select">
+<query id="getDailyArchivedList" action="select">
     <tables>
         <table name="documents" />
     </tables>

--- a/modules/document/queries/getHistory.xml
+++ b/modules/document/queries/getHistory.xml
@@ -1,4 +1,4 @@
-<query id="getHistories" action="select">
+<query id="getHistory" action="select">
     <tables>
         <table name="document_histories" />
     </tables>

--- a/modules/document/queries/insertDocumentExtraKey.xml
+++ b/modules/document/queries/insertDocumentExtraKey.xml
@@ -1,4 +1,4 @@
-<query id="insertDocumentExtraKeys" action="insert">
+<query id="insertDocumentExtraKey" action="insert">
     <tables>
         <table name="document_extra_keys" />
     </tables>

--- a/modules/file/queries/updateFileDownloadCount.xml
+++ b/modules/file/queries/updateFileDownloadCount.xml
@@ -1,4 +1,4 @@
-<query id="updateDownloadCount" action="update">
+<query id="updateFileDownloadCount" action="update">
     <tables>
         <table name="files" />
     </tables>

--- a/modules/member/queries/deleteScrapDocumentByDocumentSrl.xml
+++ b/modules/member/queries/deleteScrapDocumentByDocumentSrl.xml
@@ -1,4 +1,4 @@
-<query id="deleteScrapDocument" action="delete">
+<query id="deleteScrapDocumentByDocumentSrl" action="delete">
 	<tables>
 		<table name="member_scrap" />
 	</tables>

--- a/modules/member/queries/insertDeniedID.xml
+++ b/modules/member/queries/insertDeniedID.xml
@@ -1,4 +1,4 @@
-<query id="insertGroup" action="insert">
+<query id="insertDeniedID" action="insert">
     <tables>
         <table name="member_denied_user_id" />
     </tables>

--- a/modules/member/queries/updateMemberFindQuestionAnswer.xml
+++ b/modules/member/queries/updateMemberFindQuestionAnswer.xml
@@ -1,4 +1,4 @@
-<query id="updateMemberFindQuesionAnswer" action="update">
+<query id="updateMemberFindQuestionAnswer" action="update">
     <tables>
         <table name="member" />
     </tables>

--- a/modules/module/queries/getActionForwardWithModule.xml
+++ b/modules/module/queries/getActionForwardWithModule.xml
@@ -1,4 +1,4 @@
-<query id="getActionForward" action="select">
+<query id="getActionForwardWithModule" action="select">
     <tables>
         <table name="action_forward" />
     </tables>

--- a/modules/module/queries/getLangListByName.xml
+++ b/modules/module/queries/getLangListByName.xml
@@ -1,4 +1,4 @@
-<query id="getLangList" action="select">
+<query id="getLangListByName" action="select">
     <tables>
         <table name="lang" />
     </tables>

--- a/modules/module/queries/getModuleCategory.xml
+++ b/modules/module/queries/getModuleCategory.xml
@@ -1,4 +1,4 @@
-<query id="selectModuleCategory" action="select">
+<query id="getModuleCategory" action="select">
     <tables>
         <table name="module_categories" />
     </tables>

--- a/modules/ncenterlite/queries/deleteUnsubscribe.xml
+++ b/modules/ncenterlite/queries/deleteUnsubscribe.xml
@@ -1,4 +1,4 @@
-<query id="deleteUnsubscribeBlock" action="delete">
+<query id="deleteUnsubscribe" action="delete">
 	<tables>
 		<table name="ncenterlite_unsubscribe" />
 	</tables>

--- a/modules/ncenterlite/queries/getUnsubscribeList.xml
+++ b/modules/ncenterlite/queries/getUnsubscribeList.xml
@@ -1,4 +1,4 @@
-<query id="getUnsubscribeBlockList" action="select">
+<query id="getUnsubscribeList" action="select">
 	<tables>
 		<table name="ncenterlite_unsubscribe" />
 	</tables>

--- a/modules/ncenterlite/queries/getUserUnsubscribeConfigByUnsubscribeSrl.xml
+++ b/modules/ncenterlite/queries/getUserUnsubscribeConfigByUnsubscribeSrl.xml
@@ -1,4 +1,4 @@
-<query id="getUserUnsubscribeBlockConfigByUnsubscribeSrl" action="select">
+<query id="getUserUnsubscribeConfigByUnsubscribeSrl" action="select">
 	<tables>
 		<table name="ncenterlite_unsubscribe" />
 	</tables>

--- a/modules/ncenterlite/queries/insertUnsubscribe.xml
+++ b/modules/ncenterlite/queries/insertUnsubscribe.xml
@@ -1,4 +1,4 @@
-<query id="insertUnsubscribeBlock" action="insert">
+<query id="insertUnsubscribe" action="insert">
 	<tables>
 		<table name="ncenterlite_unsubscribe" />
 	</tables>

--- a/modules/poll/queries/updatePollItemTarget.xml
+++ b/modules/poll/queries/updatePollItemTarget.xml
@@ -1,4 +1,4 @@
-<query id="updatePollTarget" action="update">
+<query id="updatePollItemTarget" action="update">
     <tables>
         <table name="poll_item" />
     </tables>

--- a/modules/session/queries/getExpiredSessions.xml
+++ b/modules/session/queries/getExpiredSessions.xml
@@ -1,4 +1,4 @@
-<query id="getExpiredSession" action="select">
+<query id="getExpiredSessions" action="select">
     <tables>
         <table name="session" />
     </tables>

--- a/modules/spamfilter/queries/insertDeniedWord.xml
+++ b/modules/spamfilter/queries/insertDeniedWord.xml
@@ -1,4 +1,4 @@
-<query id="insertDeniedIP" action="insert">
+<query id="insertDeniedWord" action="insert">
 	<tables>
 		<table name="spamfilter_denied_word" />
 	</tables>

--- a/modules/tag/queries/getAllTagList.xml
+++ b/modules/tag/queries/getAllTagList.xml
@@ -1,4 +1,4 @@
-<query id="getDocumentsTagList" action="select">
+<query id="getAllTagList" action="select">
     <tables>
         <table name="tags" />
     </tables>

--- a/modules/trash/queries/getTrashAllList.xml
+++ b/modules/trash/queries/getTrashAllList.xml
@@ -1,4 +1,4 @@
-<query id="getTrashList" action="select">
+<query id="getTrashAllList" action="select">
     <tables>
         <table name="trash" alias="T" />
         <table name="member" alias="M" />


### PR DESCRIPTION
- XML Query 파일 본문에 지정된 `id`와 XML Query 파일 이름은 똑같아야 한다는 규칙이 확인되지만, 간혹 다른 파일이 발견됩니다.
- 현존하는 모든 XML Query 파일 내부의 `id`가 XML 파일 이름과 일치하도록 고칩니다.