### PR TITLE
확장변수 파일 삭제 불가 문제 수정

### DIFF
--- a/modules/document/document.controller.php
+++ b/modules/document/document.controller.php
@@ -1269,7 +1269,7 @@ class DocumentController extends Document
 								{
 									// Check if deletion is allowed
 									$ev_output = $extra_item->validate(null);
-									if (!$ev_output->toBool())
+									if ($ev_output && !$ev_output->toBool())
 									{
 										$oDB->rollback();
 										return $ev_output;


### PR DESCRIPTION
확장변수 파일 형식으로 등록 후 삭제하고 저장하게 되면 오류가 발생하여 저장 불가능한 문제를 수정하였습니다.