### PR TITLE
fcmv1 트리거 의해 requests 조절할 수 있게.

### DIFF
--- a/common/framework/Push.php
+++ b/common/framework/Push.php
@@ -501,7 +501,7 @@ class Push
 
 		foreach($output->data as $row)
 		{
-			$result->{$row->device_token_type}[] = $row->device_token;
+			$result->{$row->device_token_type}[] = $row;
 		}
 
 		return $result;

--- a/common/framework/drivers/push/apns.php
+++ b/common/framework/drivers/push/apns.php
@@ -69,7 +69,7 @@ class APNs extends Base implements PushInterface
 			],
 		]);
 
-		foreach($tokens as $token)
+		foreach($tokens as $row)
 		{
 			$ctx = stream_context_create();
 			stream_context_set_option($ctx, 'ssl', 'local_cert', $local_cert);
@@ -80,13 +80,13 @@ class APNs extends Base implements PushInterface
 			{
 				$message->addError('Failed to connect socket - error code: '. $err .' - '. $errstr);
 			}
-			$msg = chr(0) . pack('n', 32) . pack('H*', $token) . pack('n', strlen($payload)) . $payload;
+			$msg = chr(0) . pack('n', 32) . pack('H*', $row->token) . pack('n', strlen($payload)) . $payload;
 			$result = fwrite($fp, $msg, strlen($msg));
 			if(!$result)
 			{
 				$message->addError('APNs return empty response.');
 			}
-			$output->success[] = $token;
+			$output->success[] = $row->token;
 			fclose($fp);
 		}
 

--- a/common/framework/drivers/push/fcm.php
+++ b/common/framework/drivers/push/fcm.php
@@ -76,7 +76,9 @@ class FCM extends Base implements PushInterface
 			$notification['sound'] = isset($notification['sound']) ? $notification['sound'] : 'default';
 		}
 
-		$chunked_token = array_chunk($tokens, 500);
+		$_tokens = array_column($tokens, 'token');
+
+		$chunked_token = array_chunk($_tokens, 500);
 		foreach($chunked_token as $token_unit)
 		{
 			$data = [

--- a/common/framework/drivers/push/fcmv1.php
+++ b/common/framework/drivers/push/fcmv1.php
@@ -132,7 +132,7 @@ class FCMv1 extends Base implements PushInterface
 		foreach ($chunked_tokens as $tokens)
 		{
 			$requests = [];
-			foreach ($tokens as $i => $token)
+			foreach ($tokens as $i => $row)
 			{
 				$requests[$i] = [
 					'url' => $api_url,
@@ -144,8 +144,13 @@ class FCMv1 extends Base implements PushInterface
 						'json' => $payload,
 					],
 				];
-				$requests[$i]['settings']['json']['message']['token'] = $token;
+				$requests[$i]['settings']['json']['message']['token'] = $row->token;
 			}
+
+			$trigger_obj = new \stdClass();
+			$trigger_obj->requests = &$requests;
+			$trigger_obj->tokens = $tokens;
+			$output = \ModuleHandler::triggerCall('fcmv1.send', 'before', $trigger_obj);
 
 			$responses = HTTP::multiple($requests);
 			foreach ($responses as $i => $response)

--- a/modules/member/queries/getMemberDeviceTokensByMemberSrl.xml
+++ b/modules/member/queries/getMemberDeviceTokensByMemberSrl.xml
@@ -3,6 +3,7 @@
         <table name="member_devices" />
     </tables>
     <columns>
+		<column name="member_srl" />
         <column name="device_token" />
         <column name="device_token_type" />
     </columns>


### PR DESCRIPTION
앞의 pr 과 같은 목적이나 구현은 트리거로 했습니다.
메세지 다르게 해도 비동기 전송 가능하게 서드파티에서 조절할 수 있을 것입니다.