### PR TITLE
Fix "toBool() on null" error in DocumentItem::getComments()

### DIFF
--- a/modules/document/document.item.php
+++ b/modules/document/document.item.php
@@ -1001,7 +1001,7 @@ class DocumentItem extends BaseObject
 
 		// Get a list of comments
 		$output = CommentModel::getCommentList($this->document_srl, $cpage);
-		if(!$output->toBool() || !count($output->data)) return;
+		if(!$output || !$output->toBool() || !count($output->data)) return;
 
 		// Create commentItem object from a comment list
 		// If admin priviledge is granted on parent posts, you can read its child posts.


### PR DESCRIPTION
## Summary

`CommentModel::getCommentList()` returns void (null) in several early-exit paths:

- no `$document_srl`
- document doesn't exist
- `$document_comment_count < 1`
- `triggerCall` returns a failed BaseObject
- main query fails

`DocumentItem::getComments()` (at the line below) immediately calls `$output->toBool()` on the result, which throws:

```
PHP Fatal error: Uncaught Error: Call to a member function toBool() on null
  in modules/document/document.item.php:1004
```

## Reproduction

In production this manifests as a transient ~30-second 500 burst on a document page **immediately after a comment is inserted**. The trigger appears to be a brief inconsistency between the outer template's view of `$oDocument->getCommentcount()` (already > 0 after the new comment) and the inner `DocumentModel::getDocument()` fetch performed by `CommentModel::getCommentList()` with a limited column list — which can briefly read `comment_count < 1` due to per-fetch cache state. Once the inner method early-exits with `return;` (no value), the caller blows up on `$output->toBool()`.

On the affected production site we logged this error **201 times across 9 days** in PHP-FPM stderr, all at the same source location.

## Fix

Add a null guard before `->toBool()`. This absorbs every early-exit path of `getCommentList()`:

```diff
-		if(!$output->toBool() || !count($output->data)) return;
+		if(!$output || !$output->toBool() || !count($output->data)) return;
```

One-line change, defensive only — does not alter behavior on the happy path.

## Test plan

- [x] `php -l` passes
- [x] Patched on production (~2M PV/day site); affected page returns 200 immediately after subsequent comment insertions and no further occurrences of the error in stderr
- [x] No regression observed on existing comment-rendering paths (admin/member/guest)