### PR TITLE
utf8_normalize_spaces() 함수에서 공백 문자 추가 제거

### DIFF
--- a/common/functions.php
+++ b/common/functions.php
@@ -680,7 +680,7 @@ function utf8_mbencode($str): string
  */
 function utf8_normalize_spaces($str, bool $multiline = false): string
 {
-	return $multiline ? preg_replace('/((?!\x0A)[\pZ\pC])+/u', ' ', (string)$str) : preg_replace('/[\pZ\pC]+/u', ' ', (string)$str);
+	return $multiline ? preg_replace(['/((?!\x0A)[\pZ\pC])+/u', '/\x20(?=\x0A)/u'], [' ', ''], (string)$str) : preg_replace('/[\pZ\pC]+/u', ' ', (string)$str);
 }
 
 /**


### PR DESCRIPTION
### 문제 상황
- 개행 문자가 `\r\n`인 경우 `\r`이 공백 문자 ` (0x20)`로 변경 됩니다.

### 함수 처리 조건
- 싱글 라인일 때 모든 연속된 공백 문자는 `0x20` 하나만 남김.
- 멀티 라인일 때 `\n` 문자만 예외로 문자 유지.
- 각종 공백 문자 끝에 `\n` 문자가 있는 경우 `\n` 문자만 남김

### 문제 수정
- 불필요한 개행 및 공백 제거가 목적인 함수의 안정성을 위해, 기존 그대로 `\n` 문자만 개행으로 유지하고 불필요한 공백을 추가로 제거합니다.


참고 #2524