### PR TITLE
알림센터 닉네임 추출 정규식 변경

### DIFF
--- a/modules/ncenterlite/ncenterlite.controller.php
+++ b/modules/ncenterlite/ncenterlite.controller.php
@@ -1537,7 +1537,7 @@ class NcenterliteController extends Ncenterlite
 
 		// Extract mentions.
 		$content = html_entity_decode(strip_tags($content));
-		preg_match_all('/(?:^|\s)@([^\pC\pM\pP\pS\pZ]+)/u', $content, $matches);
+		preg_match_all('/(?:^|[\s\n(])@([\w.-]+)/u', $content, $matches);
 		$mentions = array_unique($matches[1]);
 		$members = array();
 


### PR DESCRIPTION
현재의 알림센터에서는 @"user" 는 호출할 수 있지만 @"user.name" 은 호출할 수 없습니다.
그와 함께 언더바, 하이픈도 닉네임으로 사용할 가능성이 있음으로아래와 같이 PR을 제출하여 기능 개선을 요청 드리고자 합니다.




|입력 문자열| 매칭 결과  |
|--|--|
| @user1 | user1 |
| Hello @user123 | user123 |
| Test @user.name | user.name |
| @user_name | user_name |
| @user-name | user-name |


긍정적인 검토를 부탁 드리겠습니다 (__)