### PR TITLE
Debug.php에서 잘못 지정된 변수 수정

### DIFF
--- a/common/framework/Debug.php
+++ b/common/framework/Debug.php
@@ -788,7 +788,7 @@ class Debug
 		$title = lang('msg_server_error');
 		if ($title === 'msg_server_error')
 		{
-			$message = 'Server Error';
+			$title = 'Server Error';
 		}
 
 		// Localize the error message.


### PR DESCRIPTION
`lang('msg_server_error')` 결과가 그대로 언어 코드이면 바꿔치기하는 코드로 보이는데 `$title` 대신 `$message`를 변경하고 있습니다.