### PR TITLE
가입 폼 순서 변경 시 하위 필드 값 초기화 문제 수정

### DIFF
--- a/modules/admin/tpl/js/admin.js
+++ b/modules/admin/tpl/js/admin.js
@@ -1299,7 +1299,7 @@ jQuery(function($){
 				position = {x:event.pageX, y:event.pageY};
 				offset   = getOffset($tr.get(0), ofspar);
 
-				$clone = $tr.attr('target', true).clone(true).appendTo($table);
+				$clone = $tr.attr('target', true).clone(true).find('input').removeAttr('id name').end().appendTo($table);
 
 				// get colspan
 				cols = ($th=$table.find('thead th')).length;


### PR DESCRIPTION
### 문제 상황
- 가입 폼 순서 변경을 위해 이동 버튼 클릭 순간, 기존 회원가입 폼 설정 값이 초기화 됩니다.
- 이를 인지하지 못하고 저장하면 필수/선택 값이 초기 값으로 변경됩니다.

![스크린샷 2025-03-30 135209](https://github.com/user-attachments/assets/6c8d5a0b-1a12-4851-bf32-1cdb05378187)

### 문제 수정
- 가입 폼 이동 시 복제되는 input의 id, name 속성을 제거하여, 단순 이동 표시 용도로 사용합니다.