### PR TITLE
R\F\Formatter::concatJS에 불필요한 인자를 넘기는 문제 수정

### DIFF
--- a/classes/frontendfile/FrontEndFileHandler.class.php
+++ b/classes/frontendfile/FrontEndFileHandler.class.php
@@ -639,7 +639,7 @@ class FrontEndFileHandler extends Handler
 					$concat_filename = self::$assetdir . '/combined/' . sha1(serialize($concat_files)) . '.js';
 					if (!file_exists(\RX_BASEDIR . $concat_filename) || filemtime(\RX_BASEDIR . $concat_filename) < $concat_max_timestamp)
 					{
-						$concat_content = Rhymix\Framework\Formatter::concatJS($concat_files, \RX_BASEDIR . $concat_filename);
+						$concat_content = Rhymix\Framework\Formatter::concatJS($concat_files);
 						Rhymix\Framework\Storage::write(\RX_BASEDIR . $concat_filename, $concat_content);
 					}
 					$concat_filename .= '?t=' . filemtime(\RX_BASEDIR . $concat_filename);


### PR DESCRIPTION
```php
/**
 * JS concatenation subroutine.
 *
 * @param string|array $source_filename
 * @return string
 */
public static function concatJS($source_filename): string
```

R\F\Formatter::concatJS 함수는 인자로 `$source_filename` 하나만 받지만 불필요하게 `$concat_filename`를 넘기고 있었습니다. 아마 concatCSS 코드에서 복붙하며 잘못 들어간 것으로 보입니다.