### PR TITLE
CKEditor 4 editor.fillEmptyBlocks config add

### DIFF
--- a/modules/editor/skins/ckeditor/js/editor.js
+++ b/modules/editor/skins/ckeditor/js/editor.js
@@ -111,6 +111,13 @@ $(function() {
 			settings.ckeconfig.removeButtons = 'Save,Preview,Print,Cut,Copy,Paste,Source';
 		}
 
+		// fix unused fillEmptyBlocks
+		settings.ckeconfig.fillEmptyBlocks = function ( element ) {
+			if (['video'].includes(element.name)) {
+				return false;
+			}
+		}
+
 		// Disable loading of custom configuration if config.js does not exist.
 		if (!config.custom_config_exists) {
 			CKEDITOR.config.customConfig = '';


### PR DESCRIPTION
video 태그 안에 빈 블럭이 작성되어 과도하게 줄바꿈이 늘어나는 현상을 방지합니다.

추후 video 외의 태그에 생기는 문제들도 쉽게 개선할 수 있게끔 배열형태로 추가하였습니다.