### PR TITLE
확장변수 파일 등록 후 문서 수정 시 파일 처리 문제 수정

### DIFF
--- a/modules/document/document.controller.php
+++ b/modules/document/document.controller.php
@@ -694,7 +694,7 @@ class DocumentController extends Document
 			unset($obj->user_id);
 		}
 
-		$obj->uploaded_count = FileModel::getFilesCount($obj->document_srl);
+		$obj->uploaded_count = FileModel::getFilesCount($obj->document_srl, 'doc');
 
 		// Call a trigger (before)
 		$output = ModuleHandler::triggerCall('document.insertDocument', 'before', $obj);
@@ -991,7 +991,7 @@ class DocumentController extends Document
 		if(($obj->title_color ?? 'N') === 'N') $obj->title_color = 'N';
 		if(($obj->notify_message ?? 'N') !== 'Y') $obj->notify_message = 'N';
 		if(($obj->allow_trackback ?? 'N') !== 'Y') $obj->allow_trackback = 'N';
-		$obj->uploaded_count = FileModel::getFilesCount($obj->document_srl);
+		$obj->uploaded_count = FileModel::getFilesCount($obj->document_srl, 'doc');
 
 		// Call a trigger (before)
 		$output = ModuleHandler::triggerCall('document.updateDocument', 'before', $obj);
@@ -3769,7 +3769,7 @@ Content;
 
 			$args = new stdClass;
 			$args->document_srl = $document_srl;
-			$args->uploaded_count = FileModel::getFilesCount($document_srl);
+			$args->uploaded_count = FileModel::getFilesCount($document_srl, 'doc');
 			executeQuery('document.updateUploadedCount', $args);
 		}
 	}

--- a/modules/document/document.item.php
+++ b/modules/document/document.item.php
@@ -1460,7 +1460,7 @@ class DocumentItem extends BaseObject
 
 		if(!isset($this->uploadedFiles[$sortIndex]))
 		{
-			$this->uploadedFiles[$sortIndex] = FileModel::getFiles($this->document_srl, array(), $sortIndex, true);
+			$this->uploadedFiles[$sortIndex] = FileModel::getFiles($this->document_srl, array(), $sortIndex, true, 'doc');
 		}
 
 		return $this->uploadedFiles[$sortIndex];


### PR DESCRIPTION
### 문제 상황
- 확장변수 파일 등록 후 문서 등록 후 최초 시점
문서 파일 개수 0, 문서 파일 리스트 없음

- 해당 문서 수정 등록 후 시점
확장변수 파일을 포함한 모든 문서 관련 파일이 표시됨.

### 문제 해결
- 문서 등록/수정 시 문서 파일 개수에서 확장변수 파일 개수 제외
- 문서 `getUploadedFiles` 함수에서 확장변수 파일 제외
