### PR TITLE
add index_hint for getNewestDocuments

### DIFF
--- a/widgets/content/queries/getNewestDocuments.xml
+++ b/widgets/content/queries/getNewestDocuments.xml
@@ -2,6 +2,9 @@
     <tables>
         <table name="documents" />
     </tables>
+    <index_hint for="ALL">
+        <index table="documents" name="idx_module_status" type="USE" />
+    </index_hint>
     <columns>
         <column name="*" />
     </columns>


### PR DESCRIPTION
최신 마리아DB 등에서 엉뚱한 인덱스 타는 문제 방지