### PR TITLE
회원가입 폼 설정의 추가항목을 사용 해제 할 수 없는 문제 수정

### DIFF
--- a/modules/member/tpl/signup_config.html
+++ b/modules/member/tpl/signup_config.html
@@ -251,8 +251,8 @@
 						<td style="text-align:center"><input type="checkbox" name="usable_list[]" value="{$item->name}" title="{$lang->use}" checked="checked"|cond="$item->isUse" /></td>
 						<td style="text-align:center"><input type="checkbox" name="is_{$item->name}_public" value="Y" checked="checked"|cond="$item->isPublic == 'Y'" disabled="disabled"|cond="!$item->isUse" /></td>
 						<td class="nowr">
-							<label for="{$item->name}_re" class="x_inline"><input type="radio" id="{$item->name}_re" name="{$item->name}" value="required" checked="checked"|cond="$item->required" disabled="disabled"|cond="!$item->isUse"/> {$lang->cmd_required}</label>
-							<label for="{$item->name}_op" class="x_inline"><input type="radio" id="{$item->name}_op" name="{$item->name}" value="option" checked="checked"|cond="$item->isUse && !$item->required" disabled="disabled"|cond="!$item->isUse" /> {$lang->cmd_optional}</label>
+							<label for="{$item->name}_re" class="x_inline"><input type="radio" id="{$item->name}_re" name="{$item->name}" class="item_required" value="required" checked="checked"|cond="$item->required" disabled="disabled"|cond="!$item->isUse" /> {$lang->cmd_required}</label>
+							<label for="{$item->name}_op" class="x_inline"><input type="radio" id="{$item->name}_op" name="{$item->name}" class="item_optional" value="option" checked="checked"|cond="$item->isUse && !$item->required" disabled="disabled"|cond="!$item->isUse" /> {$lang->cmd_optional}</label>
 						</td>
 						<td class="desc" title="{$item->description}">{$item->description}</td>
 						<td id="{$item->member_join_form_srl}" class="nowr" style="text-align:center"><a href="#userDefine" class="modalAnchor _extendFormEdit">{$lang->cmd_edit}</a> <i>|</i> <a href="#" class="_extendFormDelete">{$lang->cmd_delete}</a></td>


### PR DESCRIPTION
### 문제점
- 회원가입 폼의 추가항목이 필수로 설정 된 경우 사용 체크 해제를 하여도 저장이 되지 않습니다.
- 기본 항목(ex 이름, 아이디 등)은 사용 체크 해제 시점에 필수/선택을 비활성화 하여 값을 전송하지 않는 것과 상반됩니다.

### 참고 (체크 해제 상태)
![image](https://github.com/user-attachments/assets/5c943b2d-a74d-419c-9d8d-272ddeb8873c)


기본 가입폼 형식과 통일하는 내용의 PR입니다.