### PR TITLE
SMS solapi API에서 변수 지정 기능 추가

### DIFF
--- a/common/framework/drivers/sms/solapi.php
+++ b/common/framework/drivers/sms/solapi.php
@@ -132,6 +132,11 @@ class SolAPI extends Base implements \Rhymix\Framework\Drivers\SMSInterface
 					}
 				}
 
+				foreach ($original->getExtraVars() as $key => $value)
+				{
+					$options->$key = $value;
+				}
+
 				$data['messages'][] = $options;
 			}
 		}


### PR DESCRIPTION
SMS 전송 시 미리 추가된 extra vars 값을 solapi 드라이버에서도 지원합니다.

코어에서 지정한 값을 덮어쓰거나, 추가 변수를 지정하여 api의 다른 기능도 사용 할 수 있습니다.

지정 가능한 파라미터
https://developers.solapi.com/references/messages/sendManyDetail#body--messages