### PR TITLE
default 게시판 스킨에서 글목록 헤드의 항목 누락 수정

### DIFF
--- a/modules/board/skins/default/list.html
+++ b/modules/board/skins/default/list.html
@@ -7,6 +7,7 @@
 			<tr>
 				<block loop="$list_config=>$key,$val">
 				<th scope="col" cond="$val->type=='no' && $val->idx==-1"><span>{$lang->no}</span></th>
+				<th scope="col" cond="$val->type=='module_title' && $val->idx==-1"><span>{$lang->module_title}</span></th>
 				<th scope="col" class="title" cond="$val->type=='title' && $val->idx==-1"><span>{$lang->title}</span></th>
 				<th scope="col" cond="$val->type=='nick_name' && $val->idx==-1"><span>{$lang->writer}</span></th>
 				<th scope="col" cond="$val->type=='user_id' && $val->idx==-1"><span>{$lang->user_id}</span></th>


### PR DESCRIPTION
안녕하세요. default 게시판 스킨의 글목록 헤드에서 `module_title` (게시판이름) 항목 누락을 수정했습니다.