### PR TITLE
Update common/defaults/whitelist.php

### DIFF
--- a/common/defaults/whitelist.php
+++ b/common/defaults/whitelist.php
@@ -6,7 +6,6 @@
  * Copyright (c) Rhymix Developers and Contributors
  */
 return array(
-	
 	// YouTube
 	'www.youtube.com/',
 	'www.youtube-nocookie.com/',
@@ -21,41 +20,30 @@ return array(
 	'www.google.com/maps/embed',
 	'maps.google.com/',
 	'maps.google.co.kr/',
+
+	// Meta corp services(facebook, instagram, Threads, Giphy)
+	'www.facebook.com',
+	'www.instagram.com',
+	'threads.net',
+	'giphy.com',
 	
-	// Daum
-	'flvs.daum.net/',
-	'videofarm.daum.net/',
-	'api.v.daum.net/',
-	'videofarm.daum.net/',
-	
+	// X (formerly known as Twitter)
+	'platform.twitter.com',
+	'syndication.twitter.com',
+
+	// Tiktok
+	'www.tiktok.com',
+
+	// Discord
+	'discordapp.com',
+
+	// Sooplive
+	'vod.sooplive.co.kr',
+
+	// Kakao TV
+	'tv.kakao.com',
+	'play-tv.kakao.com',
+
 	// Naver
-	'serviceapi.rmcnmv.naver.com/',
-	'serviceapi.nmv.naver.com/',
-	'scrap.ad.naver.com/',
-	'static.campaign.naver.com/',
-	'musicplayer.naver.com/naverPlayer/posting/',
-	'player.music.naver.com/naverPlayer/posting/',
-	
-	// Pandora TV
-	'www.pandora.tv/view/',
-	'flvr.pandora.tv/flv2pan/',
-	
-	// Cyworld
-	'dbi.video.cyworld.com/v.sk/',
-	
-	// Egloos
-	'v.egloos.com/v.sk/',
-	
-	// Nate
-	'v.nate.com/v.sk/',
-	'w.blogdoc.nate.com/',
-	
-	// SBS
-	'netv.sbs.co.kr/sbox/',
-	'news.sbs.co.kr/',
-	'wizard2.sbs.co.kr/',
-	'sbsplayer.sbs.co.kr/',
-	
-	// Afreeca
-	'afree.ca/',
+	'chzzk.naver.com',
 );

--- a/common/defaults/whitelist.php
+++ b/common/defaults/whitelist.php
@@ -22,28 +22,28 @@ return array(
 	'maps.google.co.kr/',
 
 	// Meta corp services(facebook, instagram, Threads, Giphy)
-	'www.facebook.com',
-	'www.instagram.com',
-	'threads.net',
-	'giphy.com',
+	'www.facebook.com/',
+	'www.instagram.com/',
+	'threads.net/',
+	'giphy.com/',
 	
 	// X (formerly known as Twitter)
-	'platform.twitter.com',
-	'syndication.twitter.com',
+	'platform.twitter.com/',
+	'syndication.twitter.com/',
 
 	// Tiktok
-	'www.tiktok.com',
+	'www.tiktok.com/',
 
 	// Discord
-	'discordapp.com',
+	'discordapp.com/',
 
 	// Sooplive
-	'vod.sooplive.co.kr',
+	'vod.sooplive.co.kr/',
 
 	// Kakao TV
-	'tv.kakao.com',
-	'play-tv.kakao.com',
+	'tv.kakao.com/',
+	'play-tv.kakao.com/',
 
 	// Naver
-	'chzzk.naver.com',
+	'chzzk.naver.com/',
 );


### PR DESCRIPTION
#2475 와 연관되어있습니다.

폐쇄/지원되지 않는 서비스들 삭제, 공식적으로 embed를 지원하며 일부 규모가 있는 서비스 위주로 새롭게 추가했습니다.

## 삭제한 서비스 목록
- 다음(도메인 접속불가가 대다수)
- 판도라tv(서비스 종료)
- 싸이월드(서비스 종료)
- 이글루스 (서비스 종료)
- 네이트 (서비스 종료)
- SBS
  - 모든 방송국을 추가하지 않을거라면 추가하지 않는게 좋다고 판단했습니다
- 아프리카tv -> Soop으로 서비스 변경, 반영하여 추가

## 추가한 서비스 목록
- Meta 사 서비스
  - 페이스북
  - 인스타그램
  - 스레드
  - Giphy
- X(트위터)
- 틱톡
- 디스코드
- 카카오TV
- 네이버 치지직