### PR TITLE
통합게시판 글쓰기 방법 수정 / 통합게시판 관련 버그수정 / issue #1199

### DIFF
--- a/modules/board/board.view.php
+++ b/modules/board/board.view.php
@@ -715,7 +715,14 @@ class BoardView extends Board
 		}
 
 		$obj = new stdClass;
-		$obj->mid = $this->module_info->mid;
+		if (empty($this->include_modules))
+		{
+			$obj->mid = $this->module_info->mid;
+		}
+		else
+		{
+			$obj->module_srl = $this->include_modules;
+		}
 		$obj->list_count = 10000;
 		$output = TagModel::getInstance()->getTagList($obj);
 


### PR DESCRIPTION
안녕하세요. 

![image](https://github.com/user-attachments/assets/300c5d26-f3fa-40a5-ac9c-aa94e6456af9)

통합게시판에서 글쓰기 버튼을 클릭했을때, 첨부 그림처럼 포함된 게시판 가운데 어떤 게시판에 글을 작성할지 선택할 수 있도록 수정한 코드입니다. 
XE default 및 xedition 스킨에 해당 기능을 적용하였습니다. 
