### PR TITLE
Fix #2572 포함할 게시판 설정에 mid도 표시

### DIFF
--- a/modules/board/tpl/addition_setup.html
+++ b/modules/board/tpl/addition_setup.html
@@ -19,7 +19,7 @@
 				<select name="include_modules[]" id="include_modules" size="8" multiple="multiple">
 					<option value="">{$lang->cmd_board_include_modules_none}</option>
 					<!--@foreach($board_list as $board_info)-->
-						<option value="{$board_info->module_srl}" selected="selected"|cond="in_array($board_info->module_srl, $include_modules)">{$board_info->browser_title}</option>
+						<option value="{$board_info->module_srl}" selected="selected"|cond="in_array($board_info->module_srl, $include_modules)">{$board_info->browser_title} ({$board_info->mid})</option>
 					<!--@endforeach-->
 				</select>
 				<p class="x_help-block">{$lang->about_board_combined_board}</p>


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/68e227f3-3abf-4e30-b40f-324d430a7404)
이 스샷처럼 통합할 게시판 설정에 mid도 표시합니다. 게시판명이 같은것이 많은 경우 유용합니다.