### PR TITLE
Fix: 한국 MX 레코드 검증시 도메인이 아닌 MX 레코드의 아이피로 검증하도록 수정 #2579

### DIFF
--- a/common/framework/Korea.php
+++ b/common/framework/Korea.php
@@ -349,7 +349,7 @@ class Korea
 					return self::$_domain_cache[$domain] = false;
 				}
 			}
-			foreach (self::_getDNSRecords($domain, \DNS_A) as $mx_ip)
+			foreach (self::_getDNSRecords($mx, \DNS_A) as $mx_ip)
 			{
 				return self::$_domain_cache[$domain] = self::isKoreanIP($mx_ip);
 			}


### PR DESCRIPTION
#2579 이슈의 수정 PR입니다.