### PR TITLE
Fix 관리자 페이지에서 th의 colspan을 반영하여 데이터의 colspan을 수정하도록 개선

### DIFF
--- a/modules/admin/tpl/js/admin.js
+++ b/modules/admin/tpl/js/admin.js
@@ -367,7 +367,17 @@ jQuery(function($){
 	$.fn.tableSpan = function(){
 		this.each(function(){
 			var $this = $(this);
-			var thNum = $this.find('>thead>tr:eq(0)>th').length;
+			var thList = $this.find('>thead>tr:eq(0)>th');
+			var thNum = 0;
+			thList.each(function(){
+				var $th = $(this);
+				if($th.attr('colspan')){ // th의 colspan 반영
+					thNum += parseInt($th.attr('colspan'), 10);
+				} else {
+					thNum++;
+				}
+			});
+
 			var $tdTarget = $this.find('>tbody>tr:eq(0)>td:only-child');
 			if(thNum != $tdTarget.attr('colspan')){
 				$tdTarget.attr('colspan', thNum).css('text-align','center');


### PR DESCRIPTION
대부분의 테이블이 그렇듯 데이터가 없으면 `tbody > tr > td:only-child`에 "데이터가 없습니다"와 같이 메세지를 넣는데요.
admin.js에서 저 td의 colspan을 th의 개수에 맞게 임의로 조정하는 것을 확인하였습니다.

다만 기존 코드에서는 th의 colspan을 고려하지 않고, th의 개수만을 가지고 colspan을 수정하여 디자인이 깨지는 이슈가 있습니다.

```html
<table>
  <thead>
    <tr>
      <th colspan="3">테스트</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td colspan="3" class="no-data">데이터가 없습니다.</td>
    </tr>
  </tbody>
</table>
```

위 예시 실행시, `td.no-data`의 colspan이 1로 조정됩니다.

`thead > tr:eq(0) > th`의 colspan을 모두 더해 colspan을 계산하도록 수정하였습니다.