### PR TITLE
다국어 문서 기능 제거

### DIFF
--- a/modules/document/document.controller.php
+++ b/modules/document/document.controller.php
@@ -867,7 +867,7 @@ class DocumentController extends Document
 				}
 
 				$extra_vars[$extra_item->name] = $value;
-				$this->insertDocumentExtraVar($obj->module_srl, $obj->document_srl, $idx, $value, $extra_item->eid);
+				$this->insertDocumentExtraVar($obj->module_srl, $obj->document_srl, $idx, $value, $extra_item->eid, $obj->lang_code);
 			}
 		}
 
@@ -1858,12 +1858,18 @@ class DocumentController extends Document
 			}
 		}
 
+		if (!$lang_code)
+		{
+			$oDocument = DocumentModel::getDocument($document_srl);
+			$lang_code = $oDocument->get('lang_code') ?: Context::getLangType();
+		}
+
 		$obj = new stdClass;
 		$obj->module_srl = $module_srl;
 		$obj->document_srl = $document_srl;
 		$obj->var_idx = $idx_or_eid;
 		$obj->value = $value;
-		$obj->lang_code = $lang_code ?: Context::getLangType();
+		$obj->lang_code = $lang_code;
 		$obj->eid = $eid;
 
 		return executeQuery('document.insertDocumentExtraVar', $obj);
@@ -1907,12 +1913,18 @@ class DocumentController extends Document
 			}
 		}
 
+		if (!$lang_code)
+		{
+			$oDocument = DocumentModel::getDocument($document_srl);
+			$lang_code = $oDocument->get('lang_code') ?: Context::getLangType();
+		}
+
 		$obj = new stdClass;
 		$obj->module_srl = $module_srl;
 		$obj->document_srl = $document_srl;
 		$obj->var_idx = $idx_or_eid;
 		$obj->value = $value;
-		$obj->lang_code = $lang_code ?: Context::getLangType();
+		$obj->lang_code = $lang_code;
 		$obj->eid = $eid;
 
 		$oDB = DB::getInstance();

--- a/modules/document/document.controller.php
+++ b/modules/document/document.controller.php
@@ -1153,26 +1153,14 @@ class DocumentController extends Document
 		}
 
 		// Set lang_code if the original document doesn't have it.
-		if (!$source_obj->get('lang_code'))
+		$source_lang_code = $source_obj->get('lang_code');
+		if (!$source_lang_code)
 		{
+			$source_lang_code = Context::getLangType();
 			$output = executeQuery('document.updateDocumentsLangCode', [
 				'document_srl' => $source_obj->get('document_srl'),
-				'lang_code' => Context::getLangType(),
+				'lang_code' => $source_lang_code,
 			]);
-		}
-		// Move content to extra vars if the current language is different from the original document's lang_code.
-		elseif ($source_obj->get('lang_code') !== Context::getLangType())
-		{
-			$extra_content = new stdClass;
-			$extra_content->title = $obj->title;
-			$extra_content->content = $obj->content;
-
-			$document_output = executeQuery('document.getDocument', ['document_srl' => $source_obj->get('document_srl')], ['title', 'content']);
-			if (isset($document_output->data->title))
-			{
-				$obj->title = $document_output->data->title;
-				$obj->content = $document_output->data->content;
-			}
 		}
 
 		// Insert data into the DB
@@ -1189,7 +1177,11 @@ class DocumentController extends Document
 		{
 			// Get a copy of current extra vars before deleting all existing data.
 			$old_extra_vars = DocumentModel::getExtraVars($obj->module_srl, $obj->document_srl);
-			$this->deleteDocumentExtraVars($source_obj->get('module_srl'), $obj->document_srl, null, Context::getLangType());
+			$this->deleteDocumentExtraVars($source_obj->get('module_srl'), $obj->document_srl, null, $source_lang_code);
+			if ($source_lang_code !== Context::getLangType())
+			{
+				$this->deleteDocumentExtraVars($source_obj->get('module_srl'), $obj->document_srl, null, Context::getLangType());
+			}
 
 			// Insert extra variables if the document successfully inserted.
 			$extra_keys = DocumentModel::getExtraKeys($obj->module_srl);
@@ -1294,15 +1286,8 @@ class DocumentController extends Document
 						}
 					}
 					$extra_vars[$extra_item->name] = $value;
-					$this->insertDocumentExtraVar($obj->module_srl, $obj->document_srl, $idx, $value, $extra_item->eid);
+					$this->insertDocumentExtraVar($obj->module_srl, $obj->document_srl, $idx, $value, $extra_item->eid, $source_lang_code);
 				}
-			}
-
-			// Inert extra vars for multi-language support of title and contents.
-			if (isset($extra_content))
-			{
-				$this->insertDocumentExtraVar($obj->module_srl, $obj->document_srl, -1, $extra_content->title, 'title_'.Context::getLangType());
-				$this->insertDocumentExtraVar($obj->module_srl, $obj->document_srl, -2, $extra_content->content, 'content_'.Context::getLangType());
 			}
 		}
 


### PR DESCRIPTION
https://rhymix.org/community/1904797

- 앞으로는 A언어에서 작성한 문서를 B언어에서 수정하더라도 두 가지 버전의 문서가 생성되지 않습니다. A, B 모두 마지막으로 수정한 내용을 갖게 됩니다.
- 확장변수도 마찬가지입니다.
- 기존에 작성된 다국어 문서는 여전히 언어에 따라 다른 내용으로 표시됩니다. 단, 수정하면 하나로 합쳐집니다.
- 3개 이상의 언어를 사용하는 경우, A언어에서 작성한 문서를 B언어에서 수정하면 A, B 언어만 합쳐됩니다. 수정하지 않은 C 언어 버전은 그대로 남아 있습니다. C 언어 버전도 통합하려면 C 언어 상태에서 한 번 더 수정해 주면 됩니다. (기존 데이터 파괴를 최소화하기 위한 조치)
- 문서가 아닌 다른 곳에 적용된 다국어 기능에는 영향이 없습니다. 사이트 설정, 게시판 이름, 메뉴 등 관리자 화면에서 다국어 아이콘을 눌러 설정하는 것이라면 모두 여기에 해당됩니다.