### PR TITLE
Fix #2576 자신을 참조하는 외래키는 생성 순서에 영향을 주지 않도록 변경

### DIFF
--- a/common/framework/parsers/DBTableParser.php
+++ b/common/framework/parsers/DBTableParser.php
@@ -304,7 +304,13 @@ class DBTableParser extends BaseParser
 					if ($constraint->references)
 					{
 						$ref = explode('.', $constraint->references);
-						$info->refs[] = $ref[0];
+						$reference_table_name = $ref[0];
+						if ($reference_table_name === $table_name)
+						{
+							continue; // Ignore self-references.
+						}
+
+						$info->refs[] = $reference_table_name;
 					}
 				}
 				$ref_list[$table_name] = $info;
@@ -328,7 +334,6 @@ class DBTableParser extends BaseParser
 						}
 					}
 				}
-				$k++;
 			}
 			if (!$changed)
 			{


### PR DESCRIPTION
#2576 이슈를 해결하는 PR입니다.

https://github.com/rhymix/rhymix/blob/ba12e1b3a4a8032cb7fce849ad07ba8177da1644/common/framework/parsers/DBTableParser.php#L322-L329

테이블 간 생성 순서를 비교할 때, 자기 자신이 `ref_name`에 포함되는 경우 조건을 계속 만족하게 되어, 순서가 비정상적으로 밀려나는 문제가 있었습니다.

이번 PR에서는 테이블이 외래 키로 자기 자신을 참조하는 경우, 생성 순서에 영향을 주지 않도록 수정하였습니다.

추가로 `$k`는 존재하지 않는 변수로 보여 삭제하였습니다.