### PR TITLE
템플릿 v2에서 load 지시자의 변수가 잘못 전달되는 문제 수정

### DIFF
--- a/common/framework/Template.php
+++ b/common/framework/Template.php
@@ -694,12 +694,12 @@ class Template
 		}
 
 		// If any of the variables seems to be an array or object, it's $vars.
-		if (!is_scalar($media_type))
+		if (!is_scalar($media_type ?? ''))
 		{
 			$vars = $media_type;
 			$media_type = null;
 		}
-		if (!is_scalar($index))
+		if (!is_scalar($index ?? ''))
 		{
 			$vars = $index;
 			$index = null;


### PR DESCRIPTION
템플릿 v2 `@load` 지시자에서 media, index를 생략하고, 변수를 전달할 때 문제가 발생합니다.
생략된 파라미터의 기본값인 null로 인해 `is_scalar()`에서 `false`를 반환하여 오작동하는 문제를 수정합니다.