### PR TITLE
통합게시판에 하위게시판의 글 카테고리 문제

### DIFF
--- a/modules/board/board.view.php
+++ b/modules/board/board.view.php
@@ -226,7 +226,17 @@ class BoardView extends Board
 				return;
 			}
 
-			Context::set('category_list', DocumentModel::getCategoryList($this->module_srl));
+			// Get category list for documents belong to other modules. (i.e. submodule in combined board)
+			$document_srl = Context::get('document_srl');
+			if ($document_srl)
+			{
+				$module_srl = DocumentModel::getDocument($document_srl)->get("module_srl");
+			}
+			else
+			{
+				$module_srl = $this->module_srl;
+			}
+			Context::set('category_list', DocumentModel::getCategoryList($module_srl));
 
 			$oSecurity = new Security();
 			$oSecurity->encodeHTML('category_list.', 'category_list.childs.');

--- a/modules/board/board.view.php
+++ b/modules/board/board.view.php
@@ -227,16 +227,19 @@ class BoardView extends Board
 			}
 
 			// Get category list for documents belong to other modules. (i.e. submodule in combined board)
-			$document_srl = Context::get('document_srl');
-			if ($document_srl)
+			if (empty($this->include_modules))
 			{
-				$module_srl = DocumentModel::getDocument($document_srl)->get("module_srl");
+				$category_list = DocumentModel::getCategoryList($this->module_srl);
 			}
 			else
 			{
-				$module_srl = $this->module_srl;
+				$category_list = array();
+				foreach ($this->include_modules as $module_srl)
+				{
+					$category_list += DocumentModel::getCategoryList($module_srl);
+				}
 			}
-			Context::set('category_list', DocumentModel::getCategoryList($module_srl));
+			Context::set('category_list', $category_list);
 
 			$oSecurity = new Security();
 			$oSecurity->encodeHTML('category_list.', 'category_list.childs.');


### PR DESCRIPTION
안녕하세요. 

통합게시판에서 하위게시판의 작성된 글을 불러왔을 때, 통합게시판에 등록된 카테고리 리스트를 로드하여 게시글의 카테고리가 제대로 표시되지 않는 문제가 있습니다. 글이 등록된 하위게시판의 카테고리를 가져오도록 수정했습니다. 

