### PR TITLE
fix: 정상 동작하지 않는 우체국 우편번호 API 수정

### DIFF
--- a/modules/krzip/krzip.model.php
+++ b/modules/krzip/krzip.model.php
@@ -102,14 +102,14 @@ class krzipModel extends krzip
 	 * @param string $query
 	 * @return mixed
 	 */
-	function getKrzipCodeList($query)
+	function getKrzipCodeList($query = "")
 	{
 		$module_config = $this->getConfig();
 		if($module_config->api_handler != 1)
 		{
 			return $this->setError('msg_invalid_request');
 		}
-		if(!isset($query))
+		if(!$query)
 		{
 			$query = Context::get('query');
 		}

--- a/modules/krzip/krzip.view.php
+++ b/modules/krzip/krzip.view.php
@@ -18,12 +18,12 @@ class krzipView extends krzip
 	 * @param integer $api_handler
 	 * @return mixed
 	 */
-	function dispKrzipSearchForm($api_handler)
+	function dispKrzipSearchForm($api_handler = "")
 	{
 		$oKrzipModel = getModel('krzip');
 		$module_config = $oKrzipModel->getConfig();
 		$module_config->sequence_id = ++self::$sequence_id;
-		if(!isset($api_handler) || !isset(self::$api_list[$api_handler]))
+		if(!$api_handler || !isset(self::$api_list[$api_handler]))
 		{
 			$api_handler = $module_config->api_handler;
 		}

--- a/modules/krzip/tpl/js/epostapi.js
+++ b/modules/krzip/tpl/js/epostapi.js
@@ -27,7 +27,7 @@
 		if(!krzip) {
 			krzip = {
 				open: function (query) {
-					var request_url = "./"
+					var request_url = request_uri
 						.setQuery("module", "krzip")
 						.setQuery("act", "dispKrzipSearchForm")
 						.setQuery("query", query);


### PR DESCRIPTION
dispKrzipSearchForm나 getKrzipCodeList 모두 act를 통해 호출하므로 argument로는 아무것도 전달되지 않아야 하나, 필수 argument가 지정되어 오류가 발생하고 있었습니다. 이 부분을 argument에 기본값을 지정하여 수정합니다.(오랫동안 argument가 존재해온 만큼 삭제시 서드파티 호환성 문제가 있을수 있어 삭제하지는 않았습니다)

추가로 팝업 표시시 "./index.php?module=krzip&act=dispKrzipSearchForm"으로 잘못 이동하고 있어 이부분도 수정하였습니다.

p.s.) 우체국 우편번호 API는 현재 우체국 홈페이지에서는 발급 페이지가 연결되어 있지 않고, 별도 사이트인 https://biz.epost.go.kr/ui/index.jsp?sysType=PORTAL&menuId=PORTAL_2_1 에서만 가능한 상태입니다.(우체국 홈페이지에서는 공공데이터포털에서 제공하는 서비스를 이용할것을 권장하고 있는 상태)

이부분은 별도로 추가하지 않았으나 추후 혼동의 여지가 있어 추가하는것도 괜찮을것 같습니다.