### PR TITLE
컨텐트 위젯 기본 스킨에서 HiDPI 지원

### DIFF
--- a/widgets/content/skins/default/gallery.html
+++ b/widgets/content/skins/default/gallery.html
@@ -6,7 +6,7 @@
             <!--@if($v=='thumbnail')-->
                 <a href="{$item->getLink()}" class="thumb" style="width:{$widget_info->thumbnail_width}px;height:{$widget_info->thumbnail_height}px" target="_blank"|cond="$widget_info->new_window">
                     <!--@if($item->getThumbnail())-->
-                        <img src="{$item->getThumbnail()}" style="width:{$widget_info->thumbnail_width}px;height:{$widget_info->thumbnail_height}px"/>
+                        <img src="{$item->getThumbnail()}" srcset="{$item->getThumbnail(2)} 2x"|cond="$item->getThumbnail(2)" style="width:{$widget_info->thumbnail_width}px;height:{$widget_info->thumbnail_height}px"/>
                     <!--@else-->
                         <span class="imgNone">{$lang->none_image}</span>
                     <!--@end-->

--- a/widgets/content/skins/default/image_title.html
+++ b/widgets/content/skins/default/image_title.html
@@ -5,7 +5,7 @@
         {@$thumbnail_idx = $widget_info->content_items[0]->getFirstThumbnailIdx() }
         {@$have_first_thumbnail=true}
         <p class="widgetThumb floatLeft" style="margin-right:-{$widget_info->thumbnail_width}px">
-            <a href="{$widget_info->content_items[$thumbnail_idx]->getLink()}" class="thumb" target="_blank"|cond="$widget_info->new_window"><img src="{$widget_info->content_items[$thumbnail_idx]->getThumbnail()}" style="width:{$widget_info->thumbnail_width}px;height:{$widget_info->thumbnail_height}px"></a>
+            <a href="{$widget_info->content_items[$thumbnail_idx]->getLink()}" class="thumb" target="_blank"|cond="$widget_info->new_window"><img src="{$widget_info->content_items[$thumbnail_idx]->getThumbnail()}" srcset="{$widget_info->content_items[$thumbnail_idx]->getThumbnail(2)} 2x"|cond="$widget_info->content_items[$thumbnail_idx]->getThumbnail(2)" style="width:{$widget_info->thumbnail_width}px;height:{$widget_info->thumbnail_height}px"></a>
         </p>
     <!--@end-->
 
@@ -63,7 +63,7 @@
         {@$thumbnail_idx = $widget_info->content_items[0]->getFirstThumbnailIdx() }
         {@$have_first_thumbnail=true}
         <p class="widgetThumb floatLeft" style="margin-right:-{$widget_info->thumbnail_width}px">
-            <a href="{$widget_info->content_items[$thumbnail_idx]->getLink()}" class="thumb" target="_blank"|cond="$widget_info->new_window"><img src="{$widget_info->content_items[$thumbnail_idx]->getThumbnail()}" style="width:{$widget_info->thumbnail_width}px;height:{$widget_info->thumbnail_height}px"></a>
+            <a href="{$widget_info->content_items[$thumbnail_idx]->getLink()}" class="thumb" target="_blank"|cond="$widget_info->new_window"><img src="{$widget_info->content_items[$thumbnail_idx]->getThumbnail()}" srcset="{$widget_info->content_items[$thumbnail_idx]->getThumbnail(2)} 2x"|cond="$widget_info->content_items[$thumbnail_idx]->getThumbnail(2)" style="width:{$widget_info->thumbnail_width}px;height:{$widget_info->thumbnail_height}px"></a>
         </p>
     <!--@end-->
 

--- a/widgets/content/skins/default/image_title_content.html
+++ b/widgets/content/skins/default/image_title_content.html
@@ -6,7 +6,7 @@
         <p class="thumbArea" style="width:{$widget_info->thumbnail_width}px;margin-right:-{$widget_info->thumbnail_width}px;">
             <a href="{$item->getLink()}" class="thumb" style="width:{$widget_info->thumbnail_width}px;height:{$widget_info->thumbnail_height}px" target="_blank"|cond="$widget_info->new_window">
                 <!--@if($item->getThumbnail())-->
-                    <img src="{$item->getThumbnail()}" style="width:{$widget_info->thumbnail_width}px;height:{$widget_info->thumbnail_height}px" />
+                    <img src="{$item->getThumbnail()}" srcset="{$item->getThumbnail(2)} 2x"|cond="$item->getThumbnail(2)" style="width:{$widget_info->thumbnail_width}px;height:{$widget_info->thumbnail_height}px" />
                 <!--@else-->
                     <span class="imgNone">{$lang->none_image}</span>
                 <!--@end-->


### PR DESCRIPTION
안녕하세요.

맥북이나 모바일 기기 등 고DPI 기기로 컨텐트 위젯 기본 스킨을 사용하는 페이지에 접근시 썸네일이 저해상도로 보여서, HiDPI 썸네일 지원을 추가했습니다. 사실 새로운 코드는 아니고, 또다른 내장 스킨인 네모의 꿈 스킨에 이미 #712 를 통해 들어가있던 코드를 그대로 옮긴 것입니다. [참고](https://github.com/rhymix/rhymix/pull/712/commits/7374980d87d0b93f2adf6eab973249d97342cfb9)

결과적으로는 srcset 속성이 추가되는 것 뿐으로, 기존에 기본 스킨에 CSS·JS 등을 써서 변형해 사용하는 사용자에게도 위험성은 없으리라 예상합니다.