### PR TITLE
XML 규격 파일들에 대한 XSD 추가

### DIFF
--- a/common/manual/schemas/addon-info.xsd
+++ b/common/manual/schemas/addon-info.xsd
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+	xmlns:xml="http://www.w3.org/XML/1998/namespace"
+	elementFormDefault="qualified">
+
+	<xs:element name="addon">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="title" type="localizedString" minOccurs="0" maxOccurs="unbounded" />
+				<xs:element name="description" type="localizedString" minOccurs="0"
+					maxOccurs="unbounded" />
+				<xs:element name="version" type="versionText" minOccurs="0" />
+				<xs:element name="date" type="dateValue" minOccurs="0" />
+				<xs:element name="link" type="xs:anyURI" minOccurs="0" />
+				<xs:element name="license" type="licenseType" minOccurs="0" />
+				<xs:element name="author" type="authorType" minOccurs="0" maxOccurs="unbounded" />
+				<xs:element name="extra_vars" type="extraVarsType" minOccurs="0" />
+			</xs:sequence>
+			<xs:attribute name="version" type="xs:string" use="optional" />
+		</xs:complexType>
+	</xs:element>
+
+	<xs:complexType name="licenseType">
+		<xs:simpleContent>
+			<xs:extension base="xs:string">
+				<xs:attribute name="link" type="xs:anyURI" use="optional" />
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+
+	<xs:complexType name="authorType">
+		<xs:sequence>
+			<xs:element name="name" type="localizedString" minOccurs="0" maxOccurs="unbounded" />
+		</xs:sequence>
+		<xs:attribute name="email_address" type="xs:string" use="optional" />
+		<xs:attribute name="link" type="xs:anyURI" use="optional" />
+	</xs:complexType>
+
+	<xs:complexType name="extraVarsType">
+		<xs:choice minOccurs="0" maxOccurs="unbounded">
+			<xs:element name="var" type="varType" />
+			<xs:element name="group" type="varGroupType" />
+		</xs:choice>
+	</xs:complexType>
+
+	<xs:complexType name="varGroupType">
+		<xs:sequence>
+			<xs:element name="title" type="localizedString" minOccurs="0" maxOccurs="unbounded" />
+			<xs:element name="var" type="varType" minOccurs="0" maxOccurs="unbounded" />
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="varType">
+		<xs:choice minOccurs="0" maxOccurs="unbounded">
+			<xs:element name="title" type="localizedString" />
+			<xs:element name="description" type="localizedString" />
+			<xs:element name="options" type="varOptionType" />
+		</xs:choice>
+		<xs:attribute name="name" type="xs:string" use="optional" />
+		<xs:attribute name="id" type="xs:string" use="optional" />
+		<xs:attribute name="type" type="xs:string" use="optional" />
+		<xs:attribute name="default" type="xs:string" use="optional" />
+		<xs:anyAttribute processContents="lax" />
+	</xs:complexType>
+
+	<xs:complexType name="varOptionType">
+		<xs:sequence>
+			<xs:element name="title" type="localizedString" minOccurs="0" maxOccurs="unbounded" />
+			<xs:element name="description" type="localizedString" minOccurs="0"
+				maxOccurs="unbounded" />
+		</xs:sequence>
+		<xs:attribute name="value" type="xs:string" use="optional" />
+		<xs:anyAttribute processContents="lax" />
+	</xs:complexType>
+
+	<xs:complexType name="localizedString">
+		<xs:simpleContent>
+			<xs:extension base="xs:string">
+				<xs:anyAttribute namespace="http://www.w3.org/XML/1998/namespace"
+					processContents="lax" />
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+
+	<xs:simpleType name="versionText">
+		<xs:union memberTypes="versionPattern placeholderToken" />
+	</xs:simpleType>
+
+	<xs:simpleType name="versionPattern">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="\d+(\.\d+){0,2}" />
+		</xs:restriction>
+	</xs:simpleType>
+
+	<xs:simpleType name="placeholderToken">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="RX_[A-Z0-9_]+" />
+		</xs:restriction>
+	</xs:simpleType>
+
+	<xs:simpleType name="dateValue">
+		<xs:union memberTypes="xs:date placeholderToken" />
+	</xs:simpleType>
+
+</xs:schema>

--- a/common/manual/schemas/addon-info.xsd
+++ b/common/manual/schemas/addon-info.xsd
@@ -1,41 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
-	xmlns:xml="http://www.w3.org/XML/1998/namespace"
-	elementFormDefault="qualified">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+
+	<xs:include schemaLocation="shared-types.xsd" />
 
 	<xs:element name="addon">
 		<xs:complexType>
 			<xs:sequence>
-				<xs:element name="title" type="localizedString" minOccurs="0" maxOccurs="unbounded" />
+				<xs:element name="title" type="localizedString" minOccurs="1" maxOccurs="unbounded" />
 				<xs:element name="description" type="localizedString" minOccurs="0"
 					maxOccurs="unbounded" />
-				<xs:element name="version" type="versionText" minOccurs="0" />
-				<xs:element name="date" type="dateValue" minOccurs="0" />
+				<xs:element name="version" type="versionString" minOccurs="0" />
+				<xs:element name="date" type="dateString" minOccurs="0" />
 				<xs:element name="link" type="xs:anyURI" minOccurs="0" />
 				<xs:element name="license" type="licenseType" minOccurs="0" />
 				<xs:element name="author" type="authorType" minOccurs="0" maxOccurs="unbounded" />
 				<xs:element name="extra_vars" type="extraVarsType" minOccurs="0" />
 			</xs:sequence>
-			<xs:attribute name="version" type="xs:string" use="optional" />
+			<xs:attributeGroup ref="commonVersionAttribute"></xs:attributeGroup>
 		</xs:complexType>
 	</xs:element>
 
-	<xs:complexType name="licenseType">
-		<xs:simpleContent>
-			<xs:extension base="xs:string">
-				<xs:attribute name="link" type="xs:anyURI" use="optional" />
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-
-	<xs:complexType name="authorType">
-		<xs:sequence>
-			<xs:element name="name" type="localizedString" minOccurs="0" maxOccurs="unbounded" />
-		</xs:sequence>
-		<xs:attribute name="email_address" type="xs:string" use="optional" />
-		<xs:attribute name="link" type="xs:anyURI" use="optional" />
-	</xs:complexType>
-
+	<!-- Element:extra_vars -->
 	<xs:complexType name="extraVarsType">
 		<xs:choice minOccurs="0" maxOccurs="unbounded">
 			<xs:element name="var" type="varType" />
@@ -72,34 +57,4 @@
 		<xs:attribute name="value" type="xs:string" use="optional" />
 		<xs:anyAttribute processContents="lax" />
 	</xs:complexType>
-
-	<xs:complexType name="localizedString">
-		<xs:simpleContent>
-			<xs:extension base="xs:string">
-				<xs:anyAttribute namespace="http://www.w3.org/XML/1998/namespace"
-					processContents="lax" />
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-
-	<xs:simpleType name="versionText">
-		<xs:union memberTypes="versionPattern placeholderToken" />
-	</xs:simpleType>
-
-	<xs:simpleType name="versionPattern">
-		<xs:restriction base="xs:string">
-			<xs:pattern value="\d+(\.\d+){0,2}" />
-		</xs:restriction>
-	</xs:simpleType>
-
-	<xs:simpleType name="placeholderToken">
-		<xs:restriction base="xs:string">
-			<xs:pattern value="RX_[A-Z0-9_]+" />
-		</xs:restriction>
-	</xs:simpleType>
-
-	<xs:simpleType name="dateValue">
-		<xs:union memberTypes="xs:date placeholderToken" />
-	</xs:simpleType>
-
 </xs:schema>

--- a/common/manual/schemas/db-queries.xsd
+++ b/common/manual/schemas/db-queries.xsd
@@ -1,0 +1,278 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+	elementFormDefault="qualified"
+	version="1.1">
+
+	<xs:annotation>
+		<xs:documentation> Schema describing Rhymix query definition files under modules/*/queries,
+			addons/*/queries, and widgets/*/queries. </xs:documentation>
+	</xs:annotation>
+
+	<xs:element name="query" type="queryType" />
+
+	<xs:complexType name="queryType">
+		<xs:sequence>
+			<xs:element name="tables" type="tableListType" />
+			<xs:choice minOccurs="0" maxOccurs="unbounded">
+				<xs:element name="index_hint" type="indexHintType" />
+				<xs:element name="columns" type="columnCollectionType" />
+				<xs:element name="conditions" type="conditionsType" />
+				<xs:element name="groups" type="groupByCollectionType" />
+				<xs:element name="navigation" type="navigationType" />
+			</xs:choice>
+		</xs:sequence>
+		<xs:attribute name="id" type="identifierType" use="optional" />
+		<xs:attribute name="action" type="queryActionType" use="optional" />
+		<xs:attribute name="alias" type="identifierType" use="optional" />
+		<xs:attribute name="column" type="xs:string" use="optional" />
+		<xs:attribute name="notnull" type="notNullLiteral" use="optional" />
+		<xs:attribute name="operation" type="conditionOperationType" use="optional" />
+		<xs:attribute name="priority" type="priorityType" use="optional" />
+		<xs:anyAttribute processContents="lax" />
+	</xs:complexType>
+
+	<xs:complexType name="tableListType">
+		<xs:sequence>
+			<xs:element name="table" type="tableType" minOccurs="1" maxOccurs="unbounded" />
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="tableType">
+		<xs:sequence>
+			<xs:choice minOccurs="0" maxOccurs="unbounded">
+				<xs:element name="tables" type="tableListType" />
+				<xs:element name="columns" type="columnCollectionType" />
+				<xs:element name="conditions" type="conditionsType" />
+				<xs:element name="groups" type="groupByCollectionType" />
+			</xs:choice>
+		</xs:sequence>
+		<xs:attribute name="name" type="identifierType" use="optional" />
+		<xs:attribute name="alias" type="identifierType" use="optional" />
+		<xs:attribute name="alais" type="identifierType" use="optional" />
+		<xs:attribute name="type" type="joinType" use="optional" />
+		<xs:attribute name="query" type="queryFlagType" use="optional" />
+		<xs:attribute name="if" type="xs:string" use="optional" />
+		<xs:anyAttribute processContents="lax" />
+	</xs:complexType>
+
+	<xs:complexType name="columnCollectionType">
+		<xs:sequence>
+			<xs:element name="column" type="columnType" minOccurs="0" maxOccurs="unbounded" />
+		</xs:sequence>
+		<xs:attribute name="distinct" type="distinctLiteral" use="optional" />
+	</xs:complexType>
+
+	<xs:complexType name="columnType">
+		<xs:attribute name="name" type="xs:string" use="required" />
+		<xs:attribute name="alias" type="identifierType" use="optional" />
+		<xs:attribute name="alais" type="identifierType" use="optional" />
+		<xs:attribute name="var" type="xs:string" use="optional" />
+		<xs:attribute name="filter" type="filterType" use="optional" />
+		<xs:attribute name="default" type="xs:string" use="optional" />
+		<xs:attribute name="notnull" type="notNullLiteral" use="optional" />
+		<xs:attribute name="operation" type="columnOperationType" use="optional" />
+		<xs:attribute name="if" type="xs:string" use="optional" />
+		<xs:attribute name="maxlength" type="xs:positiveInteger" use="optional" />
+		<xs:attribute name="minlength" type="xs:nonNegativeInteger" use="optional" />
+		<xs:anyAttribute processContents="lax" />
+	</xs:complexType>
+
+	<xs:complexType name="conditionsType">
+		<xs:choice minOccurs="0" maxOccurs="unbounded">
+			<xs:element name="condition" type="conditionType" />
+			<xs:element name="group" type="conditionGroupType" />
+			<xs:element ref="query" />
+		</xs:choice>
+	</xs:complexType>
+
+	<xs:complexType name="conditionType">
+		<xs:attribute name="operation" type="conditionOperationType" use="required" />
+		<xs:attribute name="column" type="xs:string" use="required" />
+		<xs:attribute name="var" type="xs:string" use="optional" />
+		<xs:attribute name="default" type="xs:string" use="optional" />
+		<xs:attribute name="filter" type="filterType" use="optional" />
+		<xs:attribute name="pipe" type="pipeType" use="optional" />
+		<xs:attribute name="notnull" type="notNullLiteral" use="optional" />
+		<xs:attribute name="if" type="xs:string" use="optional" />
+		<xs:anyAttribute processContents="lax" />
+	</xs:complexType>
+
+	<xs:complexType name="conditionGroupType">
+		<xs:choice minOccurs="1" maxOccurs="unbounded">
+			<xs:element name="condition" type="conditionType" />
+			<xs:element name="group" type="conditionGroupType" />
+			<xs:element ref="query" />
+		</xs:choice>
+		<xs:attribute name="pipe" type="pipeType" use="optional" />
+		<xs:anyAttribute processContents="lax" />
+	</xs:complexType>
+
+	<xs:complexType name="groupByCollectionType">
+		<xs:sequence>
+			<xs:element name="group" type="groupByEntryType" minOccurs="1" maxOccurs="unbounded" />
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="groupByEntryType">
+		<xs:attribute name="column" type="xs:string" use="required" />
+		<xs:anyAttribute processContents="lax" />
+	</xs:complexType>
+
+	<xs:complexType name="navigationType">
+		<xs:sequence>
+			<xs:element name="index" type="navigationIndexType" minOccurs="0" maxOccurs="unbounded" />
+			<xs:element name="list_count" type="navigationParameterType" minOccurs="0" />
+			<xs:element name="page_count" type="navigationParameterType" minOccurs="0" />
+			<xs:element name="page" type="navigationParameterType" minOccurs="0" />
+			<xs:element name="offset" type="navigationParameterType" minOccurs="0" />
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="navigationParameterType">
+		<xs:attribute name="var" type="xs:string" use="optional" />
+		<xs:attribute name="default" type="xs:string" use="optional" />
+		<xs:anyAttribute processContents="lax" />
+	</xs:complexType>
+
+	<xs:complexType name="navigationIndexType">
+		<xs:attribute name="var" type="xs:string" use="optional" />
+		<xs:attribute name="default" type="xs:string" use="optional" />
+		<xs:attribute name="defualt" type="xs:string" use="optional" />
+		<xs:attribute name="order" type="xs:string" use="optional" />
+		<xs:attribute name="order_default" type="orderDirectionType" use="optional" />
+		<xs:attribute name="order-default" type="orderDirectionType" use="optional" />
+		<xs:attribute name="type" type="xs:string" use="optional" />
+		<xs:attribute name="name" type="identifierType" use="optional" />
+		<xs:attribute name="comment" type="xs:string" use="optional" />
+		<xs:anyAttribute processContents="lax" />
+	</xs:complexType>
+
+	<xs:complexType name="indexHintType">
+		<xs:sequence>
+			<xs:element name="index" type="indexHintEntryType" minOccurs="0" />
+		</xs:sequence>
+		<xs:attribute name="for" type="indexHintScopeType" use="optional" />
+		<xs:attribute name="name" type="identifierType" use="optional" />
+		<xs:attribute name="type" type="indexHintModeType" use="optional" />
+		<xs:anyAttribute processContents="lax" />
+	</xs:complexType>
+
+	<xs:complexType name="indexHintEntryType">
+		<xs:attribute name="table" type="identifierType" use="optional" />
+		<xs:attribute name="name" type="identifierType" use="optional" />
+		<xs:attribute name="var" type="xs:string" use="optional" />
+		<xs:attribute name="default" type="xs:string" use="optional" />
+		<xs:attribute name="type" type="xs:string" use="optional" />
+		<xs:anyAttribute processContents="lax" />
+	</xs:complexType>
+
+	<xs:simpleType name="identifierType">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="[A-Za-z_][A-Za-z0-9_]*" />
+		</xs:restriction>
+	</xs:simpleType>
+
+	<xs:simpleType name="queryActionType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="select" />
+			<xs:enumeration value="insert" />
+			<xs:enumeration value="update" />
+			<xs:enumeration value="delete" />
+		</xs:restriction>
+	</xs:simpleType>
+
+	<xs:simpleType name="joinType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="left join" />
+			<xs:enumeration value="left outer join" />
+		</xs:restriction>
+	</xs:simpleType>
+
+	<xs:simpleType name="queryFlagType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="true" />
+		</xs:restriction>
+	</xs:simpleType>
+
+	<xs:simpleType name="distinctLiteral">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="distinct" />
+		</xs:restriction>
+	</xs:simpleType>
+
+	<xs:simpleType name="filterType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="email" />
+			<xs:enumeration value="homepage" />
+			<xs:enumeration value="number" />
+			<xs:enumeration value="numbers" />
+			<xs:enumeration value="userid" />
+		</xs:restriction>
+	</xs:simpleType>
+
+	<xs:simpleType name="notNullLiteral">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="notnull" />
+		</xs:restriction>
+	</xs:simpleType>
+
+	<xs:simpleType name="columnOperationType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="plus" />
+		</xs:restriction>
+	</xs:simpleType>
+
+	<xs:simpleType name="conditionOperationType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="below" />
+			<xs:enumeration value="equal" />
+			<xs:enumeration value="excess" />
+			<xs:enumeration value="in" />
+			<xs:enumeration value="less" />
+			<xs:enumeration value="like" />
+			<xs:enumeration value="like_prefix" />
+			<xs:enumeration value="more" />
+			<xs:enumeration value="notequal" />
+			<xs:enumeration value="notin" />
+			<xs:enumeration value="notnull" />
+			<xs:enumeration value="null" />
+			<xs:enumeration value="search" />
+		</xs:restriction>
+	</xs:simpleType>
+
+	<xs:simpleType name="pipeType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="and" />
+			<xs:enumeration value="or" />
+			<xs:enumeration value="where" />
+		</xs:restriction>
+	</xs:simpleType>
+
+	<xs:simpleType name="priorityType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="LOW" />
+		</xs:restriction>
+	</xs:simpleType>
+
+	<xs:simpleType name="orderDirectionType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="asc" />
+			<xs:enumeration value="desc" />
+		</xs:restriction>
+	</xs:simpleType>
+
+	<xs:simpleType name="indexHintScopeType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="ALL" />
+			<xs:enumeration value="MYSQL" />
+		</xs:restriction>
+	</xs:simpleType>
+
+	<xs:simpleType name="indexHintModeType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="use" />
+			<xs:enumeration value="USE" />
+		</xs:restriction>
+	</xs:simpleType>
+
+</xs:schema>

--- a/common/manual/schemas/db-queries.xsd
+++ b/common/manual/schemas/db-queries.xsd
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
-	elementFormDefault="qualified"
-	version="1.1">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
 
 	<xs:annotation>
 		<xs:documentation> Schema describing Rhymix query definition files under modules/*/queries,

--- a/common/manual/schemas/db-schemas.xsd
+++ b/common/manual/schemas/db-schemas.xsd
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+	xmlns:xml="http://www.w3.org/XML/1998/namespace"
+	elementFormDefault="qualified">
+
+	<xs:annotation>
+		<xs:documentation> Schema describing database table definitions located under
+			modules/*/schemas. </xs:documentation>
+	</xs:annotation>
+
+	<xs:element name="table" type="tableType" />
+
+	<xs:complexType name="tableType">
+		<xs:sequence>
+			<xs:choice minOccurs="0" maxOccurs="unbounded">
+				<xs:element name="column" type="columnType" />
+				<xs:element name="index" type="indexType" />
+			</xs:choice>
+		</xs:sequence>
+		<xs:attribute name="name" type="dbIdentifier" use="required" />
+		<xs:attribute name="deleted" type="xs:boolean" use="optional" />
+		<xs:anyAttribute processContents="lax" />
+	</xs:complexType>
+
+	<xs:complexType name="columnType">
+		<xs:attribute name="name" type="dbIdentifier" use="required" />
+		<xs:attribute name="type" type="columnDataType" use="required" />
+		<xs:attribute name="size" type="xs:positiveInteger" use="optional" />
+		<xs:attribute name="default" type="xs:string" use="optional" />
+		<xs:attribute name="notnull" type="notNullLiteral" use="optional" />
+		<xs:attribute name="primary_key" type="primaryKeyLiteral" use="optional" />
+		<xs:attribute name="unique" type="constraintName" use="optional" />
+		<xs:attribute name="index" type="constraintName" use="optional" />
+		<xs:attribute name="auto_increment" type="autoIncrementLiteral" use="optional" />
+		<xs:attribute name="charset" type="charsetName" use="optional" />
+		<xs:attribute name="brief" type="xs:string" use="optional" />
+		<xs:anyAttribute processContents="lax" />
+	</xs:complexType>
+
+	<xs:complexType name="indexType">
+		<xs:attribute name="name" type="constraintName" use="required" />
+		<xs:attribute name="columns" type="xs:string" use="required" />
+		<xs:anyAttribute processContents="lax" />
+	</xs:complexType>
+
+	<xs:simpleType name="dbIdentifier">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="[A-Za-z_][A-Za-z0-9_]*" />
+		</xs:restriction>
+	</xs:simpleType>
+
+	<xs:simpleType name="constraintName">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="[A-Za-z_][A-Za-z0-9_]*" />
+		</xs:restriction>
+	</xs:simpleType>
+
+	<xs:simpleType name="columnDataType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="bigint" />
+			<xs:enumeration value="bignumber" />
+			<xs:enumeration value="bigtext" />
+			<xs:enumeration value="char" />
+			<xs:enumeration value="date" />
+			<xs:enumeration value="datetime" />
+			<xs:enumeration value="int" />
+			<xs:enumeration value="longtext" />
+			<xs:enumeration value="number" />
+			<xs:enumeration value="text" />
+			<xs:enumeration value="varchar" />
+		</xs:restriction>
+	</xs:simpleType>
+
+	<xs:simpleType name="notNullLiteral">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="notnull" />
+		</xs:restriction>
+	</xs:simpleType>
+
+	<xs:simpleType name="primaryKeyLiteral">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="primary_key" />
+		</xs:restriction>
+	</xs:simpleType>
+
+	<xs:simpleType name="autoIncrementLiteral">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="auto_increment" />
+		</xs:restriction>
+	</xs:simpleType>
+
+	<xs:simpleType name="charsetName">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="[A-Za-z0-9_-]+" />
+		</xs:restriction>
+	</xs:simpleType>
+
+</xs:schema>

--- a/common/manual/schemas/db-schemas.xsd
+++ b/common/manual/schemas/db-schemas.xsd
@@ -1,27 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
-	xmlns:xml="http://www.w3.org/XML/1998/namespace"
-	elementFormDefault="qualified">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
 
 	<xs:annotation>
 		<xs:documentation> Schema describing database table definitions located under
 			modules/*/schemas. </xs:documentation>
 	</xs:annotation>
 
-	<xs:element name="table" type="tableType" />
+	<xs:element name="table">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:choice minOccurs="0" maxOccurs="unbounded">
+					<xs:element name="column" type="columnType" />
+					<xs:element name="index" type="indexType" />
+				</xs:choice>
+			</xs:sequence>
+			<xs:attribute name="name" type="dbIdentifier" use="required" />
+			<xs:attribute name="deleted" type="xs:boolean" use="optional" />
+			<xs:anyAttribute processContents="lax" />
+		</xs:complexType>
+	</xs:element>
 
-	<xs:complexType name="tableType">
-		<xs:sequence>
-			<xs:choice minOccurs="0" maxOccurs="unbounded">
-				<xs:element name="column" type="columnType" />
-				<xs:element name="index" type="indexType" />
-			</xs:choice>
-		</xs:sequence>
-		<xs:attribute name="name" type="dbIdentifier" use="required" />
-		<xs:attribute name="deleted" type="xs:boolean" use="optional" />
-		<xs:anyAttribute processContents="lax" />
-	</xs:complexType>
-
+	<!-- Element:column -->
 	<xs:complexType name="columnType">
 		<xs:attribute name="name" type="dbIdentifier" use="required" />
 		<xs:attribute name="type" type="columnDataType" use="required" />
@@ -37,20 +36,24 @@
 		<xs:anyAttribute processContents="lax" />
 	</xs:complexType>
 
+	<!-- Element:index -->
 	<xs:complexType name="indexType">
 		<xs:attribute name="name" type="constraintName" use="required" />
 		<xs:attribute name="columns" type="xs:string" use="required" />
 		<xs:anyAttribute processContents="lax" />
 	</xs:complexType>
 
+	<!-- Types -->
 	<xs:simpleType name="dbIdentifier">
 		<xs:restriction base="xs:string">
+			<!-- FIXME -->
 			<xs:pattern value="[A-Za-z_][A-Za-z0-9_]*" />
 		</xs:restriction>
 	</xs:simpleType>
 
 	<xs:simpleType name="constraintName">
 		<xs:restriction base="xs:string">
+			<!-- FIXME -->
 			<xs:pattern value="[A-Za-z_][A-Za-z0-9_]*" />
 		</xs:restriction>
 	</xs:simpleType>

--- a/common/manual/schemas/layout.xsd
+++ b/common/manual/schemas/layout.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
-	xmlns:xml="http://www.w3.org/XML/1998/namespace"
-	elementFormDefault="qualified">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+
+	<xs:include schemaLocation="shared-types.xsd" />
 
 	<xs:element name="layout">
 		<xs:complexType>
@@ -9,34 +9,19 @@
 				<xs:element name="title" type="localizedString" minOccurs="0" maxOccurs="unbounded" />
 				<xs:element name="description" type="localizedString" minOccurs="0"
 					maxOccurs="unbounded" />
-				<xs:element name="version" type="versionText" minOccurs="0" />
-				<xs:element name="date" type="xs:date" minOccurs="0" />
+				<xs:element name="version" type="versionString" minOccurs="0" />
+				<xs:element name="date" type="dateString" minOccurs="0" />
 				<xs:element name="link" type="xs:anyURI" minOccurs="0" />
 				<xs:element name="license" type="licenseType" minOccurs="0" />
 				<xs:element name="author" type="authorType" minOccurs="0" maxOccurs="unbounded" />
 				<xs:element name="menus" type="menusType" minOccurs="0" />
 				<xs:element name="extra_vars" type="extraVarsType" minOccurs="0" />
 			</xs:sequence>
-			<xs:attribute name="version" type="xs:string" use="optional" />
+			<xs:attributeGroup ref="commonVersionAttribute"></xs:attributeGroup>
 		</xs:complexType>
 	</xs:element>
 
-	<xs:complexType name="licenseType">
-		<xs:simpleContent>
-			<xs:extension base="xs:string">
-				<xs:attribute name="link" type="xs:anyURI" use="optional" />
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-
-	<xs:complexType name="authorType">
-		<xs:sequence>
-			<xs:element name="name" type="localizedString" minOccurs="0" maxOccurs="unbounded" />
-		</xs:sequence>
-		<xs:attribute name="email_address" type="xs:string" use="optional" />
-		<xs:attribute name="link" type="xs:anyURI" use="optional" />
-	</xs:complexType>
-
+	<!-- Element:menus -->
 	<xs:complexType name="menusType">
 		<xs:sequence>
 			<xs:element name="menu" type="menuType" minOccurs="0" maxOccurs="unbounded" />
@@ -52,6 +37,7 @@
 		<xs:attribute name="default" type="xs:boolean" use="optional" />
 	</xs:complexType>
 
+	<!-- Element:extra_vars -->
 	<xs:complexType name="extraVarsType">
 		<xs:choice minOccurs="0" maxOccurs="unbounded">
 			<xs:element name="var" type="varType" />
@@ -83,30 +69,4 @@
 		</xs:sequence>
 		<xs:attribute name="value" type="xs:string" use="required" />
 	</xs:complexType>
-
-	<xs:complexType name="localizedString">
-		<xs:simpleContent>
-			<xs:extension base="xs:string">
-				<xs:anyAttribute namespace="http://www.w3.org/XML/1998/namespace"
-					processContents="lax" />
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-
-	<xs:simpleType name="versionText">
-		<xs:union memberTypes="versionPattern placeholderToken" />
-	</xs:simpleType>
-
-	<xs:simpleType name="versionPattern">
-		<xs:restriction base="xs:string">
-			<xs:pattern value="\d+(\.\d+){0,2}" />
-		</xs:restriction>
-	</xs:simpleType>
-
-	<xs:simpleType name="placeholderToken">
-		<xs:restriction base="xs:string">
-			<xs:pattern value="RX_[A-Z0-9_]+" />
-		</xs:restriction>
-	</xs:simpleType>
-
 </xs:schema>

--- a/common/manual/schemas/layout.xsd
+++ b/common/manual/schemas/layout.xsd
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+	xmlns:xml="http://www.w3.org/XML/1998/namespace"
+	elementFormDefault="qualified">
+
+	<xs:element name="layout">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="title" type="localizedString" minOccurs="0" maxOccurs="unbounded" />
+				<xs:element name="description" type="localizedString" minOccurs="0"
+					maxOccurs="unbounded" />
+				<xs:element name="version" type="versionText" minOccurs="0" />
+				<xs:element name="date" type="xs:date" minOccurs="0" />
+				<xs:element name="link" type="xs:anyURI" minOccurs="0" />
+				<xs:element name="license" type="licenseType" minOccurs="0" />
+				<xs:element name="author" type="authorType" minOccurs="0" maxOccurs="unbounded" />
+				<xs:element name="menus" type="menusType" minOccurs="0" />
+				<xs:element name="extra_vars" type="extraVarsType" minOccurs="0" />
+			</xs:sequence>
+			<xs:attribute name="version" type="xs:string" use="optional" />
+		</xs:complexType>
+	</xs:element>
+
+	<xs:complexType name="licenseType">
+		<xs:simpleContent>
+			<xs:extension base="xs:string">
+				<xs:attribute name="link" type="xs:anyURI" use="optional" />
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+
+	<xs:complexType name="authorType">
+		<xs:sequence>
+			<xs:element name="name" type="localizedString" minOccurs="0" maxOccurs="unbounded" />
+		</xs:sequence>
+		<xs:attribute name="email_address" type="xs:string" use="optional" />
+		<xs:attribute name="link" type="xs:anyURI" use="optional" />
+	</xs:complexType>
+
+	<xs:complexType name="menusType">
+		<xs:sequence>
+			<xs:element name="menu" type="menuType" minOccurs="0" maxOccurs="unbounded" />
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="menuType">
+		<xs:sequence>
+			<xs:element name="title" type="localizedString" minOccurs="0" maxOccurs="unbounded" />
+		</xs:sequence>
+		<xs:attribute name="name" type="xs:string" use="required" />
+		<xs:attribute name="maxdepth" type="xs:integer" use="optional" />
+		<xs:attribute name="default" type="xs:boolean" use="optional" />
+	</xs:complexType>
+
+	<xs:complexType name="extraVarsType">
+		<xs:choice minOccurs="0" maxOccurs="unbounded">
+			<xs:element name="var" type="varType" />
+			<xs:element name="group" type="varGroupType" />
+		</xs:choice>
+	</xs:complexType>
+
+	<xs:complexType name="varGroupType">
+		<xs:sequence>
+			<xs:element name="title" type="localizedString" minOccurs="0" maxOccurs="unbounded" />
+			<xs:element name="var" type="varType" minOccurs="1" maxOccurs="unbounded" />
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="varType">
+		<xs:choice minOccurs="0" maxOccurs="unbounded">
+			<xs:element name="title" type="localizedString" />
+			<xs:element name="description" type="localizedString" />
+			<xs:element name="options" type="varOptionType" />
+		</xs:choice>
+		<xs:attribute name="name" type="xs:string" use="required" />
+		<xs:attribute name="type" type="xs:string" use="required" />
+		<xs:attribute name="default" type="xs:string" use="optional" />
+	</xs:complexType>
+
+	<xs:complexType name="varOptionType">
+		<xs:sequence>
+			<xs:element name="title" type="localizedString" minOccurs="0" maxOccurs="unbounded" />
+		</xs:sequence>
+		<xs:attribute name="value" type="xs:string" use="required" />
+	</xs:complexType>
+
+	<xs:complexType name="localizedString">
+		<xs:simpleContent>
+			<xs:extension base="xs:string">
+				<xs:anyAttribute namespace="http://www.w3.org/XML/1998/namespace"
+					processContents="lax" />
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+
+	<xs:simpleType name="versionText">
+		<xs:union memberTypes="versionPattern placeholderToken" />
+	</xs:simpleType>
+
+	<xs:simpleType name="versionPattern">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="\d+(\.\d+){0,2}" />
+		</xs:restriction>
+	</xs:simpleType>
+
+	<xs:simpleType name="placeholderToken">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="RX_[A-Z0-9_]+" />
+		</xs:restriction>
+	</xs:simpleType>
+
+</xs:schema>

--- a/common/manual/schemas/module-info.xsd
+++ b/common/manual/schemas/module-info.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
-	xmlns:xml="http://www.w3.org/XML/1998/namespace"
-	elementFormDefault="qualified">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+
+	<xs:include schemaLocation="shared-types.xsd" />
 
 	<xs:element name="module">
 		<xs:complexType>
@@ -11,14 +11,15 @@
 					maxOccurs="unbounded" />
 				<xs:element name="version" type="versionString" minOccurs="0" />
 				<xs:element name="date" type="dateString" minOccurs="0" />
-				<xs:element name="category" type="categoryType" minOccurs="0" />
 				<xs:element name="license" type="licenseType" minOccurs="0" />
+				<xs:element name="category" type="categoryType" minOccurs="0" />
 				<xs:element name="author" type="authorType" minOccurs="0" maxOccurs="unbounded" />
 			</xs:sequence>
-			<xs:attribute name="version" type="xs:string" use="optional" />
+			<xs:attributeGroup ref="commonVersionAttribute"></xs:attributeGroup>
 		</xs:complexType>
 	</xs:element>
 
+	<!-- Element:category -->
 	<xs:simpleType name="categoryType">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="accessory" />
@@ -32,56 +33,4 @@
 			<xs:enumeration value="utility" />
 		</xs:restriction>
 	</xs:simpleType>
-
-	<xs:complexType name="localizedString">
-		<xs:simpleContent>
-			<xs:extension base="xs:string">
-				<xs:anyAttribute namespace="http://www.w3.org/XML/1998/namespace"
-					processContents="lax" />
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-
-	<xs:complexType name="licenseType">
-		<xs:simpleContent>
-			<xs:extension base="xs:string">
-				<xs:attribute name="link" type="xs:anyURI" use="optional" />
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-
-	<xs:complexType name="authorType">
-		<xs:sequence>
-			<xs:element name="name" type="localizedString" minOccurs="1" maxOccurs="unbounded" />
-		</xs:sequence>
-		<xs:attribute name="email_address" type="xs:string" use="optional" />
-		<xs:attribute name="link" type="xs:anyURI" use="optional" />
-	</xs:complexType>
-
-	<xs:simpleType name="versionString">
-		<xs:union memberTypes="semanticVersion rxVersion" />
-	</xs:simpleType>
-
-	<xs:simpleType name="semanticVersion">
-		<xs:restriction base="xs:string">
-			<xs:pattern value="\d+(\.\d+){0,2}" />
-		</xs:restriction>
-	</xs:simpleType>
-
-	<xs:simpleType name="rxVersion">
-		<xs:restriction base="xs:string">
-			<xs:pattern value="RX_VERSION" />
-		</xs:restriction>
-	</xs:simpleType>
-
-	<xs:simpleType name="dateString">
-		<xs:union memberTypes="xs:date rxDate" />
-	</xs:simpleType>
-
-	<xs:simpleType name="rxDate">
-		<xs:restriction base="xs:string">
-			<xs:pattern value="RX_CORE" />
-		</xs:restriction>
-	</xs:simpleType>
-
 </xs:schema>

--- a/common/manual/schemas/module-info.xsd
+++ b/common/manual/schemas/module-info.xsd
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+	xmlns:xml="http://www.w3.org/XML/1998/namespace"
+	elementFormDefault="qualified">
+
+	<xs:element name="module">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="title" type="localizedString" minOccurs="1" maxOccurs="unbounded" />
+				<xs:element name="description" type="localizedString" minOccurs="0"
+					maxOccurs="unbounded" />
+				<xs:element name="version" type="versionString" minOccurs="0" />
+				<xs:element name="date" type="dateString" minOccurs="0" />
+				<xs:element name="category" type="categoryType" minOccurs="0" />
+				<xs:element name="license" type="licenseType" minOccurs="0" />
+				<xs:element name="author" type="authorType" minOccurs="0" maxOccurs="unbounded" />
+			</xs:sequence>
+			<xs:attribute name="version" type="xs:string" use="optional" />
+		</xs:complexType>
+	</xs:element>
+
+	<xs:simpleType name="categoryType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="accessory" />
+			<xs:enumeration value="construction" />
+			<xs:enumeration value="content" />
+			<xs:enumeration value="member" />
+			<xs:enumeration value="migration" />
+			<xs:enumeration value="service" />
+			<xs:enumeration value="statistics" />
+			<xs:enumeration value="system" />
+			<xs:enumeration value="utility" />
+		</xs:restriction>
+	</xs:simpleType>
+
+	<xs:complexType name="localizedString">
+		<xs:simpleContent>
+			<xs:extension base="xs:string">
+				<xs:anyAttribute namespace="http://www.w3.org/XML/1998/namespace"
+					processContents="lax" />
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+
+	<xs:complexType name="licenseType">
+		<xs:simpleContent>
+			<xs:extension base="xs:string">
+				<xs:attribute name="link" type="xs:anyURI" use="optional" />
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+
+	<xs:complexType name="authorType">
+		<xs:sequence>
+			<xs:element name="name" type="localizedString" minOccurs="1" maxOccurs="unbounded" />
+		</xs:sequence>
+		<xs:attribute name="email_address" type="xs:string" use="optional" />
+		<xs:attribute name="link" type="xs:anyURI" use="optional" />
+	</xs:complexType>
+
+	<xs:simpleType name="versionString">
+		<xs:union memberTypes="semanticVersion rxVersion" />
+	</xs:simpleType>
+
+	<xs:simpleType name="semanticVersion">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="\d+(\.\d+){0,2}" />
+		</xs:restriction>
+	</xs:simpleType>
+
+	<xs:simpleType name="rxVersion">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="RX_VERSION" />
+		</xs:restriction>
+	</xs:simpleType>
+
+	<xs:simpleType name="dateString">
+		<xs:union memberTypes="xs:date rxDate" />
+	</xs:simpleType>
+
+	<xs:simpleType name="rxDate">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="RX_CORE" />
+		</xs:restriction>
+	</xs:simpleType>
+
+</xs:schema>

--- a/common/manual/schemas/module-skin.xsd
+++ b/common/manual/schemas/module-skin.xsd
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+	xmlns:xml="http://www.w3.org/XML/1998/namespace"
+	elementFormDefault="qualified">
+
+	<xs:element name="skin">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="title" type="localizedString" minOccurs="0" maxOccurs="unbounded" />
+				<xs:element name="description" type="localizedString" minOccurs="0"
+					maxOccurs="unbounded" />
+				<xs:element name="version" type="versionText" minOccurs="0" />
+				<xs:element name="date" type="dateValue" minOccurs="0" />
+				<xs:element name="link" type="xs:anyURI" minOccurs="0" />
+				<xs:element name="author" type="authorType" minOccurs="0" maxOccurs="unbounded" />
+				<xs:element name="license" type="licenseType" minOccurs="0" />
+				<xs:element name="colorset" type="colorsetType" minOccurs="0" />
+				<xs:element name="extra_vars" type="extraVarsType" minOccurs="0" />
+			</xs:sequence>
+			<xs:attribute name="version" type="xs:string" use="optional" />
+		</xs:complexType>
+	</xs:element>
+
+	<xs:complexType name="authorType">
+		<xs:sequence>
+			<xs:element name="name" type="localizedString" minOccurs="0" maxOccurs="unbounded" />
+		</xs:sequence>
+		<xs:attribute name="email_address" type="xs:string" use="optional" />
+		<xs:attribute name="link" type="xs:anyURI" use="optional" />
+	</xs:complexType>
+
+	<xs:complexType name="licenseType">
+		<xs:simpleContent>
+			<xs:extension base="xs:string">
+				<xs:attribute name="link" type="xs:anyURI" use="optional" />
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+
+	<xs:complexType name="colorsetType">
+		<xs:sequence>
+			<xs:element name="color" type="colorType" minOccurs="0" maxOccurs="unbounded" />
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="colorType">
+		<xs:sequence>
+			<xs:element name="title" type="localizedString" minOccurs="0" maxOccurs="unbounded" />
+		</xs:sequence>
+		<xs:attribute name="name" type="xs:string" use="required" />
+		<xs:attribute name="src" type="xs:anyURI" use="optional" />
+	</xs:complexType>
+
+	<xs:complexType name="extraVarsType">
+		<xs:choice minOccurs="0" maxOccurs="unbounded">
+			<xs:element name="var" type="varType" />
+			<xs:element name="group" type="varGroupType" />
+		</xs:choice>
+	</xs:complexType>
+
+	<xs:complexType name="varGroupType">
+		<xs:sequence>
+			<xs:element name="title" type="localizedString" minOccurs="0" maxOccurs="unbounded" />
+			<xs:element name="var" type="varType" minOccurs="0" maxOccurs="unbounded" />
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="varType">
+		<xs:choice minOccurs="0" maxOccurs="unbounded">
+			<xs:element name="title" type="localizedString" />
+			<xs:element name="description" type="localizedString" />
+			<xs:element name="options" type="varOptionType" />
+		</xs:choice>
+		<xs:attribute name="name" type="xs:string" use="required" />
+		<xs:attribute name="type" type="xs:string" use="optional" default="text" />
+		<xs:attribute name="default" type="xs:string" use="optional" />
+		<xs:anyAttribute processContents="lax" />
+	</xs:complexType>
+
+	<xs:complexType name="varOptionType">
+		<xs:sequence>
+			<xs:element name="title" type="localizedString" minOccurs="0" maxOccurs="unbounded" />
+			<xs:element name="description" type="localizedString" minOccurs="0"
+				maxOccurs="unbounded" />
+		</xs:sequence>
+		<xs:attribute name="value" type="xs:string" use="required" />
+		<xs:anyAttribute processContents="lax" />
+	</xs:complexType>
+
+	<xs:complexType name="localizedString">
+		<xs:simpleContent>
+			<xs:extension base="xs:string">
+				<xs:anyAttribute namespace="http://www.w3.org/XML/1998/namespace"
+					processContents="lax" />
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+
+	<xs:simpleType name="versionText">
+		<xs:union memberTypes="versionPattern placeholderToken" />
+	</xs:simpleType>
+
+	<xs:simpleType name="versionPattern">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="\d+(\.\d+){0,2}" />
+		</xs:restriction>
+	</xs:simpleType>
+
+	<xs:simpleType name="placeholderToken">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="RX_[A-Z0-9_]+" />
+		</xs:restriction>
+	</xs:simpleType>
+
+	<xs:simpleType name="dateValue">
+		<xs:union memberTypes="xs:date xs:gYear placeholderToken" />
+	</xs:simpleType>
+
+</xs:schema>

--- a/common/manual/schemas/module-skin.xsd
+++ b/common/manual/schemas/module-skin.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
-	xmlns:xml="http://www.w3.org/XML/1998/namespace"
-	elementFormDefault="qualified">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+
+	<xs:include schemaLocation="shared-types.xsd" />
 
 	<xs:element name="skin">
 		<xs:complexType>
@@ -9,34 +9,19 @@
 				<xs:element name="title" type="localizedString" minOccurs="0" maxOccurs="unbounded" />
 				<xs:element name="description" type="localizedString" minOccurs="0"
 					maxOccurs="unbounded" />
-				<xs:element name="version" type="versionText" minOccurs="0" />
-				<xs:element name="date" type="dateValue" minOccurs="0" />
+				<xs:element name="version" type="versionString" minOccurs="0" />
+				<xs:element name="date" type="dateString" minOccurs="0" />
 				<xs:element name="link" type="xs:anyURI" minOccurs="0" />
-				<xs:element name="author" type="authorType" minOccurs="0" maxOccurs="unbounded" />
 				<xs:element name="license" type="licenseType" minOccurs="0" />
+				<xs:element name="author" type="authorType" minOccurs="0" maxOccurs="unbounded" />
 				<xs:element name="colorset" type="colorsetType" minOccurs="0" />
 				<xs:element name="extra_vars" type="extraVarsType" minOccurs="0" />
 			</xs:sequence>
-			<xs:attribute name="version" type="xs:string" use="optional" />
+			<xs:attributeGroup ref="commonVersionAttribute"></xs:attributeGroup>
 		</xs:complexType>
 	</xs:element>
 
-	<xs:complexType name="authorType">
-		<xs:sequence>
-			<xs:element name="name" type="localizedString" minOccurs="0" maxOccurs="unbounded" />
-		</xs:sequence>
-		<xs:attribute name="email_address" type="xs:string" use="optional" />
-		<xs:attribute name="link" type="xs:anyURI" use="optional" />
-	</xs:complexType>
-
-	<xs:complexType name="licenseType">
-		<xs:simpleContent>
-			<xs:extension base="xs:string">
-				<xs:attribute name="link" type="xs:anyURI" use="optional" />
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-
+	<!-- Element:colorset -->
 	<xs:complexType name="colorsetType">
 		<xs:sequence>
 			<xs:element name="color" type="colorType" minOccurs="0" maxOccurs="unbounded" />
@@ -51,6 +36,7 @@
 		<xs:attribute name="src" type="xs:anyURI" use="optional" />
 	</xs:complexType>
 
+	<!-- Element:extra_vars -->
 	<xs:complexType name="extraVarsType">
 		<xs:choice minOccurs="0" maxOccurs="unbounded">
 			<xs:element name="var" type="varType" />
@@ -86,34 +72,4 @@
 		<xs:attribute name="value" type="xs:string" use="required" />
 		<xs:anyAttribute processContents="lax" />
 	</xs:complexType>
-
-	<xs:complexType name="localizedString">
-		<xs:simpleContent>
-			<xs:extension base="xs:string">
-				<xs:anyAttribute namespace="http://www.w3.org/XML/1998/namespace"
-					processContents="lax" />
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-
-	<xs:simpleType name="versionText">
-		<xs:union memberTypes="versionPattern placeholderToken" />
-	</xs:simpleType>
-
-	<xs:simpleType name="versionPattern">
-		<xs:restriction base="xs:string">
-			<xs:pattern value="\d+(\.\d+){0,2}" />
-		</xs:restriction>
-	</xs:simpleType>
-
-	<xs:simpleType name="placeholderToken">
-		<xs:restriction base="xs:string">
-			<xs:pattern value="RX_[A-Z0-9_]+" />
-		</xs:restriction>
-	</xs:simpleType>
-
-	<xs:simpleType name="dateValue">
-		<xs:union memberTypes="xs:date xs:gYear placeholderToken" />
-	</xs:simpleType>
-
 </xs:schema>

--- a/common/manual/schemas/module.xsd
+++ b/common/manual/schemas/module.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
-	xmlns:xml="http://www.w3.org/XML/1998/namespace"
-	elementFormDefault="qualified">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+
+	<xs:include schemaLocation="shared-types.xsd" />
 
 	<xs:element name="module">
 		<xs:complexType>
@@ -17,6 +17,7 @@
 		</xs:complexType>
 	</xs:element>
 
+	<!-- Element:namespaces -->
 	<xs:complexType name="namespacesType">
 		<xs:sequence>
 			<xs:element name="namespace" type="namespaceType" minOccurs="1" maxOccurs="unbounded" />
@@ -27,6 +28,7 @@
 		<xs:attribute name="name" type="xs:string" use="required" />
 	</xs:complexType>
 
+	<!-- Element:classes -->
 	<xs:complexType name="classesType">
 		<xs:sequence>
 			<xs:element name="class" type="classType" minOccurs="1" maxOccurs="unbounded" />
@@ -38,6 +40,7 @@
 		<xs:attribute name="name" type="xs:string" use="required" />
 	</xs:complexType>
 
+	<!-- Element:grants -->
 	<xs:complexType name="grantsType">
 		<xs:sequence>
 			<xs:element name="grant" type="grantType" minOccurs="0" maxOccurs="unbounded" />
@@ -61,6 +64,7 @@
 		</xs:restriction>
 	</xs:simpleType>
 
+	<!-- Element:permissions -->
 	<xs:complexType name="permissionsType">
 		<xs:sequence>
 			<xs:element name="permission" type="permissionType" minOccurs="0" maxOccurs="unbounded" />
@@ -75,6 +79,7 @@
 		<xs:attribute name="default" type="xs:string" use="optional" />
 	</xs:complexType>
 
+	<!-- Element:actions -->
 	<xs:complexType name="actionsType">
 		<xs:sequence>
 			<xs:element name="action" type="actionType" minOccurs="0" maxOccurs="unbounded" />
@@ -110,11 +115,22 @@
 		<xs:attribute name="error-handlers" type="xs:string" use="optional" />
 	</xs:complexType>
 
+	<xs:simpleType name="actionKind">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="view" />
+			<xs:enumeration value="model" />
+			<xs:enumeration value="controller" />
+			<xs:enumeration value="mobile" />
+		</xs:restriction>
+	</xs:simpleType>
+
+	<!-- Element:route -->
 	<xs:complexType name="routeType">
 		<xs:attribute name="route" type="xs:string" use="required" />
 		<xs:attribute name="priority" type="xs:integer" use="optional" />
 	</xs:complexType>
 
+	<!-- Element:eventHandlers -->
 	<xs:complexType name="eventHandlersType">
 		<xs:sequence>
 			<xs:element name="eventHandler" type="eventHandlerType" minOccurs="0"
@@ -131,6 +147,7 @@
 		<xs:attribute name="method" type="xs:string" use="required" />
 	</xs:complexType>
 
+	<!-- Element:menus -->
 	<xs:complexType name="menusType">
 		<xs:sequence>
 			<xs:element name="menu" type="menuType" minOccurs="0" maxOccurs="unbounded" />
@@ -146,23 +163,4 @@
 		<xs:attribute name="maxdepth" type="xs:integer" use="optional" />
 		<xs:attribute name="default" type="xs:boolean" use="optional" />
 	</xs:complexType>
-
-	<xs:simpleType name="actionKind">
-		<xs:restriction base="xs:string">
-			<xs:enumeration value="view" />
-			<xs:enumeration value="model" />
-			<xs:enumeration value="controller" />
-			<xs:enumeration value="mobile" />
-		</xs:restriction>
-	</xs:simpleType>
-
-	<xs:complexType name="localizedString">
-		<xs:simpleContent>
-			<xs:extension base="xs:string">
-				<xs:anyAttribute namespace="http://www.w3.org/XML/1998/namespace"
-					processContents="lax" />
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-
 </xs:schema>

--- a/common/manual/schemas/module.xsd
+++ b/common/manual/schemas/module.xsd
@@ -1,0 +1,168 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+	xmlns:xml="http://www.w3.org/XML/1998/namespace"
+	elementFormDefault="qualified">
+
+	<xs:element name="module">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="namespaces" type="namespacesType" minOccurs="0" />
+				<xs:element name="classes" type="classesType" minOccurs="0" />
+				<xs:element name="grants" type="grantsType" minOccurs="0" />
+				<xs:element name="actions" type="actionsType" minOccurs="0" />
+				<xs:element name="permissions" type="permissionsType" minOccurs="0" />
+				<xs:element name="eventHandlers" type="eventHandlersType" minOccurs="0" />
+				<xs:element name="menus" type="menusType" minOccurs="0" />
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+
+	<xs:complexType name="namespacesType">
+		<xs:sequence>
+			<xs:element name="namespace" type="namespaceType" minOccurs="1" maxOccurs="unbounded" />
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="namespaceType">
+		<xs:attribute name="name" type="xs:string" use="required" />
+	</xs:complexType>
+
+	<xs:complexType name="classesType">
+		<xs:sequence>
+			<xs:element name="class" type="classType" minOccurs="1" maxOccurs="unbounded" />
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="classType">
+		<xs:attribute name="type" type="xs:string" use="optional" />
+		<xs:attribute name="name" type="xs:string" use="required" />
+	</xs:complexType>
+
+	<xs:complexType name="grantsType">
+		<xs:sequence>
+			<xs:element name="grant" type="grantType" minOccurs="0" maxOccurs="unbounded" />
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="grantType">
+		<xs:sequence>
+			<xs:element name="title" type="localizedString" minOccurs="0" maxOccurs="unbounded" />
+		</xs:sequence>
+		<xs:attribute name="name" type="xs:string" use="required" />
+		<xs:attribute name="default" type="grantDefaultType" use="optional" />
+	</xs:complexType>
+
+	<xs:simpleType name="grantDefaultType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="guest" />
+			<xs:enumeration value="member" />
+			<xs:enumeration value="admin" />
+			<xs:enumeration value="manager" />
+		</xs:restriction>
+	</xs:simpleType>
+
+	<xs:complexType name="permissionsType">
+		<xs:sequence>
+			<xs:element name="permission" type="permissionType" minOccurs="0" maxOccurs="unbounded" />
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="permissionType">
+		<xs:sequence>
+			<xs:element name="title" type="localizedString" minOccurs="0" maxOccurs="unbounded" />
+		</xs:sequence>
+		<xs:attribute name="name" type="xs:string" use="optional" />
+		<xs:attribute name="default" type="xs:string" use="optional" />
+	</xs:complexType>
+
+	<xs:complexType name="actionsType">
+		<xs:sequence>
+			<xs:element name="action" type="actionType" minOccurs="0" maxOccurs="unbounded" />
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="actionType">
+		<xs:sequence>
+			<xs:element name="route" type="routeType" minOccurs="0" maxOccurs="unbounded" />
+		</xs:sequence>
+		<xs:attribute name="name" type="xs:string" use="required" />
+		<xs:attribute name="type" type="actionKind" use="optional" />
+		<xs:attribute name="class" type="xs:string" use="optional" />
+		<xs:attribute name="permission" type="xs:string" use="optional" />
+		<xs:attribute name="method" type="xs:string" use="optional" />
+		<xs:attribute name="ruleset" type="xs:string" use="optional" />
+		<xs:attribute name="route" type="xs:string" use="optional" />
+		<xs:attribute name="standalone" type="xs:boolean" use="optional" />
+		<xs:attribute name="index" type="xs:boolean" use="optional" />
+		<xs:attribute name="admin_index" type="xs:boolean" use="optional" />
+		<xs:attribute name="admin-index" type="xs:boolean" use="optional" />
+		<xs:attribute name="menu_name" type="xs:string" use="optional" />
+		<xs:attribute name="menu-name" type="xs:string" use="optional" />
+		<xs:attribute name="menu_index" type="xs:boolean" use="optional" />
+		<xs:attribute name="menu-index" type="xs:boolean" use="optional" />
+		<xs:attribute name="setup_index" type="xs:boolean" use="optional" />
+		<xs:attribute name="simple_setup_index" type="xs:boolean" use="optional" />
+		<xs:attribute name="meta-noindex" type="xs:boolean" use="optional" />
+		<xs:attribute name="check_var" type="xs:string" use="optional" />
+		<xs:attribute name="check_type" type="xs:string" use="optional" />
+		<xs:attribute name="check_csrf" type="xs:boolean" use="optional" />
+		<xs:attribute name="check-csrf" type="xs:boolean" use="optional" />
+		<xs:attribute name="error-handlers" type="xs:string" use="optional" />
+	</xs:complexType>
+
+	<xs:complexType name="routeType">
+		<xs:attribute name="route" type="xs:string" use="required" />
+		<xs:attribute name="priority" type="xs:integer" use="optional" />
+	</xs:complexType>
+
+	<xs:complexType name="eventHandlersType">
+		<xs:sequence>
+			<xs:element name="eventHandler" type="eventHandlerType" minOccurs="0"
+				maxOccurs="unbounded" />
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="eventHandlerType">
+		<xs:attribute name="before" type="xs:string" use="optional" />
+		<xs:attribute name="after" type="xs:string" use="optional" />
+		<xs:attribute name="beforeAction" type="xs:string" use="optional" />
+		<xs:attribute name="afterAction" type="xs:string" use="optional" />
+		<xs:attribute name="class" type="xs:string" use="required" />
+		<xs:attribute name="method" type="xs:string" use="required" />
+	</xs:complexType>
+
+	<xs:complexType name="menusType">
+		<xs:sequence>
+			<xs:element name="menu" type="menuType" minOccurs="0" maxOccurs="unbounded" />
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="menuType">
+		<xs:sequence>
+			<xs:element name="title" type="localizedString" minOccurs="0" maxOccurs="unbounded" />
+		</xs:sequence>
+		<xs:attribute name="name" type="xs:string" use="required" />
+		<xs:attribute name="type" type="xs:string" use="optional" />
+		<xs:attribute name="maxdepth" type="xs:integer" use="optional" />
+		<xs:attribute name="default" type="xs:boolean" use="optional" />
+	</xs:complexType>
+
+	<xs:simpleType name="actionKind">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="view" />
+			<xs:enumeration value="model" />
+			<xs:enumeration value="controller" />
+			<xs:enumeration value="mobile" />
+		</xs:restriction>
+	</xs:simpleType>
+
+	<xs:complexType name="localizedString">
+		<xs:simpleContent>
+			<xs:extension base="xs:string">
+				<xs:anyAttribute namespace="http://www.w3.org/XML/1998/namespace"
+					processContents="lax" />
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+
+</xs:schema>

--- a/common/manual/schemas/shared-types.xsd
+++ b/common/manual/schemas/shared-types.xsd
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+
+	<xs:complexType name="commonInfoElements">
+		<xs:sequence>
+			<xs:element name="title" type="localizedString" minOccurs="1" maxOccurs="unbounded" />
+			<xs:element name="description" type="localizedString" minOccurs="0" maxOccurs="unbounded" />
+			<xs:element name="version" type="versionString" minOccurs="0" />
+			<xs:element name="date" type="dateString" minOccurs="0" />
+			<xs:element name="link" type="xs:anyURI" minOccurs="0" />
+			<xs:element name="license" type="licenseType" minOccurs="0" />
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:attributeGroup name="commonVersionAttribute">
+		<xs:attribute name="version" type="xs:string" fixed="0.2"/>
+	</xs:attributeGroup>
+
+	<xs:complexType name="licenseType">
+		<xs:simpleContent>
+			<xs:extension base="xs:string">
+				<xs:attribute name="link" type="xs:anyURI" use="optional" />
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+
+	<xs:complexType name="authorType">
+		<xs:sequence>
+			<xs:element name="name" type="localizedString" minOccurs="0" maxOccurs="unbounded" />
+		</xs:sequence>
+		<xs:attribute name="email_address" type="xs:string" use="optional" />
+		<xs:attribute name="link" type="xs:anyURI" use="optional" />
+	</xs:complexType>
+
+	<xs:complexType name="localizedString">
+		<xs:simpleContent>
+			<xs:extension base="xs:string">
+				<xs:anyAttribute namespace="http://www.w3.org/XML/1998/namespace"
+					processContents="lax" />
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+
+	<xs:simpleType name="versionString">
+		<xs:union memberTypes="semanticVersion versionPattern rxCoreVersion" />
+	</xs:simpleType>
+
+	<xs:simpleType name="dateString">
+		<xs:union memberTypes="xs:date rxCoreDate" />
+	</xs:simpleType>
+
+	<xs:simpleType name="semanticVersion">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-((0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)(\.((0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)))*))?(\+([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?" />
+		</xs:restriction>
+	</xs:simpleType>
+
+	<xs:simpleType name="versionPattern">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="\d+(\.\d+){1,3}" />
+		</xs:restriction>
+	</xs:simpleType>
+
+	<xs:simpleType name="rxCoreVersion">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="RX_VERSION" />
+		</xs:restriction>
+	</xs:simpleType>
+
+	<xs:simpleType name="rxCoreDate">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="RX_CORE" />
+		</xs:restriction>
+	</xs:simpleType>
+
+</xs:schema>

--- a/common/manual/schemas/widget-info.xsd
+++ b/common/manual/schemas/widget-info.xsd
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+	xmlns:xml="http://www.w3.org/XML/1998/namespace"
+	elementFormDefault="qualified">
+
+	<xs:element name="widget">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="title" type="localizedString" minOccurs="0" maxOccurs="unbounded" />
+				<xs:element name="description" type="localizedString" minOccurs="0"
+					maxOccurs="unbounded" />
+				<xs:element name="version" type="versionText" minOccurs="0" />
+				<xs:element name="date" type="dateValue" minOccurs="0" />
+				<xs:element name="category" type="xs:string" minOccurs="0" />
+				<xs:element name="link" type="xs:anyURI" minOccurs="0" />
+				<xs:element name="license" type="licenseType" minOccurs="0" />
+				<xs:element name="author" type="authorType" minOccurs="0" maxOccurs="unbounded" />
+				<xs:element name="extra_vars" type="extraVarsType" minOccurs="0" />
+			</xs:sequence>
+			<xs:attribute name="version" type="xs:string" use="optional" />
+		</xs:complexType>
+	</xs:element>
+
+	<xs:complexType name="licenseType">
+		<xs:simpleContent>
+			<xs:extension base="xs:string">
+				<xs:attribute name="link" type="xs:anyURI" use="optional" />
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+
+	<xs:complexType name="authorType">
+		<xs:sequence>
+			<xs:element name="name" type="localizedString" minOccurs="0" maxOccurs="unbounded" />
+		</xs:sequence>
+		<xs:attribute name="email_address" type="xs:string" use="optional" />
+		<xs:attribute name="link" type="xs:anyURI" use="optional" />
+	</xs:complexType>
+
+	<xs:complexType name="extraVarsType">
+		<xs:choice minOccurs="0" maxOccurs="unbounded">
+			<xs:element name="var" type="varType" />
+			<xs:element name="group" type="varGroupType" />
+		</xs:choice>
+	</xs:complexType>
+
+	<xs:complexType name="varGroupType">
+		<xs:sequence>
+			<xs:element name="title" type="localizedString" minOccurs="0" maxOccurs="unbounded" />
+			<xs:element name="var" type="varType" minOccurs="1" maxOccurs="unbounded" />
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="varType">
+		<xs:choice minOccurs="0" maxOccurs="unbounded">
+			<xs:element name="name" type="localizedString" />
+			<xs:element name="title" type="localizedString" />
+			<xs:element name="description" type="localizedString" />
+			<xs:element name="type" type="xs:string" />
+			<xs:element name="options" type="varOptionType" />
+			<xs:element name="default" type="xs:string" />
+			<xs:element name="attrs" type="varAttrsType" />
+		</xs:choice>
+		<xs:attribute name="id" type="xs:string" use="optional" />
+		<xs:attribute name="type" type="xs:string" use="optional" />
+		<xs:attribute name="default" type="xs:string" use="optional" />
+		<xs:anyAttribute processContents="lax" />
+	</xs:complexType>
+
+	<xs:complexType name="varAttrsType">
+		<xs:sequence>
+			<xs:element name="attr" type="varAttrType" minOccurs="0" maxOccurs="unbounded" />
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="varAttrType">
+		<xs:simpleContent>
+			<xs:extension base="xs:string">
+				<xs:attribute name="name" type="xs:string" use="required" />
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+
+	<xs:complexType name="varOptionType">
+		<xs:sequence>
+			<xs:element name="value" type="xs:string" minOccurs="0" />
+			<xs:element name="name" type="localizedString" minOccurs="0" maxOccurs="unbounded" />
+			<xs:element name="description" type="localizedString" minOccurs="0"
+				maxOccurs="unbounded" />
+		</xs:sequence>
+		<xs:attribute name="value" type="xs:string" use="optional" />
+		<xs:anyAttribute processContents="lax" />
+	</xs:complexType>
+
+	<xs:complexType name="localizedString">
+		<xs:simpleContent>
+			<xs:extension base="xs:string">
+				<xs:anyAttribute namespace="http://www.w3.org/XML/1998/namespace"
+					processContents="lax" />
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+
+	<xs:simpleType name="versionText">
+		<xs:union memberTypes="versionPattern placeholderToken" />
+	</xs:simpleType>
+
+	<xs:simpleType name="versionPattern">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="\d+(\.\d+){0,2}" />
+		</xs:restriction>
+	</xs:simpleType>
+
+	<xs:simpleType name="placeholderToken">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="RX_[A-Z0-9_]+" />
+		</xs:restriction>
+	</xs:simpleType>
+
+	<xs:simpleType name="dateValue">
+		<xs:union memberTypes="xs:date placeholderToken" />
+	</xs:simpleType>
+
+</xs:schema>

--- a/common/manual/schemas/widget-info.xsd
+++ b/common/manual/schemas/widget-info.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
-	xmlns:xml="http://www.w3.org/XML/1998/namespace"
-	elementFormDefault="qualified">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+
+	<xs:include schemaLocation="shared-types.xsd" />
 
 	<xs:element name="widget">
 		<xs:complexType>
@@ -9,34 +9,19 @@
 				<xs:element name="title" type="localizedString" minOccurs="0" maxOccurs="unbounded" />
 				<xs:element name="description" type="localizedString" minOccurs="0"
 					maxOccurs="unbounded" />
-				<xs:element name="version" type="versionText" minOccurs="0" />
-				<xs:element name="date" type="dateValue" minOccurs="0" />
+				<xs:element name="version" type="versionString" minOccurs="0" />
+				<xs:element name="date" type="dateString" minOccurs="0" />
 				<xs:element name="category" type="xs:string" minOccurs="0" />
 				<xs:element name="link" type="xs:anyURI" minOccurs="0" />
 				<xs:element name="license" type="licenseType" minOccurs="0" />
 				<xs:element name="author" type="authorType" minOccurs="0" maxOccurs="unbounded" />
 				<xs:element name="extra_vars" type="extraVarsType" minOccurs="0" />
 			</xs:sequence>
-			<xs:attribute name="version" type="xs:string" use="optional" />
+			<xs:attributeGroup ref="commonVersionAttribute"></xs:attributeGroup>
 		</xs:complexType>
 	</xs:element>
 
-	<xs:complexType name="licenseType">
-		<xs:simpleContent>
-			<xs:extension base="xs:string">
-				<xs:attribute name="link" type="xs:anyURI" use="optional" />
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-
-	<xs:complexType name="authorType">
-		<xs:sequence>
-			<xs:element name="name" type="localizedString" minOccurs="0" maxOccurs="unbounded" />
-		</xs:sequence>
-		<xs:attribute name="email_address" type="xs:string" use="optional" />
-		<xs:attribute name="link" type="xs:anyURI" use="optional" />
-	</xs:complexType>
-
+	<!-- Element:extra_vars -->
 	<xs:complexType name="extraVarsType">
 		<xs:choice minOccurs="0" maxOccurs="unbounded">
 			<xs:element name="var" type="varType" />
@@ -91,34 +76,4 @@
 		<xs:attribute name="value" type="xs:string" use="optional" />
 		<xs:anyAttribute processContents="lax" />
 	</xs:complexType>
-
-	<xs:complexType name="localizedString">
-		<xs:simpleContent>
-			<xs:extension base="xs:string">
-				<xs:anyAttribute namespace="http://www.w3.org/XML/1998/namespace"
-					processContents="lax" />
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-
-	<xs:simpleType name="versionText">
-		<xs:union memberTypes="versionPattern placeholderToken" />
-	</xs:simpleType>
-
-	<xs:simpleType name="versionPattern">
-		<xs:restriction base="xs:string">
-			<xs:pattern value="\d+(\.\d+){0,2}" />
-		</xs:restriction>
-	</xs:simpleType>
-
-	<xs:simpleType name="placeholderToken">
-		<xs:restriction base="xs:string">
-			<xs:pattern value="RX_[A-Z0-9_]+" />
-		</xs:restriction>
-	</xs:simpleType>
-
-	<xs:simpleType name="dateValue">
-		<xs:union memberTypes="xs:date placeholderToken" />
-	</xs:simpleType>
-
 </xs:schema>

--- a/common/manual/schemas/widget-skin.xsd
+++ b/common/manual/schemas/widget-skin.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
-	xmlns:xml="http://www.w3.org/XML/1998/namespace"
-	elementFormDefault="qualified">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+
+	<xs:include schemaLocation="shared-types.xsd" />
 
 	<xs:element name="skin">
 		<xs:complexType>
@@ -9,34 +9,19 @@
 				<xs:element name="title" type="localizedString" minOccurs="0" maxOccurs="unbounded" />
 				<xs:element name="description" type="localizedString" minOccurs="0"
 					maxOccurs="unbounded" />
-				<xs:element name="version" type="versionText" minOccurs="0" />
-				<xs:element name="date" type="xs:date" minOccurs="0" />
+				<xs:element name="version" type="versionString" minOccurs="0" />
+				<xs:element name="date" type="dateString" minOccurs="0" />
 				<xs:element name="link" type="xs:anyURI" minOccurs="0" />
 				<xs:element name="license" type="licenseType" minOccurs="0" />
 				<xs:element name="author" type="authorType" minOccurs="0" maxOccurs="unbounded" />
 				<xs:element name="colorset" type="colorsetType" minOccurs="0" />
 				<xs:element name="extra_vars" type="extraVarsType" minOccurs="0" />
 			</xs:sequence>
-			<xs:attribute name="version" type="xs:string" use="optional" />
+			<xs:attributeGroup ref="commonVersionAttribute"></xs:attributeGroup>
 		</xs:complexType>
 	</xs:element>
 
-	<xs:complexType name="authorType">
-		<xs:sequence>
-			<xs:element name="name" type="localizedString" minOccurs="0" maxOccurs="unbounded" />
-		</xs:sequence>
-		<xs:attribute name="email_address" type="xs:string" use="optional" />
-		<xs:attribute name="link" type="xs:anyURI" use="optional" />
-	</xs:complexType>
-
-	<xs:complexType name="licenseType">
-		<xs:simpleContent>
-			<xs:extension base="xs:string">
-				<xs:attribute name="link" type="xs:anyURI" use="optional" />
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-
+	<!-- Element:colorset -->
 	<xs:complexType name="colorsetType">
 		<xs:sequence>
 			<xs:element name="color" type="colorType" minOccurs="0" maxOccurs="unbounded" />
@@ -51,6 +36,7 @@
 		<xs:attribute name="src" type="xs:anyURI" use="optional" />
 	</xs:complexType>
 
+	<!-- Element:extra_vars -->
 	<xs:complexType name="extraVarsType">
 		<xs:choice minOccurs="0" maxOccurs="unbounded">
 			<xs:element name="var" type="varType" />
@@ -86,30 +72,4 @@
 		<xs:attribute name="value" type="xs:string" use="required" />
 		<xs:anyAttribute processContents="lax" />
 	</xs:complexType>
-
-	<xs:complexType name="localizedString">
-		<xs:simpleContent>
-			<xs:extension base="xs:string">
-				<xs:anyAttribute namespace="http://www.w3.org/XML/1998/namespace"
-					processContents="lax" />
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-
-	<xs:simpleType name="versionText">
-		<xs:union memberTypes="versionPattern placeholderToken" />
-	</xs:simpleType>
-
-	<xs:simpleType name="versionPattern">
-		<xs:restriction base="xs:string">
-			<xs:pattern value="\d+(\.\d+){0,2}" />
-		</xs:restriction>
-	</xs:simpleType>
-
-	<xs:simpleType name="placeholderToken">
-		<xs:restriction base="xs:string">
-			<xs:pattern value="RX_[A-Z0-9_]+" />
-		</xs:restriction>
-	</xs:simpleType>
-
 </xs:schema>

--- a/common/manual/schemas/widget-skin.xsd
+++ b/common/manual/schemas/widget-skin.xsd
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+	xmlns:xml="http://www.w3.org/XML/1998/namespace"
+	elementFormDefault="qualified">
+
+	<xs:element name="skin">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="title" type="localizedString" minOccurs="0" maxOccurs="unbounded" />
+				<xs:element name="description" type="localizedString" minOccurs="0"
+					maxOccurs="unbounded" />
+				<xs:element name="version" type="versionText" minOccurs="0" />
+				<xs:element name="date" type="xs:date" minOccurs="0" />
+				<xs:element name="link" type="xs:anyURI" minOccurs="0" />
+				<xs:element name="license" type="licenseType" minOccurs="0" />
+				<xs:element name="author" type="authorType" minOccurs="0" maxOccurs="unbounded" />
+				<xs:element name="colorset" type="colorsetType" minOccurs="0" />
+				<xs:element name="extra_vars" type="extraVarsType" minOccurs="0" />
+			</xs:sequence>
+			<xs:attribute name="version" type="xs:string" use="optional" />
+		</xs:complexType>
+	</xs:element>
+
+	<xs:complexType name="authorType">
+		<xs:sequence>
+			<xs:element name="name" type="localizedString" minOccurs="0" maxOccurs="unbounded" />
+		</xs:sequence>
+		<xs:attribute name="email_address" type="xs:string" use="optional" />
+		<xs:attribute name="link" type="xs:anyURI" use="optional" />
+	</xs:complexType>
+
+	<xs:complexType name="licenseType">
+		<xs:simpleContent>
+			<xs:extension base="xs:string">
+				<xs:attribute name="link" type="xs:anyURI" use="optional" />
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+
+	<xs:complexType name="colorsetType">
+		<xs:sequence>
+			<xs:element name="color" type="colorType" minOccurs="0" maxOccurs="unbounded" />
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="colorType">
+		<xs:sequence>
+			<xs:element name="title" type="localizedString" minOccurs="0" maxOccurs="unbounded" />
+		</xs:sequence>
+		<xs:attribute name="name" type="xs:string" use="required" />
+		<xs:attribute name="src" type="xs:anyURI" use="optional" />
+	</xs:complexType>
+
+	<xs:complexType name="extraVarsType">
+		<xs:choice minOccurs="0" maxOccurs="unbounded">
+			<xs:element name="var" type="varType" />
+			<xs:element name="group" type="varGroupType" />
+		</xs:choice>
+	</xs:complexType>
+
+	<xs:complexType name="varGroupType">
+		<xs:sequence>
+			<xs:element name="title" type="localizedString" minOccurs="0" maxOccurs="unbounded" />
+			<xs:element name="var" type="varType" minOccurs="0" maxOccurs="unbounded" />
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="varType">
+		<xs:choice minOccurs="0" maxOccurs="unbounded">
+			<xs:element name="title" type="localizedString" />
+			<xs:element name="description" type="localizedString" />
+			<xs:element name="options" type="varOptionType" />
+		</xs:choice>
+		<xs:attribute name="name" type="xs:string" use="required" />
+		<xs:attribute name="type" type="xs:string" use="required" />
+		<xs:attribute name="default" type="xs:string" use="optional" />
+		<xs:anyAttribute processContents="lax" />
+	</xs:complexType>
+
+	<xs:complexType name="varOptionType">
+		<xs:sequence>
+			<xs:element name="title" type="localizedString" minOccurs="0" maxOccurs="unbounded" />
+			<xs:element name="description" type="localizedString" minOccurs="0"
+				maxOccurs="unbounded" />
+		</xs:sequence>
+		<xs:attribute name="value" type="xs:string" use="required" />
+		<xs:anyAttribute processContents="lax" />
+	</xs:complexType>
+
+	<xs:complexType name="localizedString">
+		<xs:simpleContent>
+			<xs:extension base="xs:string">
+				<xs:anyAttribute namespace="http://www.w3.org/XML/1998/namespace"
+					processContents="lax" />
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+
+	<xs:simpleType name="versionText">
+		<xs:union memberTypes="versionPattern placeholderToken" />
+	</xs:simpleType>
+
+	<xs:simpleType name="versionPattern">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="\d+(\.\d+){0,2}" />
+		</xs:restriction>
+	</xs:simpleType>
+
+	<xs:simpleType name="placeholderToken">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="RX_[A-Z0-9_]+" />
+		</xs:restriction>
+	</xs:simpleType>
+
+</xs:schema>


### PR DESCRIPTION
> [!NOTE]
> 이 PR은 XSD 문서를 논의를 통해 완성해가기 위한 것이며, 병합을 위한 것은 아닙니다.
> 적정 수준으로 완성이 되면, 적절한 위치에 두거나 호스팅하여 활용할 수 있을 것 같습니다.
> #2319 이슈와 연결됩니다.

> [!NOTE]
> 이 초안은 AI에 의해 이미 존재하는 XML 파일을 분석하여 생성한 결과입니다.
> 각 규격의 Parser 가 처리하는 방식과 다를 수 있으며, 보완이 필요 합니다.

---

## 대상 파일
- [ ] `addons/*/conf/info.xml`
- [ ] `modules/*/conf/info.xml`
- [ ] `modules/*/conf/module.xml`
- [ ] `moduels/*/schemas/*.xml`
- [ ] `modules/*/queries/*.xml`
- [ ] `modules/*/skins/skin.xml`
- [ ] `modules/*/m.skins/skin.xml`
- [ ] `layouts/*/conf/info.xml`
- [ ] `m.layouts/*/conf/info.xml`
- [ ] `widgets/*/conf/info.xml`
- [ ] `widgets/*/skins/*/skin.xml`
- [ ] `widgetstyles/*/skin.xml`

## 검증 예시

```bash
> xmllint --noout --schema ./common/manual/schemas/module.xsd ./modules/*/conf/module.xml

./modules/addon/conf/module.xml validates
./modules/admin/conf/module.xml validates
./modules/adminlogging/conf/module.xml validates
./modules/advanced_mailer/conf/module.xml validates
./modules/autoinstall/conf/module.xml validates
./modules/board/conf/module.xml validates
./modules/comment/conf/module.xml validates
./modules/communication/conf/module.xml validates
./modules/counter/conf/module.xml validates
./modules/document/conf/module.xml validates
./modules/editor/conf/module.xml validates
./modules/extravar/conf/module.xml validates
./modules/file/conf/module.xml validates
./modules/importer/conf/module.xml validates
./modules/install/conf/module.xml validates
./modules/integration_search/conf/module.xml validates
./modules/krzip/conf/module.xml validates
./modules/layout/conf/module.xml validates
./modules/member/conf/module.xml validates
./modules/menu/conf/module.xml validates
./modules/message/conf/module.xml validates
./modules/module/conf/module.xml validates
./modules/ncenterlite/conf/module.xml validates
./modules/page/conf/module.xml validates
./modules/point/conf/module.xml validates
./modules/poll/conf/module.xml validates
./modules/rss/conf/module.xml validates
./modules/session/conf/module.xml validates
./modules/spamfilter/conf/module.xml validates
./modules/tag/conf/module.xml:4: element actions: Schemas validity error : Element 'actions': This element is not expected. Expected is one of ( eventHandlers, menus ).
./modules/tag/conf/module.xml fails to validate
./modules/trash/conf/module.xml validates
./modules/widget/conf/module.xml validates
```

## 할 일 및 현재 문제점
- 존재하는 XML 파일들에 대한 AI가 생성한 초안이므로 각 규격에 대한 parser 에서 처리하는 방식 및 누락된 항목을 확인 필요
- [ ] `xs:sequence`로 인해 element 의 순서가 강제되는 문제. `xs:all` 로 지정 시 `<title>` 등의 반복 요소 검증에 문제가 있음
- [ ] title, description 등 통합 가능한 규격을 xsd:import 활용 고려
  - `extravars`는 규격이 미묘하게 달라서 통합 불가
- [ ] `placeholderToken` 을 `RX_CORE`, `RX_VERSION` 등의 정해진 문자열로 허용하도록 변경 필요


## 규격 정리

### 공통 규격

아래 규격의 일부 공통 요소

- `addons/*/conf/info.xml`
- `modules/*/conf/info.xml`
- `modules/*/skins/skin.xml`
- `modules/*/m.skins/skin.xml`
- `layouts/*/conf/info.xml`
- `m.layouts/*/conf/info.xml`
- `widgets/*/conf/info.xml`
- `widgets/*/skins/*/skin.xml`
- `widgetstyles/*/skin.xml`

| Element & Attribute | 필수&반복 | 포맷 | 설명 |
| --- | --- | --- | --- |
| `/*/title` | 필수?, 다국어 | string | 자료의 이름 |
| `/*/description` | 필수?, 다국어 | string | 자료에 대한 설명 |
| `/*/version` | | semVer,RX_VERSION | 자료의 버전 |
| `/*/date` | | YYYY-MM-DD, RX_CORE | 자료의 제작/업데이트 일시 |
| `/*/link` | | string(URL) | 제작자 홈페이지 |
| `/*/license` | | string | 자료의 라이선스 |
| `/*/license[@link]` | | string(URL) | 자료 라이선스에 대한 링크 |
| `/*/author` | 다중 항목 | | 제작자 정보 |
| `/*/author/name` | 다국어 | string | 제작자 이름 |
| `/*/author[@email_address]` | | string(email) | 제작자 이메일 |
| `/*/author[@link]` | | string(URL) | 제작자 웹사이트 |

### `modules/*/conf/info.xml`

#### 공통 규격 외 추가 요소
| Element & Attribute | 필수&반복 | 포맷 | 설명 |
| --- | --- | --- | --- |
| `/module/category` | 기본 값: `service` | string | 모듈의 분류 |

### `modules/*/conf/module.xml`
