### PR TITLE
모듈 관리자 권한 문제 수정

### DIFF
--- a/modules/board/board.view.php
+++ b/modules/board/board.view.php
@@ -289,9 +289,6 @@ class BoardView extends Board
 					}
 				}
 
-				// check the manage grant
-				if($this->grant->manager) $oDocument->setGrant();
-
 				// if the consultation function is enabled, and the document is not a notice
 				if($this->consultation && !$oDocument->isNotice())
 				{

--- a/modules/document/conf/module.xml
+++ b/modules/document/conf/module.xml
@@ -47,7 +47,7 @@
 		<action name="procDocumentAdminMoveToTrash" type="controller" permission="manager:moderate:document" check_type="document" check_var="document_srl" />
 		<action name="procDocumentAdminRestoreTrash" type="controller" />
 		<action name="procDocumentAdminInsertExtraVar" type="controller" permission="manager:config:*" check_var="module_srl" ruleset="insertExtraVar" />
-		<action name="procDocumentAdminDeleteExtraVar" type="controller" permission="manage:config:*" check_var="module_srl" />
+		<action name="procDocumentAdminDeleteExtraVar" type="controller" permission="manager:config:*" check_var="module_srl" />
 		<action name="procDocumentAdminMoveExtraVar" type="controller" permission="manager:config:*" check_var="module_srl" />
 	</actions>
 	<eventHandlers>


### PR DESCRIPTION
1. 게시판 관리자가 확장변수 항목을 삭제 할 수 없는 문제 수정

   - `게시판 -> 설정 -> 확장변수`에서 추가 수정은 가능하나, 삭제만 불가능한 문제입니다.   
<br>

2. 게시판 글 읽기 화면에서 불필요한 게시물 권한 추가를 제거

   - 게시물 글 읽기에서 문서 관리 권한이 없음에도 모든 모듈 관리자의 `isGranted()` 값이 항상 `true`로 반환되는 문제입니다.