### PR TITLE
여러 notify 보내더라도 메세지의 정보(특히 링크)를 다르게

### DIFF
--- a/common/framework/Push.php
+++ b/common/framework/Push.php
@@ -19,6 +19,7 @@ class Push
 	protected $image = '';
 	protected $metadata = [];
 	protected $data = [];
+	protected $datas = [];
 	protected $errors = [];
 	protected $success_tokens = [];
 	protected $deleted_tokens = [];
@@ -142,6 +143,18 @@ class Push
 	public function addTo(int $member_srl): bool
 	{
 		$this->to[] = $member_srl;
+		return true;
+	}
+
+	/**
+	 * Add a list of data.
+	 *
+	 * @param array $data
+	 * @return bool
+	 */
+	public function addData(array $data): bool
+	{
+		$this->datas[] = $data;
 		return true;
 	}
 
@@ -365,12 +378,12 @@ class Push
 
 	/**
 	 * Get the data associated with this push notification.
-	 *
+	 * @param int $idx
 	 * @return array
 	 */
-	public function getData(): array
+	public function getData(int $idx = -1): array
 	{
-		return $this->data;
+		return $this->datas[$idx] ?? $this->data;
 	}
 
 	/**


### PR DESCRIPTION
addData 메소드를 사용하면 여러 notify 보내더라도 메세지의 정보(특히 링크)를 다르게 할 수 있습니다.
따라서 링크에 member_srl 인자를 포함하면 같은 notify 여도 누가 읽었는지 추적/통계 가능합니다.
제대로 하려면 $payload 정보를 통으로 분리해야 겠지만 범위가 너무 커져서 간단히 활용 가능한 정도만 고쳤습니다.
...
$extra_data['url'] = '...&member_srl=4'; // 추적 링크
$oPush->addData($extra_data);
$oPush->addTo(4);
$oPush->send();