### PR TITLE
파일 이름에 & 가 있는 경우 정상적으로 다운로드 되지 않던 문제

### DIFF
--- a/modules/file/file.controller.php
+++ b/modules/file/file.controller.php
@@ -318,7 +318,7 @@ class FileController extends File
 		{
 			throw new Rhymix\Framework\Exceptions\TargetNotFound('msg_file_not_found');
 		}
-		if ($filename_arg !== null && $filename_arg !== $filename)
+		if ($filename_arg !== null && html_entity_decode($filename_arg, ENT_QUOTES, 'UTF-8') !== $filename)
 		{
 			throw new Rhymix\Framework\Exceptions\TargetNotFound('msg_file_not_found');
 		}
@@ -460,7 +460,7 @@ class FileController extends File
 		}
 
 		// Check filename if given
-		if ($filename_arg !== null && $filename_arg !== $filename)
+		if ($filename_arg !== null && html_entity_decode($filename_arg, ENT_QUOTES, 'UTF-8') !== $filename)
 		{
 			throw new Rhymix\Framework\Exceptions\TargetNotFound('msg_file_not_found');
 		}


### PR DESCRIPTION
## 요약
다운로드 경로의 `filename` 파라미터가 HTML 엔티티(`&amp;` 등)로 넘어오는 경우가 있어 DB에 저장된 원본 파일명과 비교가 실패합니다.
이 PR은 비교 직전에 HTML 엔티티를 디코드하여 원본 파일명과 정상적으로 일치시키는 최소 변경을 합니다.

## 문제 재현(증상)
다음과 같은 URL로 접근할 때: /files/download/link/217/<sid>/%EA%B0%80%EB%82%98%EB%8B%A4&%ED%85%8C%EC%8A%A4%ED%8A%B8.txt

템플릿/라우터 과정에서 `filename` 값이 `가나다&amp;테스트.txt`(또는 엔티티화된 상태)로 들어오면 기존 비교 구문에서는 DB의 `가나다&테스트.txt`와 불일치가 발생하여 `msg_file_not_found` 예외가 발생합니다.

## 원인
- 화면으로 `var_dump()` 했을 때 브라우저가 `&amp;`를 `&`로 렌더링하므로 사람이 보기에 같아 보여도 내부 문자열은 다른 상태입니다(예: 바이트 길이 불일치).

## 변경 내용
비교 직전에 `html_entity_decode(..., ENT_QUOTES, 'UTF-8')`을 적용하여 HTML 엔티티를 원래 문자로 복원하도록 했습니다.

**변경 전**
```php
if ($filename_arg !== null && $filename_arg !== $filename) {
    throw new Rhymix\Framework\Exceptions\TargetNotFound('msg_file_not_found');
}
```
**변경 후**
```php
if ($filename_arg !== null && html_entity_decode($filename_arg, ENT_QUOTES, 'UTF-8') !== $filename) {
    throw new Rhymix\Framework\Exceptions\TargetNotFound('msg_file_not_found');
}
```
